### PR TITLE
Add pr-cleanup command to remove merged pull request branches

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/temirov/git_scripts/internal/audit"
+	"github.com/temirov/git_scripts/internal/branches"
 	"github.com/temirov/git_scripts/internal/utils"
 )
 
@@ -106,6 +107,16 @@ func newCLIApplication() *CLIApplication {
 	auditCommand, auditBuildError := auditBuilder.Build()
 	if auditBuildError == nil {
 		cobraCommand.AddCommand(auditCommand)
+	}
+
+	branchCleanupBuilder := branches.CommandBuilder{
+		LoggerProvider: func() *zap.Logger {
+			return cliApplication.logger
+		},
+	}
+	branchCleanupCommand, branchCleanupBuildError := branchCleanupBuilder.Build()
+	if branchCleanupBuildError == nil {
+		cobraCommand.AddCommand(branchCleanupCommand)
 	}
 
 	cliApplication.rootCommand = cobraCommand

--- a/internal/branches/command.go
+++ b/internal/branches/command.go
@@ -1,0 +1,134 @@
+package branches
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	commandUseConstant                    = "pr-cleanup"
+	commandShortDescriptionConstant       = "Remove remote and local branches for closed pull requests"
+	commandLongDescriptionConstant        = "pr-cleanup removes remote and local Git branches whose pull requests are already closed."
+	commandExecutionErrorTemplateConstant = "branch cleanup failed: %w"
+	unexpectedArgumentsMessageConstant    = "pr-cleanup does not accept positional arguments"
+	flagRemoteNameConstant                = "remote"
+	flagRemoteDescriptionConstant         = "Name of the remote containing pull request branches"
+	flagLimitNameConstant                 = "limit"
+	flagLimitDescriptionConstant          = "Maximum number of closed pull requests to examine"
+	flagDryRunNameConstant                = "dry-run"
+	flagDryRunDescriptionConstant         = "Preview deletions without making changes"
+)
+
+var errUnexpectedArguments = errors.New(unexpectedArgumentsMessageConstant)
+
+// LoggerProvider supplies a zap logger instance.
+type LoggerProvider func() *zap.Logger
+
+// CommandBuilder assembles the Cobra command for branch cleanup.
+type CommandBuilder struct {
+	LoggerProvider   LoggerProvider
+	Executor         CommandExecutor
+	WorkingDirectory string
+}
+
+// Build constructs the pr-cleanup command.
+func (builder *CommandBuilder) Build() (*cobra.Command, error) {
+	command := &cobra.Command{
+		Use:   commandUseConstant,
+		Short: commandShortDescriptionConstant,
+		Long:  commandLongDescriptionConstant,
+		RunE:  builder.run,
+	}
+
+	command.Flags().String(flagRemoteNameConstant, defaultRemoteNameConstant, flagRemoteDescriptionConstant)
+	command.Flags().Int(flagLimitNameConstant, defaultPullRequestLimitConstant, flagLimitDescriptionConstant)
+	command.Flags().Bool(flagDryRunNameConstant, false, flagDryRunDescriptionConstant)
+
+	return command, nil
+}
+
+func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) error {
+	if len(arguments) > 0 {
+		return errUnexpectedArguments
+	}
+
+	options, optionsError := builder.parseOptions(command)
+	if optionsError != nil {
+		return optionsError
+	}
+
+	logger := builder.resolveLogger()
+	executor, executorError := builder.resolveExecutor(logger)
+	if executorError != nil {
+		return executorError
+	}
+
+	service, serviceError := NewService(logger, executor)
+	if serviceError != nil {
+		return serviceError
+	}
+
+	cleanupError := service.Cleanup(command.Context(), options)
+	if cleanupError != nil {
+		return fmt.Errorf(commandExecutionErrorTemplateConstant, cleanupError)
+	}
+
+	return nil
+}
+
+func (builder *CommandBuilder) parseOptions(command *cobra.Command) (CleanupOptions, error) {
+	remoteNameValue, _ := command.Flags().GetString(flagRemoteNameConstant)
+	trimmedRemoteName := strings.TrimSpace(remoteNameValue)
+	if len(trimmedRemoteName) == 0 {
+		trimmedRemoteName = defaultRemoteNameConstant
+	}
+
+	limitValue, _ := command.Flags().GetInt(flagLimitNameConstant)
+	if limitValue == 0 {
+		limitValue = defaultPullRequestLimitConstant
+	}
+
+	dryRunValue, _ := command.Flags().GetBool(flagDryRunNameConstant)
+
+	cleanupOptions := CleanupOptions{
+		RemoteName:       trimmedRemoteName,
+		PullRequestLimit: limitValue,
+		DryRun:           dryRunValue,
+		WorkingDirectory: builder.WorkingDirectory,
+	}
+
+	return cleanupOptions, nil
+}
+
+func (builder *CommandBuilder) resolveLogger() *zap.Logger {
+	if builder.LoggerProvider == nil {
+		return zap.NewNop()
+	}
+
+	logger := builder.LoggerProvider()
+	if logger == nil {
+		return zap.NewNop()
+	}
+
+	return logger
+}
+
+func (builder *CommandBuilder) resolveExecutor(logger *zap.Logger) (CommandExecutor, error) {
+	if builder.Executor != nil {
+		return builder.Executor, nil
+	}
+
+	commandRunner := execshell.NewOSCommandRunner()
+	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner)
+	if creationError != nil {
+		return nil, creationError
+	}
+
+	return shellExecutor, nil
+}

--- a/internal/branches/doc.go
+++ b/internal/branches/doc.go
@@ -1,0 +1,2 @@
+// Package branches provides functionality for cleaning up Git branches associated with closed pull requests.
+package branches

--- a/internal/branches/service.go
+++ b/internal/branches/service.go
@@ -1,0 +1,304 @@
+package branches
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	defaultRemoteNameConstant                    = "origin"
+	defaultPullRequestLimitConstant              = 100
+	lsRemoteSubcommandConstant                   = "ls-remote"
+	headsFlagConstant                            = "--heads"
+	pushSubcommandConstant                       = "push"
+	deleteFlagConstant                           = "--delete"
+	branchSubcommandConstant                     = "branch"
+	forceDeleteFlagConstant                      = "-D"
+	pullRequestSubcommandConstant                = "pr"
+	listSubcommandConstant                       = "list"
+	stateFlagConstant                            = "--state"
+	closedStateConstant                          = "closed"
+	jsonFlagConstant                             = "--json"
+	headRefFieldConstant                         = "headRefName"
+	limitFlagConstant                            = "--limit"
+	branchReferencePrefixConstant                = "refs/heads/"
+	logMessageListingRemoteBranchesConstant      = "Listing remote branches"
+	logMessageListingPullRequestsConstant        = "Listing closed pull request branches"
+	logMessageDeletingRemoteBranchConstant       = "Deleting remote branch"
+	logMessageSkippingRemoteBranchDryRunConstant = "Skipping remote branch deletion (dry run)"
+	logMessageSkippingMissingBranchConstant      = "Skipping branch (already gone)"
+	logMessageDeletingLocalBranchConstant        = "Deleting local branch"
+	logMessageSkippingLocalBranchDryRunConstant  = "Skipping local branch deletion (dry run)"
+	logMessageRemoteDeletionFailedConstant       = "Remote branch deletion failed"
+	logMessageLocalDeletionFailedConstant        = "Local branch deletion failed"
+	logFieldBranchNameConstant                   = "branch"
+	logFieldRemoteNameConstant                   = "remote"
+	logFieldDryRunConstant                       = "dry_run"
+	logFieldWorkingDirectoryConstant             = "working_directory"
+	logFieldErrorConstant                        = "error"
+	logFieldPullRequestLimitConstant             = "pull_request_limit"
+	remoteBranchesListErrorTemplateConstant      = "unable to list remote branches: %w"
+	pullRequestListErrorTemplateConstant         = "unable to list closed pull requests: %w"
+	remoteBranchParsingErrorTemplateConstant     = "unable to parse remote branch list: %w"
+	pullRequestDecodingErrorTemplateConstant     = "unable to decode pull request response: %w"
+	remoteNameRequiredMessageConstant            = "remote name must be provided"
+	limitPositiveRequirementMessageConstant      = "pull request limit must be greater than zero"
+	executorNotConfiguredMessageConstant         = "command executor not configured"
+)
+
+// CommandExecutor coordinates git and GitHub CLI invocations required for cleanup.
+type CommandExecutor interface {
+	ExecuteGit(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error)
+	ExecuteGitHubCLI(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error)
+}
+
+// CleanupOptions describe the behavior of the branch cleanup routine.
+type CleanupOptions struct {
+	RemoteName       string
+	PullRequestLimit int
+	DryRun           bool
+	WorkingDirectory string
+}
+
+// Service orchestrates removal of remote and local branches tied to closed pull requests.
+type Service struct {
+	logger   *zap.Logger
+	executor CommandExecutor
+}
+
+var (
+	errRemoteNameRequired    = errors.New(remoteNameRequiredMessageConstant)
+	errLimitMustBePositive   = errors.New(limitPositiveRequirementMessageConstant)
+	errExecutorNotConfigured = errors.New(executorNotConfiguredMessageConstant)
+)
+
+// NewService constructs a Service instance.
+func NewService(logger *zap.Logger, executor CommandExecutor) (*Service, error) {
+	if executor == nil {
+		return nil, errExecutorNotConfigured
+	}
+
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &Service{logger: logger, executor: executor}, nil
+}
+
+// Cleanup removes stale branches based on closed pull requests.
+func (service *Service) Cleanup(executionContext context.Context, options CleanupOptions) error {
+	trimmedRemoteName := strings.TrimSpace(options.RemoteName)
+	if len(trimmedRemoteName) == 0 {
+		return errRemoteNameRequired
+	}
+
+	if options.PullRequestLimit <= 0 {
+		return errLimitMustBePositive
+	}
+
+	remoteBranches, remoteBranchesError := service.fetchRemoteBranches(executionContext, trimmedRemoteName, options.WorkingDirectory)
+	if remoteBranchesError != nil {
+		return fmt.Errorf(remoteBranchesListErrorTemplateConstant, remoteBranchesError)
+	}
+
+	closedBranches, pullRequestsError := service.fetchClosedPullRequestBranches(executionContext, options.PullRequestLimit, options.WorkingDirectory)
+	if pullRequestsError != nil {
+		return fmt.Errorf(pullRequestListErrorTemplateConstant, pullRequestsError)
+	}
+
+	service.processBranches(executionContext, trimmedRemoteName, remoteBranches, closedBranches, options)
+
+	return nil
+}
+
+func (service *Service) fetchRemoteBranches(executionContext context.Context, remoteName string, workingDirectory string) (map[string]struct{}, error) {
+	service.logger.Info(logMessageListingRemoteBranchesConstant,
+		zap.String(logFieldRemoteNameConstant, remoteName),
+		zap.String(logFieldWorkingDirectoryConstant, workingDirectory),
+	)
+
+	commandDetails := execshell.CommandDetails{
+		Arguments:        []string{lsRemoteSubcommandConstant, headsFlagConstant, remoteName},
+		WorkingDirectory: workingDirectory,
+	}
+
+	executionResult, executionError := service.executor.ExecuteGit(executionContext, commandDetails)
+	if executionError != nil {
+		return nil, executionError
+	}
+
+	branchSet, parsingError := parseRemoteBranches(executionResult.StandardOutput)
+	if parsingError != nil {
+		return nil, parsingError
+	}
+
+	return branchSet, nil
+}
+
+func (service *Service) fetchClosedPullRequestBranches(executionContext context.Context, limit int, workingDirectory string) ([]string, error) {
+	service.logger.Info(logMessageListingPullRequestsConstant,
+		zap.Int(logFieldPullRequestLimitConstant, limit),
+		zap.String(logFieldWorkingDirectoryConstant, workingDirectory),
+	)
+
+	limitArgument := strconv.Itoa(limit)
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			pullRequestSubcommandConstant,
+			listSubcommandConstant,
+			stateFlagConstant,
+			closedStateConstant,
+			jsonFlagConstant,
+			headRefFieldConstant,
+			limitFlagConstant,
+			limitArgument,
+		},
+		WorkingDirectory: workingDirectory,
+	}
+
+	executionResult, executionError := service.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError != nil {
+		return nil, executionError
+	}
+
+	pullRequestBranches, decodingError := decodePullRequestBranches(executionResult.StandardOutput)
+	if decodingError != nil {
+		return nil, decodingError
+	}
+
+	return pullRequestBranches, nil
+}
+
+func (service *Service) processBranches(executionContext context.Context, remoteName string, remoteBranches map[string]struct{}, pullRequestBranches []string, options CleanupOptions) {
+	processedBranches := make(map[string]struct{})
+	for branchIndex := range pullRequestBranches {
+		branchName := strings.TrimSpace(pullRequestBranches[branchIndex])
+		if len(branchName) == 0 {
+			continue
+		}
+
+		if _, alreadyProcessed := processedBranches[branchName]; alreadyProcessed {
+			continue
+		}
+		processedBranches[branchName] = struct{}{}
+
+		if _, existsInRemote := remoteBranches[branchName]; existsInRemote {
+			service.deleteRemoteAndLocalBranch(executionContext, remoteName, branchName, options)
+			continue
+		}
+
+		service.logger.Info(logMessageSkippingMissingBranchConstant,
+			zap.String(logFieldBranchNameConstant, branchName),
+			zap.String(logFieldRemoteNameConstant, remoteName),
+			zap.String(logFieldWorkingDirectoryConstant, options.WorkingDirectory),
+		)
+	}
+}
+
+func (service *Service) deleteRemoteAndLocalBranch(executionContext context.Context, remoteName string, branchName string, options CleanupOptions) {
+	baseFields := []zap.Field{
+		zap.String(logFieldBranchNameConstant, branchName),
+		zap.String(logFieldRemoteNameConstant, remoteName),
+		zap.String(logFieldWorkingDirectoryConstant, options.WorkingDirectory),
+	}
+
+	if options.DryRun {
+		service.logger.Info(logMessageSkippingRemoteBranchDryRunConstant,
+			append(baseFields, zap.Bool(logFieldDryRunConstant, true))...,
+		)
+		service.logger.Info(logMessageSkippingLocalBranchDryRunConstant,
+			append(baseFields, zap.Bool(logFieldDryRunConstant, true))...,
+		)
+		return
+	}
+
+	service.logger.Info(logMessageDeletingRemoteBranchConstant, baseFields...)
+	pushCommandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			pushSubcommandConstant,
+			remoteName,
+			deleteFlagConstant,
+			branchName,
+		},
+		WorkingDirectory: options.WorkingDirectory,
+	}
+
+	if _, pushError := service.executor.ExecuteGit(executionContext, pushCommandDetails); pushError != nil {
+		service.logger.Warn(logMessageRemoteDeletionFailedConstant,
+			append(baseFields, zap.Error(pushError))...,
+		)
+	}
+
+	service.logger.Info(logMessageDeletingLocalBranchConstant, baseFields...)
+	deleteLocalCommand := execshell.CommandDetails{
+		Arguments: []string{
+			branchSubcommandConstant,
+			forceDeleteFlagConstant,
+			branchName,
+		},
+		WorkingDirectory: options.WorkingDirectory,
+	}
+
+	if _, deleteError := service.executor.ExecuteGit(executionContext, deleteLocalCommand); deleteError != nil {
+		service.logger.Warn(logMessageLocalDeletionFailedConstant,
+			append(baseFields, zap.Error(deleteError))...,
+		)
+	}
+}
+
+func parseRemoteBranches(commandOutput string) (map[string]struct{}, error) {
+	branchSet := make(map[string]struct{})
+	scanner := bufio.NewScanner(strings.NewReader(commandOutput))
+	for scanner.Scan() {
+		lineText := scanner.Text()
+		lineParts := strings.Fields(lineText)
+		if len(lineParts) < 2 {
+			continue
+		}
+		referenceName := lineParts[1]
+		branchName := strings.TrimPrefix(referenceName, branchReferencePrefixConstant)
+		branchName = strings.TrimSpace(branchName)
+		if len(branchName) == 0 {
+			continue
+		}
+		branchSet[branchName] = struct{}{}
+	}
+
+	if scanError := scanner.Err(); scanError != nil {
+		return nil, fmt.Errorf(remoteBranchParsingErrorTemplateConstant, scanError)
+	}
+
+	return branchSet, nil
+}
+
+func decodePullRequestBranches(standardOutput string) ([]string, error) {
+	type pullRequestPayload struct {
+		HeadRefName string `json:"headRefName"`
+	}
+
+	trimmedOutput := strings.TrimSpace(standardOutput)
+	if len(trimmedOutput) == 0 {
+		return []string{}, nil
+	}
+
+	var payload []pullRequestPayload
+	if decodeError := json.Unmarshal([]byte(trimmedOutput), &payload); decodeError != nil {
+		return nil, fmt.Errorf(pullRequestDecodingErrorTemplateConstant, decodeError)
+	}
+
+	branches := make([]string, 0, len(payload))
+	for payloadIndex := range payload {
+		branches = append(branches, payload[payloadIndex].HeadRefName)
+	}
+	return branches, nil
+}

--- a/internal/branches/service_test.go
+++ b/internal/branches/service_test.go
@@ -1,0 +1,457 @@
+package branches_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	branches "github.com/temirov/git_scripts/internal/branches"
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	testRemoteNameConstant                 = "origin"
+	testWorkingDirectoryConstant           = "/tmp/worktree"
+	testPullRequestLimitConstant           = 50
+	gitCommandLabelConstant                = "git"
+	githubCommandLabelConstant             = "gh"
+	commandKeySeparatorConstant            = " "
+	commandKeyTemplateConstant             = "%s%s%s"
+	remoteBranchOutputTemplateConstant     = "%s\trefs/heads/%s\n"
+	remoteCommitPlaceholderConstant        = "1111111111111111111111111111111111111111"
+	subtestNameTemplateConstant            = "%02d_%s"
+	expectedLogMessageTemplateConstant     = "expected log message %s"
+	unexpectedLogMessageTemplateConstant   = "unexpected log message %s"
+	unexpectedCommandTemplateConstant      = "unexpected %s command: %s"
+	deletingRemoteLogMessageConstant       = "Deleting remote branch"
+	deletingLocalLogMessageConstant        = "Deleting local branch"
+	skippingMissingLogMessageConstant      = "Skipping branch (already gone)"
+	skippingRemoteDryRunLogMessageConstant = "Skipping remote branch deletion (dry run)"
+	skippingLocalDryRunLogMessageConstant  = "Skipping local branch deletion (dry run)"
+	pullRequestJSONFieldNameConstant       = "headRefName"
+	gitListRemoteSubcommandConstant        = "ls-remote"
+	gitHeadsFlagConstant                   = "--heads"
+	gitPushSubcommandConstant              = "push"
+	gitDeleteFlagConstant                  = "--delete"
+	gitBranchSubcommandConstant            = "branch"
+	gitForceDeleteFlagConstant             = "-D"
+	githubPullRequestSubcommandConstant    = "pr"
+	githubListSubcommandConstant           = "list"
+	githubStateFlagConstant                = "--state"
+	githubClosedStateConstant              = "closed"
+	githubJSONFlagConstant                 = "--json"
+	githubLimitFlagConstant                = "--limit"
+	remoteNameErrorMessageConstant         = "remote name must be provided"
+	limitValidationErrorMessageConstant    = "pull request limit must be greater than zero"
+	executorNotConfiguredMessageConstant   = "command executor not configured"
+	remoteListFailureMessageConstant       = "ls failure"
+	pullRequestListFailureMessageConstant  = "gh failure"
+	invalidJSONPayloadConstant             = "{invalid"
+	remoteListErrorContainsConstant        = "unable to list remote branches"
+	pullRequestListErrorContainsConstant   = "unable to list closed pull requests"
+	pullRequestDecodeErrorContainsConstant = "unable to decode pull request response"
+)
+
+type fakeCommandExecutor struct {
+	responses        map[string]fakeCommandResponse
+	executedCommands []executedCommandRecord
+}
+
+type fakeCommandResponse struct {
+	result execshell.ExecutionResult
+	err    error
+}
+
+type executedCommandRecord struct {
+	key              string
+	toolName         string
+	arguments        []string
+	workingDirectory string
+}
+
+func (executor *fakeCommandExecutor) ExecuteGit(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return executor.executeCommand(gitCommandLabelConstant, details)
+}
+
+func (executor *fakeCommandExecutor) ExecuteGitHubCLI(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return executor.executeCommand(githubCommandLabelConstant, details)
+}
+
+func (executor *fakeCommandExecutor) executeCommand(toolName string, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	if executor.responses == nil {
+		executor.responses = map[string]fakeCommandResponse{}
+	}
+
+	commandKey := buildCommandKey(toolName, details.Arguments)
+	executor.executedCommands = append(executor.executedCommands, executedCommandRecord{
+		key:              commandKey,
+		toolName:         toolName,
+		arguments:        append([]string{}, details.Arguments...),
+		workingDirectory: details.WorkingDirectory,
+	})
+
+	if response, found := executor.responses[commandKey]; found {
+		if response.err != nil {
+			return execshell.ExecutionResult{}, response.err
+		}
+		return response.result, nil
+	}
+
+	return execshell.ExecutionResult{}, fmt.Errorf(unexpectedCommandTemplateConstant, toolName, commandKey)
+}
+
+func buildCommandKey(toolName string, arguments []string) string {
+	return fmt.Sprintf(commandKeyTemplateConstant, toolName, commandKeySeparatorConstant, strings.Join(arguments, commandKeySeparatorConstant))
+}
+
+func registerResponse(executor *fakeCommandExecutor, toolName string, arguments []string, result execshell.ExecutionResult, commandError error) {
+	if executor.responses == nil {
+		executor.responses = map[string]fakeCommandResponse{}
+	}
+	executor.responses[buildCommandKey(toolName, arguments)] = fakeCommandResponse{result: result, err: commandError}
+}
+
+func buildRemoteOutput(branchNames []string) string {
+	var builder strings.Builder
+	for branchIndex := range branchNames {
+		builder.WriteString(fmt.Sprintf(remoteBranchOutputTemplateConstant, remoteCommitPlaceholderConstant, branchNames[branchIndex]))
+	}
+	return builder.String()
+}
+
+func buildPullRequestJSON(branchNames []string) (string, error) {
+	type pullRequestPayload struct {
+		HeadRefName string `json:"headRefName"`
+	}
+
+	payload := make([]pullRequestPayload, 0, len(branchNames))
+	for branchIndex := range branchNames {
+		payload = append(payload, pullRequestPayload{HeadRefName: branchNames[branchIndex]})
+	}
+
+	encodedBytes, encodingError := json.Marshal(payload)
+	if encodingError != nil {
+		return "", encodingError
+	}
+	return string(encodedBytes), nil
+}
+
+func TestServiceCleanupScenarios(testInstance *testing.T) {
+	testCases := []struct {
+		name                  string
+		remoteBranches        []string
+		pullRequestBranches   []string
+		options               branches.CleanupOptions
+		expectedCommandKeys   []string
+		expectedLogMessages   []string
+		unexpectedLogMessages []string
+	}{
+		{
+			name:                "deletes_remote_and_local_branches",
+			remoteBranches:      []string{"feature/delete"},
+			pullRequestBranches: []string{"feature/delete"},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           false,
+				WorkingDirectory: testWorkingDirectoryConstant,
+			},
+			expectedCommandKeys: []string{
+				buildCommandKey(gitCommandLabelConstant, []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testRemoteNameConstant}),
+				buildCommandKey(githubCommandLabelConstant, []string{
+					githubPullRequestSubcommandConstant,
+					githubListSubcommandConstant,
+					githubStateFlagConstant,
+					githubClosedStateConstant,
+					githubJSONFlagConstant,
+					pullRequestJSONFieldNameConstant,
+					githubLimitFlagConstant,
+					strconv.Itoa(testPullRequestLimitConstant),
+				}),
+				buildCommandKey(gitCommandLabelConstant, []string{gitPushSubcommandConstant, testRemoteNameConstant, gitDeleteFlagConstant, "feature/delete"}),
+				buildCommandKey(gitCommandLabelConstant, []string{gitBranchSubcommandConstant, gitForceDeleteFlagConstant, "feature/delete"}),
+			},
+			expectedLogMessages:   []string{deletingRemoteLogMessageConstant, deletingLocalLogMessageConstant},
+			unexpectedLogMessages: []string{skippingMissingLogMessageConstant, skippingRemoteDryRunLogMessageConstant, skippingLocalDryRunLogMessageConstant},
+		},
+		{
+			name:                "skips_missing_remote_branch",
+			remoteBranches:      []string{},
+			pullRequestBranches: []string{"feature/missing"},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           false,
+				WorkingDirectory: testWorkingDirectoryConstant,
+			},
+			expectedCommandKeys: []string{
+				buildCommandKey(gitCommandLabelConstant, []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testRemoteNameConstant}),
+				buildCommandKey(githubCommandLabelConstant, []string{
+					githubPullRequestSubcommandConstant,
+					githubListSubcommandConstant,
+					githubStateFlagConstant,
+					githubClosedStateConstant,
+					githubJSONFlagConstant,
+					pullRequestJSONFieldNameConstant,
+					githubLimitFlagConstant,
+					strconv.Itoa(testPullRequestLimitConstant),
+				}),
+			},
+			expectedLogMessages:   []string{skippingMissingLogMessageConstant},
+			unexpectedLogMessages: []string{deletingRemoteLogMessageConstant, deletingLocalLogMessageConstant},
+		},
+		{
+			name:                "dry_run_does_not_execute_deletions",
+			remoteBranches:      []string{"feature/dry-run"},
+			pullRequestBranches: []string{"feature/dry-run"},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           true,
+				WorkingDirectory: testWorkingDirectoryConstant,
+			},
+			expectedCommandKeys: []string{
+				buildCommandKey(gitCommandLabelConstant, []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testRemoteNameConstant}),
+				buildCommandKey(githubCommandLabelConstant, []string{
+					githubPullRequestSubcommandConstant,
+					githubListSubcommandConstant,
+					githubStateFlagConstant,
+					githubClosedStateConstant,
+					githubJSONFlagConstant,
+					pullRequestJSONFieldNameConstant,
+					githubLimitFlagConstant,
+					strconv.Itoa(testPullRequestLimitConstant),
+				}),
+			},
+			expectedLogMessages:   []string{skippingRemoteDryRunLogMessageConstant, skippingLocalDryRunLogMessageConstant},
+			unexpectedLogMessages: []string{deletingRemoteLogMessageConstant, deletingLocalLogMessageConstant},
+		},
+		{
+			name:                "duplicates_are_processed_once",
+			remoteBranches:      []string{"feature/duplicate"},
+			pullRequestBranches: []string{"feature/duplicate", "feature/duplicate"},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           false,
+				WorkingDirectory: testWorkingDirectoryConstant,
+			},
+			expectedCommandKeys: []string{
+				buildCommandKey(gitCommandLabelConstant, []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testRemoteNameConstant}),
+				buildCommandKey(githubCommandLabelConstant, []string{
+					githubPullRequestSubcommandConstant,
+					githubListSubcommandConstant,
+					githubStateFlagConstant,
+					githubClosedStateConstant,
+					githubJSONFlagConstant,
+					pullRequestJSONFieldNameConstant,
+					githubLimitFlagConstant,
+					strconv.Itoa(testPullRequestLimitConstant),
+				}),
+				buildCommandKey(gitCommandLabelConstant, []string{gitPushSubcommandConstant, testRemoteNameConstant, gitDeleteFlagConstant, "feature/duplicate"}),
+				buildCommandKey(gitCommandLabelConstant, []string{gitBranchSubcommandConstant, gitForceDeleteFlagConstant, "feature/duplicate"}),
+			},
+			expectedLogMessages:   []string{deletingRemoteLogMessageConstant, deletingLocalLogMessageConstant},
+			unexpectedLogMessages: []string{skippingMissingLogMessageConstant},
+		},
+	}
+
+	for testCaseIndex := range testCases {
+		testCase := testCases[testCaseIndex]
+		testInstance.Run(fmt.Sprintf(subtestNameTemplateConstant, testCaseIndex, testCase.name), func(testInstance *testing.T) {
+			fakeExecutorInstance := &fakeCommandExecutor{}
+
+			remoteOutput := buildRemoteOutput(testCase.remoteBranches)
+			pullRequestJSON, jsonError := buildPullRequestJSON(testCase.pullRequestBranches)
+			require.NoError(testInstance, jsonError)
+
+			gitListArguments := []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testCase.options.RemoteName}
+			registerResponse(fakeExecutorInstance, gitCommandLabelConstant, gitListArguments, execshell.ExecutionResult{StandardOutput: remoteOutput, ExitCode: 0}, nil)
+
+			githubListArguments := []string{
+				githubPullRequestSubcommandConstant,
+				githubListSubcommandConstant,
+				githubStateFlagConstant,
+				githubClosedStateConstant,
+				githubJSONFlagConstant,
+				pullRequestJSONFieldNameConstant,
+				githubLimitFlagConstant,
+				strconv.Itoa(testCase.options.PullRequestLimit),
+			}
+			registerResponse(fakeExecutorInstance, githubCommandLabelConstant, githubListArguments, execshell.ExecutionResult{StandardOutput: pullRequestJSON, ExitCode: 0}, nil)
+
+			for branchIndex := range testCase.pullRequestBranches {
+				branchName := testCase.pullRequestBranches[branchIndex]
+				if len(branchName) == 0 {
+					continue
+				}
+				registerResponse(fakeExecutorInstance, gitCommandLabelConstant, []string{gitPushSubcommandConstant, testCase.options.RemoteName, gitDeleteFlagConstant, branchName}, execshell.ExecutionResult{ExitCode: 0}, nil)
+				registerResponse(fakeExecutorInstance, gitCommandLabelConstant, []string{gitBranchSubcommandConstant, gitForceDeleteFlagConstant, branchName}, execshell.ExecutionResult{ExitCode: 0}, nil)
+			}
+
+			logCore, observedLogs := observer.New(zap.DebugLevel)
+			logger := zap.New(logCore)
+
+			service, serviceError := branches.NewService(logger, fakeExecutorInstance)
+			require.NoError(testInstance, serviceError)
+
+			cleanupError := service.Cleanup(context.Background(), testCase.options)
+			require.NoError(testInstance, cleanupError)
+
+			actualCommandKeys := make([]string, 0, len(fakeExecutorInstance.executedCommands))
+			for commandIndex := range fakeExecutorInstance.executedCommands {
+				actualCommandKeys = append(actualCommandKeys, fakeExecutorInstance.executedCommands[commandIndex].key)
+				require.Equal(testInstance, testCase.options.WorkingDirectory, fakeExecutorInstance.executedCommands[commandIndex].workingDirectory)
+			}
+			require.Equal(testInstance, testCase.expectedCommandKeys, actualCommandKeys)
+
+			loggedEntries := observedLogs.All()
+			for expectedIndex := range testCase.expectedLogMessages {
+				expectedMessage := testCase.expectedLogMessages[expectedIndex]
+				require.True(testInstance, containsLogMessage(loggedEntries, expectedMessage), fmt.Sprintf(expectedLogMessageTemplateConstant, expectedMessage))
+			}
+
+			for unexpectedIndex := range testCase.unexpectedLogMessages {
+				unexpectedMessage := testCase.unexpectedLogMessages[unexpectedIndex]
+				require.False(testInstance, containsLogMessage(loggedEntries, unexpectedMessage), fmt.Sprintf(unexpectedLogMessageTemplateConstant, unexpectedMessage))
+			}
+		})
+	}
+}
+
+func containsLogMessage(entries []observer.LoggedEntry, message string) bool {
+	for entryIndex := range entries {
+		if entries[entryIndex].Message == message {
+			return true
+		}
+	}
+	return false
+}
+
+func TestServiceCleanupFailures(testInstance *testing.T) {
+	testCases := []struct {
+		name              string
+		configureExecutor func(*fakeCommandExecutor)
+		options           branches.CleanupOptions
+		expectedError     string
+	}{
+		{
+			name: "remote_name_required",
+			configureExecutor: func(executor *fakeCommandExecutor) {
+			},
+			options: branches.CleanupOptions{
+				RemoteName:       "",
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           false,
+			},
+			expectedError: remoteNameErrorMessageConstant,
+		},
+		{
+			name: "limit_must_be_positive",
+			configureExecutor: func(executor *fakeCommandExecutor) {
+			},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: 0,
+				DryRun:           false,
+			},
+			expectedError: limitValidationErrorMessageConstant,
+		},
+		{
+			name: "remote_listing_failure",
+			configureExecutor: func(executor *fakeCommandExecutor) {
+				failingArguments := []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testRemoteNameConstant}
+				registerResponse(executor, gitCommandLabelConstant, failingArguments, execshell.ExecutionResult{}, errors.New(remoteListFailureMessageConstant))
+			},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           false,
+			},
+			expectedError: remoteListErrorContainsConstant,
+		},
+		{
+			name: "pull_request_listing_failure",
+			configureExecutor: func(executor *fakeCommandExecutor) {
+				gitArguments := []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testRemoteNameConstant}
+				registerResponse(executor, gitCommandLabelConstant, gitArguments, execshell.ExecutionResult{ExitCode: 0}, nil)
+
+				ghArguments := []string{
+					githubPullRequestSubcommandConstant,
+					githubListSubcommandConstant,
+					githubStateFlagConstant,
+					githubClosedStateConstant,
+					githubJSONFlagConstant,
+					pullRequestJSONFieldNameConstant,
+					githubLimitFlagConstant,
+					strconv.Itoa(testPullRequestLimitConstant),
+				}
+				registerResponse(executor, githubCommandLabelConstant, ghArguments, execshell.ExecutionResult{}, errors.New(pullRequestListFailureMessageConstant))
+			},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           false,
+			},
+			expectedError: pullRequestListErrorContainsConstant,
+		},
+		{
+			name: "pull_request_decoding_failure",
+			configureExecutor: func(executor *fakeCommandExecutor) {
+				gitArguments := []string{gitListRemoteSubcommandConstant, gitHeadsFlagConstant, testRemoteNameConstant}
+				registerResponse(executor, gitCommandLabelConstant, gitArguments, execshell.ExecutionResult{ExitCode: 0}, nil)
+
+				ghArguments := []string{
+					githubPullRequestSubcommandConstant,
+					githubListSubcommandConstant,
+					githubStateFlagConstant,
+					githubClosedStateConstant,
+					githubJSONFlagConstant,
+					pullRequestJSONFieldNameConstant,
+					githubLimitFlagConstant,
+					strconv.Itoa(testPullRequestLimitConstant),
+				}
+				registerResponse(executor, githubCommandLabelConstant, ghArguments, execshell.ExecutionResult{StandardOutput: invalidJSONPayloadConstant, ExitCode: 0}, nil)
+			},
+			options: branches.CleanupOptions{
+				RemoteName:       testRemoteNameConstant,
+				PullRequestLimit: testPullRequestLimitConstant,
+				DryRun:           false,
+			},
+			expectedError: pullRequestDecodeErrorContainsConstant,
+		},
+	}
+
+	for testCaseIndex := range testCases {
+		testCase := testCases[testCaseIndex]
+		testInstance.Run(fmt.Sprintf(subtestNameTemplateConstant, testCaseIndex, testCase.name), func(testInstance *testing.T) {
+			fakeExecutorInstance := &fakeCommandExecutor{}
+			testCase.configureExecutor(fakeExecutorInstance)
+
+			logCore, _ := observer.New(zap.DebugLevel)
+			logger := zap.New(logCore)
+
+			service, serviceError := branches.NewService(logger, fakeExecutorInstance)
+			require.NoError(testInstance, serviceError)
+
+			cleanupError := service.Cleanup(context.Background(), testCase.options)
+			require.Error(testInstance, cleanupError)
+			require.Contains(testInstance, cleanupError.Error(), testCase.expectedError)
+		})
+	}
+}
+
+func TestNewServiceRequiresExecutor(testInstance *testing.T) {
+	service, serviceError := branches.NewService(zap.NewNop(), nil)
+	require.Error(testInstance, serviceError)
+	require.Nil(testInstance, service)
+	require.EqualError(testInstance, serviceError, executorNotConfiguredMessageConstant)
+}

--- a/tests/pr_cleanup_integration_test.go
+++ b/tests/pr_cleanup_integration_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/branches"
+	"github.com/temirov/git_scripts/internal/execshell"
+)
+
+const (
+	integrationRemoteDirectoryNameConstant        = "remote.git"
+	integrationLocalDirectoryNameConstant         = "workspace"
+	integrationGitExecutableNameConstant          = "git"
+	integrationGHExecutableNameConstant           = "gh"
+	integrationFakeGHDirectoryNameConstant        = "fake_gh"
+	integrationInitialFileNameConstant            = "initial.txt"
+	integrationInitialFileContentsConstant        = "initial commit contents\n"
+	integrationUpdatedFileContentsConstant        = "updated contents\n"
+	integrationInitialCommitMessageConstant       = "Initial commit"
+	integrationFeatureDeleteCommitMessageConstant = "Feature delete changes"
+	integrationFeatureSkipCommitMessageConstant   = "Feature skip changes"
+	integrationUserNameConstant                   = "Integration Tester"
+	integrationUserEmailConstant                  = "tester@example.com"
+	integrationMainBranchNameConstant             = "main"
+	integrationFeatureDeleteBranchConstant        = "feature/delete"
+	integrationFeatureSkipBranchConstant          = "feature/skip"
+	integrationFeatureMissingBranchConstant       = "feature/missing"
+	integrationRemoteNameConstant                 = "origin"
+	integrationPullRequestLimitConstant           = 100
+	prCleanupCommandTimeoutConstant               = 10 * time.Second
+	integrationFakeGHPayloadConstant              = "[{\"headRefName\":\"feature/delete\"},{\"headRefName\":\"feature/missing\"}]"
+	integrationFakeGHScriptTemplateConstant       = "#!/bin/sh\ncat <<'JSON'\n%s\nJSON\n"
+	integrationExpectationMessageTemplateConstant = "expected branch state: %s"
+)
+
+func TestPullRequestCleanupIntegration(testInstance *testing.T) {
+	temporaryRoot := testInstance.TempDir()
+	remoteRepositoryPath := filepath.Join(temporaryRoot, integrationRemoteDirectoryNameConstant)
+	localRepositoryPath := filepath.Join(temporaryRoot, integrationLocalDirectoryNameConstant)
+
+	runGitCommand(testInstance, temporaryRoot, []string{integrationGitExecutableNameConstant, "init", "--bare", remoteRepositoryPath})
+
+	runGitCommand(testInstance, temporaryRoot, []string{integrationGitExecutableNameConstant, "init", localRepositoryPath})
+	configureLocalRepository(testInstance, localRepositoryPath)
+
+	initialFilePath := filepath.Join(localRepositoryPath, integrationInitialFileNameConstant)
+	writeFile(testInstance, initialFilePath, integrationInitialFileContentsConstant)
+
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "add", integrationInitialFileNameConstant})
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "commit", "-m", integrationInitialCommitMessageConstant})
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "branch", "-M", integrationMainBranchNameConstant})
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "remote", "add", integrationRemoteNameConstant, remoteRepositoryPath})
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "push", "-u", integrationRemoteNameConstant, integrationMainBranchNameConstant})
+
+	createFeatureBranch(testInstance, localRepositoryPath, integrationFeatureDeleteBranchConstant, integrationFeatureDeleteCommitMessageConstant, integrationUpdatedFileContentsConstant)
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "push", integrationRemoteNameConstant, integrationFeatureDeleteBranchConstant})
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "checkout", integrationMainBranchNameConstant})
+
+	createFeatureBranch(testInstance, localRepositoryPath, integrationFeatureSkipBranchConstant, integrationFeatureSkipCommitMessageConstant, integrationUpdatedFileContentsConstant)
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "push", integrationRemoteNameConstant, integrationFeatureSkipBranchConstant})
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "checkout", integrationMainBranchNameConstant})
+
+	runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "branch", integrationFeatureMissingBranchConstant})
+
+	fakeGHDirectoryPath := filepath.Join(temporaryRoot, integrationFakeGHDirectoryNameConstant)
+	require.NoError(testInstance, os.MkdirAll(fakeGHDirectoryPath, 0o755))
+	fakeGHScriptPath := filepath.Join(fakeGHDirectoryPath, integrationGHExecutableNameConstant)
+	scriptContents := fmt.Sprintf(integrationFakeGHScriptTemplateConstant, integrationFakeGHPayloadConstant)
+	writeFile(testInstance, fakeGHScriptPath, scriptContents)
+	require.NoError(testInstance, os.Chmod(fakeGHScriptPath, 0o755))
+
+	originalPathVariable := os.Getenv("PATH")
+	updatedPathVariable := fmt.Sprintf("%s%c%s", fakeGHDirectoryPath, os.PathListSeparator, originalPathVariable)
+	require.NoError(testInstance, os.Setenv("PATH", updatedPathVariable))
+	defer func() {
+		require.NoError(testInstance, os.Setenv("PATH", originalPathVariable))
+	}()
+
+	commandRunner := execshell.NewOSCommandRunner()
+	commandLogger := zap.NewNop()
+	shellExecutor, executorError := execshell.NewShellExecutor(commandLogger, commandRunner)
+	require.NoError(testInstance, executorError)
+
+	serviceLogger := zap.NewNop()
+	cleanupService, serviceError := branches.NewService(serviceLogger, shellExecutor)
+	require.NoError(testInstance, serviceError)
+
+	cleanupOptions := branches.CleanupOptions{
+		RemoteName:       integrationRemoteNameConstant,
+		PullRequestLimit: integrationPullRequestLimitConstant,
+		DryRun:           false,
+		WorkingDirectory: localRepositoryPath,
+	}
+
+	cleanupError := cleanupService.Cleanup(context.Background(), cleanupOptions)
+	require.NoError(testInstance, cleanupError)
+
+	remoteDeletedOutput := runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "ls-remote", "--heads", integrationRemoteNameConstant, integrationFeatureDeleteBranchConstant})
+	require.Empty(testInstance, strings.TrimSpace(remoteDeletedOutput), fmt.Sprintf(integrationExpectationMessageTemplateConstant, integrationFeatureDeleteBranchConstant))
+
+	remoteSkipOutput := runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "ls-remote", "--heads", integrationRemoteNameConstant, integrationFeatureSkipBranchConstant})
+	require.NotEmpty(testInstance, strings.TrimSpace(remoteSkipOutput), fmt.Sprintf(integrationExpectationMessageTemplateConstant, integrationFeatureSkipBranchConstant))
+
+	localDeletedOutput := runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "branch", "--list", integrationFeatureDeleteBranchConstant})
+	require.Empty(testInstance, strings.TrimSpace(localDeletedOutput), fmt.Sprintf(integrationExpectationMessageTemplateConstant, integrationFeatureDeleteBranchConstant))
+
+	localMissingOutput := runGitCommand(testInstance, localRepositoryPath, []string{integrationGitExecutableNameConstant, "branch", "--list", integrationFeatureMissingBranchConstant})
+	require.NotEmpty(testInstance, strings.TrimSpace(localMissingOutput), fmt.Sprintf(integrationExpectationMessageTemplateConstant, integrationFeatureMissingBranchConstant))
+}
+
+func configureLocalRepository(testInstance *testing.T, repositoryPath string) {
+	runGitCommand(testInstance, repositoryPath, []string{integrationGitExecutableNameConstant, "config", "user.name", integrationUserNameConstant})
+	runGitCommand(testInstance, repositoryPath, []string{integrationGitExecutableNameConstant, "config", "user.email", integrationUserEmailConstant})
+}
+
+func createFeatureBranch(testInstance *testing.T, repositoryPath string, branchName string, commitMessage string, fileContents string) {
+	runGitCommand(testInstance, repositoryPath, []string{integrationGitExecutableNameConstant, "checkout", "-b", branchName})
+	writeFile(testInstance, filepath.Join(repositoryPath, integrationInitialFileNameConstant), fileContents)
+	runGitCommand(testInstance, repositoryPath, []string{integrationGitExecutableNameConstant, "commit", "-am", commitMessage})
+}
+
+func writeFile(testInstance *testing.T, filePath string, contents string) {
+	require.NoError(testInstance, os.MkdirAll(filepath.Dir(filePath), 0o755))
+	require.NoError(testInstance, os.WriteFile(filePath, []byte(contents), 0o644))
+}
+
+func runGitCommand(testInstance *testing.T, workingDirectory string, arguments []string) string {
+	executionContext, cancelFunction := context.WithTimeout(context.Background(), prCleanupCommandTimeoutConstant)
+	defer cancelFunction()
+
+	command := exec.CommandContext(executionContext, arguments[0], arguments[1:]...)
+	if len(workingDirectory) > 0 {
+		command.Dir = workingDirectory
+	}
+
+	outputBytes, commandError := command.CombinedOutput()
+	require.NoError(testInstance, commandError, string(outputBytes))
+	return string(outputBytes)
+}


### PR DESCRIPTION
## Summary
- add a branches cleanup service that enumerates remote heads, resolves closed pull requests with gh, and deletes or skips branches with dry-run aware logging
- expose the workflow through a new `pr-cleanup` Cobra command wired into the CLI
- cover the feature with table-driven unit tests and an integration test that exercises a temporary git repository and fake gh output

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1e8dfe97883278c9947b99467e3c8