### PR TITLE
Add branch migration command and GitHub migration services

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/temirov/git_scripts/internal/audit"
 	"github.com/temirov/git_scripts/internal/branches"
+	"github.com/temirov/git_scripts/internal/migrate"
 	"github.com/temirov/git_scripts/internal/utils"
 )
 
@@ -117,6 +118,16 @@ func newCLIApplication() *CLIApplication {
 	branchCleanupCommand, branchCleanupBuildError := branchCleanupBuilder.Build()
 	if branchCleanupBuildError == nil {
 		cobraCommand.AddCommand(branchCleanupCommand)
+	}
+
+	branchMigrationBuilder := migrate.CommandBuilder{
+		LoggerProvider: func() *zap.Logger {
+			return cliApplication.logger
+		},
+	}
+	branchCommand, branchBuildError := branchMigrationBuilder.Build()
+	if branchBuildError == nil {
+		cobraCommand.AddCommand(branchCommand)
 	}
 
 	cliApplication.rootCommand = cobraCommand

--- a/internal/githubcli/client.go
+++ b/internal/githubcli/client.go
@@ -12,39 +12,53 @@ import (
 )
 
 const (
-	repoSubcommandConstant                  = "repo"
-	viewSubcommandConstant                  = "view"
-	pullRequestSubcommandConstant           = "pr"
-	listSubcommandConstant                  = "list"
-	apiSubcommandConstant                   = "api"
-	jsonFlagConstant                        = "--json"
-	repoFlagConstant                        = "--repo"
-	stateFlagConstant                       = "--state"
-	baseFlagConstant                        = "--base"
-	limitFlagConstant                       = "--limit"
-	methodFlagConstant                      = "-X"
-	inputFlagConstant                       = "--input"
-	stdinReferenceConstant                  = "-"
-	acceptHeaderFlagConstant                = "-H"
-	acceptHeaderValueConstant               = "Accept: application/vnd.github+json"
-	repositoryFieldNameConstant             = "repository"
-	baseBranchFieldNameConstant             = "base_branch"
-	sourceBranchFieldNameConstant           = "source_branch"
-	stateFieldNameConstant                  = "state"
-	requiredValueMessageConstant            = "value required"
-	executorNotConfiguredMessageConstant    = "github cli executor not configured"
-	pullRequestLimitDefaultValueConstant    = 100
-	pullRequestJSONFieldsConstant           = "number,title,headRefName"
-	repoViewJSONFieldsConstant              = "defaultBranchRef,nameWithOwner,description"
-	operationErrorMessageTemplateConstant   = "%s operation failed"
-	operationErrorWithCauseTemplateConstant = "%s operation failed: %s"
-	responseDecodingErrorTemplateConstant   = "%s response decoding failed: %s"
-	payloadEncodingErrorTemplateConstant    = "%s payload encoding failed: %s"
-	invalidInputErrorTemplateConstant       = "%s: %s"
-	pagesEndpointTemplateConstant           = "repos/%s/pages"
-	repositoryMetadataOperationNameConstant = OperationName("ResolveRepoMetadata")
-	listPullRequestsOperationNameConstant   = OperationName("ListPullRequests")
-	updatePagesOperationNameConstant        = OperationName("UpdatePagesConfig")
+	repoSubcommandConstant                     = "repo"
+	viewSubcommandConstant                     = "view"
+	pullRequestSubcommandConstant              = "pr"
+	listSubcommandConstant                     = "list"
+	editSubcommandConstant                     = "edit"
+	apiSubcommandConstant                      = "api"
+	jsonFlagConstant                           = "--json"
+	repoFlagConstant                           = "--repo"
+	stateFlagConstant                          = "--state"
+	baseFlagConstant                           = "--base"
+	limitFlagConstant                          = "--limit"
+	methodFlagConstant                         = "-X"
+	fieldFlagConstant                          = "-f"
+	inputFlagConstant                          = "--input"
+	stdinReferenceConstant                     = "-"
+	acceptHeaderFlagConstant                   = "-H"
+	acceptHeaderValueConstant                  = "Accept: application/vnd.github+json"
+	repositoryFieldNameConstant                = "repository"
+	baseBranchFieldNameConstant                = "base_branch"
+	sourceBranchFieldNameConstant              = "source_branch"
+	defaultBranchFieldNameConstant             = "default_branch"
+	pullRequestNumberFieldNameConstant         = "pull_request_number"
+	stateFieldNameConstant                     = "state"
+	requiredValueMessageConstant               = "value required"
+	executorNotConfiguredMessageConstant       = "github cli executor not configured"
+	pullRequestLimitDefaultValueConstant       = 100
+	pullRequestJSONFieldsConstant              = "number,title,headRefName"
+	repoViewJSONFieldsConstant                 = "defaultBranchRef,nameWithOwner,description"
+	operationErrorMessageTemplateConstant      = "%s operation failed"
+	operationErrorWithCauseTemplateConstant    = "%s operation failed: %s"
+	responseDecodingErrorTemplateConstant      = "%s response decoding failed: %s"
+	payloadEncodingErrorTemplateConstant       = "%s payload encoding failed: %s"
+	invalidInputErrorTemplateConstant          = "%s: %s"
+	pagesEndpointTemplateConstant              = "repos/%s/pages"
+	repositoryEndpointTemplateConstant         = "repos/%s"
+	branchProtectionEndpointTemplateConstant   = "repos/%s/branches/%s/protection"
+	pagesNullResponseConstant                  = "null"
+	httpMethodGetConstant                      = "GET"
+	httpMethodPutConstant                      = "PUT"
+	httpMethodPatchConstant                    = "PATCH"
+	repositoryMetadataOperationNameConstant    = OperationName("ResolveRepoMetadata")
+	listPullRequestsOperationNameConstant      = OperationName("ListPullRequests")
+	updatePagesOperationNameConstant           = OperationName("UpdatePagesConfig")
+	getPagesOperationNameConstant              = OperationName("GetPagesConfig")
+	updateDefaultBranchOperationNameConstant   = OperationName("UpdateDefaultBranch")
+	updatePullRequestOperationNameConstant     = OperationName("UpdatePullRequestBase")
+	checkBranchProtectionOperationNameConstant = OperationName("CheckBranchProtection")
 )
 
 // OperationName describes a named GitHub CLI workflow supported by the client.
@@ -83,6 +97,23 @@ type PullRequestListOptions struct {
 
 // PagesConfiguration describes the desired GitHub Pages configuration.
 type PagesConfiguration struct {
+	SourceBranch string
+	SourcePath   string
+}
+
+// PagesBuildType describes GitHub Pages build modes.
+type PagesBuildType string
+
+// Supported Pages build types.
+const (
+	PagesBuildTypeLegacy   PagesBuildType = PagesBuildType("legacy")
+	PagesBuildTypeWorkflow PagesBuildType = PagesBuildType("workflow")
+)
+
+// PagesStatus captures the GitHub Pages configuration state.
+type PagesStatus struct {
+	Enabled      bool
+	BuildType    PagesBuildType
 	SourceBranch string
 	SourcePath   string
 }
@@ -327,4 +358,158 @@ func (client *Client) UpdatePagesConfig(executionContext context.Context, reposi
 	return nil
 }
 
-const httpMethodPutConstant = "PUT"
+// GetPagesConfig retrieves the GitHub Pages configuration for a repository.
+func (client *Client) GetPagesConfig(executionContext context.Context, repository string) (PagesStatus, error) {
+	repositoryIdentifier := strings.TrimSpace(repository)
+	if len(repositoryIdentifier) == 0 {
+		return PagesStatus{}, InvalidInputError{FieldName: repositoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			apiSubcommandConstant,
+			fmt.Sprintf(pagesEndpointTemplateConstant, repositoryIdentifier),
+			methodFlagConstant,
+			httpMethodGetConstant,
+			acceptHeaderFlagConstant,
+			acceptHeaderValueConstant,
+		},
+	}
+
+	executionResult, executionError := client.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError != nil {
+		return PagesStatus{}, OperationError{Operation: getPagesOperationNameConstant, Cause: executionError}
+	}
+
+	trimmedOutput := strings.TrimSpace(executionResult.StandardOutput)
+	if len(trimmedOutput) == 0 || trimmedOutput == pagesNullResponseConstant {
+		return PagesStatus{Enabled: false}, nil
+	}
+
+	var response struct {
+		BuildType string `json:"build_type"`
+		Source    struct {
+			Branch string `json:"branch"`
+			Path   string `json:"path"`
+		} `json:"source"`
+	}
+
+	decodingError := json.Unmarshal([]byte(trimmedOutput), &response)
+	if decodingError != nil {
+		return PagesStatus{}, ResponseDecodingError{Operation: getPagesOperationNameConstant, Cause: decodingError}
+	}
+
+	pagesStatus := PagesStatus{
+		Enabled:      true,
+		BuildType:    PagesBuildType(response.BuildType),
+		SourceBranch: response.Source.Branch,
+		SourcePath:   response.Source.Path,
+	}
+
+	return pagesStatus, nil
+}
+
+// SetDefaultBranch updates the default branch for the repository.
+func (client *Client) SetDefaultBranch(executionContext context.Context, repository string, branchName string) error {
+	repositoryIdentifier := strings.TrimSpace(repository)
+	if len(repositoryIdentifier) == 0 {
+		return InvalidInputError{FieldName: repositoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedBranch := strings.TrimSpace(branchName)
+	if len(trimmedBranch) == 0 {
+		return InvalidInputError{FieldName: defaultBranchFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			apiSubcommandConstant,
+			fmt.Sprintf(repositoryEndpointTemplateConstant, repositoryIdentifier),
+			methodFlagConstant,
+			httpMethodPatchConstant,
+			fieldFlagConstant,
+			fmt.Sprintf("%s=%s", defaultBranchFieldNameConstant, trimmedBranch),
+			acceptHeaderFlagConstant,
+			acceptHeaderValueConstant,
+		},
+	}
+
+	_, executionError := client.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError != nil {
+		return OperationError{Operation: updateDefaultBranchOperationNameConstant, Cause: executionError}
+	}
+
+	return nil
+}
+
+// UpdatePullRequestBase retargets a pull request to a new base branch.
+func (client *Client) UpdatePullRequestBase(executionContext context.Context, repository string, pullRequestNumber int, baseBranch string) error {
+	repositoryIdentifier := strings.TrimSpace(repository)
+	if len(repositoryIdentifier) == 0 {
+		return InvalidInputError{FieldName: repositoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	if pullRequestNumber <= 0 {
+		return InvalidInputError{FieldName: pullRequestNumberFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedBase := strings.TrimSpace(baseBranch)
+	if len(trimmedBase) == 0 {
+		return InvalidInputError{FieldName: baseBranchFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			pullRequestSubcommandConstant,
+			editSubcommandConstant,
+			strconv.Itoa(pullRequestNumber),
+			repoFlagConstant,
+			repositoryIdentifier,
+			baseFlagConstant,
+			trimmedBase,
+		},
+	}
+
+	_, executionError := client.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError != nil {
+		return OperationError{Operation: updatePullRequestOperationNameConstant, Cause: executionError}
+	}
+
+	return nil
+}
+
+// CheckBranchProtection verifies whether the branch has protection rules.
+func (client *Client) CheckBranchProtection(executionContext context.Context, repository string, branchName string) (bool, error) {
+	repositoryIdentifier := strings.TrimSpace(repository)
+	if len(repositoryIdentifier) == 0 {
+		return false, InvalidInputError{FieldName: repositoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	trimmedBranch := strings.TrimSpace(branchName)
+	if len(trimmedBranch) == 0 {
+		return false, InvalidInputError{FieldName: sourceBranchFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+
+	commandDetails := execshell.CommandDetails{
+		Arguments: []string{
+			apiSubcommandConstant,
+			fmt.Sprintf(branchProtectionEndpointTemplateConstant, repositoryIdentifier, trimmedBranch),
+			methodFlagConstant,
+			httpMethodGetConstant,
+			acceptHeaderFlagConstant,
+			acceptHeaderValueConstant,
+		},
+	}
+
+	_, executionError := client.executor.ExecuteGitHubCLI(executionContext, commandDetails)
+	if executionError == nil {
+		return true, nil
+	}
+
+	var commandFailure execshell.CommandFailedError
+	if errors.As(executionError, &commandFailure) {
+		return false, nil
+	}
+
+	return false, OperationError{Operation: checkBranchProtectionOperationNameConstant, Cause: executionError}
+}

--- a/internal/migrate/command.go
+++ b/internal/migrate/command.go
@@ -1,0 +1,217 @@
+package migrate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
+	"github.com/temirov/git_scripts/internal/gitrepo"
+)
+
+const (
+	branchCommandUseConstant                     = "branch"
+	branchCommandShortDescriptionConstant        = "Manage repository branches"
+	branchCommandLongDescriptionConstant         = "Branch utilities for Git repositories."
+	migrateCommandUseConstant                    = "migrate"
+	migrateCommandShortDescriptionConstant       = "Migrate repository defaults from main to master"
+	migrateCommandLongDescriptionConstant        = "branch migrate retargets workflows, updates GitHub configuration, and evaluates safety gates before switching the default branch."
+	migrateCommandExecutionErrorTemplateConstant = "branch migration failed: %w"
+	unexpectedArgumentsMessageConstant           = "branch migrate does not accept positional arguments"
+	debugFlagNameConstant                        = "debug"
+	debugFlagDescriptionConstant                 = "Enable verbose debug logging for migration diagnostics"
+	defaultRemoteNameConstant                    = "origin"
+	workflowsDirectoryConstant                   = ".github/workflows"
+	repositoryResolutionErrorTemplateConstant    = "unable to resolve repository identifier: %w"
+	repositoryOwnerRepositoryFormatConstant      = "%s/%s"
+	workingDirectoryResolutionErrorTemplate      = "unable to resolve working directory: %w"
+	repositoryManagerCreationErrorTemplate       = "unable to construct repository manager: %w"
+	githubClientCreationErrorTemplate            = "unable to construct GitHub client: %w"
+	migrationCompletedMessageConstant            = "Branch migration completed"
+	migratedWorkflowFilesFieldConstant           = "migrated_workflows"
+	defaultBranchUpdatedFieldConstant            = "default_branch_updated"
+	pagesConfigurationUpdatedFieldConstant       = "pages_configuration_updated"
+	retargetedPullRequestsFieldConstant          = "retargeted_pull_requests"
+	safeToDeleteFieldConstant                    = "safe_to_delete"
+	safetyGatesBlockingMessageConstant           = "Branch deletion blocked by safety gates"
+	safetyGateReasonsFieldConstant               = "blocking_reasons"
+)
+
+type commandOptions struct {
+	enableDebug bool
+}
+
+// LoggerProvider supplies a zap logger instance.
+type LoggerProvider func() *zap.Logger
+
+// CommandBuilder assembles the Cobra command hierarchy for branch migration.
+type CommandBuilder struct {
+	LoggerProvider   LoggerProvider
+	Executor         CommandExecutor
+	WorkingDirectory string
+}
+
+var errUnexpectedArguments = errors.New(unexpectedArgumentsMessageConstant)
+
+// Build constructs the branch command with the migrate subcommand.
+func (builder *CommandBuilder) Build() (*cobra.Command, error) {
+	branchCommand := &cobra.Command{
+		Use:   branchCommandUseConstant,
+		Short: branchCommandShortDescriptionConstant,
+		Long:  branchCommandLongDescriptionConstant,
+	}
+
+	migrateCommand := &cobra.Command{
+		Use:           migrateCommandUseConstant,
+		Short:         migrateCommandShortDescriptionConstant,
+		Long:          migrateCommandLongDescriptionConstant,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE:          builder.runMigrate,
+	}
+
+	migrateCommand.Flags().Bool(debugFlagNameConstant, false, debugFlagDescriptionConstant)
+
+	branchCommand.AddCommand(migrateCommand)
+
+	return branchCommand, nil
+}
+
+func (builder *CommandBuilder) runMigrate(command *cobra.Command, arguments []string) error {
+	if len(arguments) > 0 {
+		return errUnexpectedArguments
+	}
+
+	options, optionsError := builder.parseOptions(command)
+	if optionsError != nil {
+		return optionsError
+	}
+
+	logger := builder.resolveLogger(options.enableDebug)
+
+	executor, executorError := builder.resolveExecutor(logger)
+	if executorError != nil {
+		return executorError
+	}
+
+	repositoryManager, managerError := gitrepo.NewRepositoryManager(executor)
+	if managerError != nil {
+		return fmt.Errorf(repositoryManagerCreationErrorTemplate, managerError)
+	}
+
+	githubClient, githubClientError := githubcli.NewClient(executor)
+	if githubClientError != nil {
+		return fmt.Errorf(githubClientCreationErrorTemplate, githubClientError)
+	}
+
+	workingDirectory := builder.WorkingDirectory
+	if len(strings.TrimSpace(workingDirectory)) == 0 {
+		resolvedDirectory, directoryError := os.Getwd()
+		if directoryError != nil {
+			return fmt.Errorf(workingDirectoryResolutionErrorTemplate, directoryError)
+		}
+		workingDirectory = resolvedDirectory
+	}
+
+	normalizedWorkingDirectory := filepath.Clean(workingDirectory)
+
+	remoteURL, remoteError := repositoryManager.GetRemoteURL(command.Context(), normalizedWorkingDirectory, defaultRemoteNameConstant)
+	if remoteError != nil {
+		return fmt.Errorf(repositoryResolutionErrorTemplateConstant, remoteError)
+	}
+
+	parsedRemote, parseError := gitrepo.ParseRemoteURL(remoteURL)
+	if parseError != nil {
+		return fmt.Errorf(repositoryResolutionErrorTemplateConstant, parseError)
+	}
+
+	repositoryIdentifier := fmt.Sprintf(repositoryOwnerRepositoryFormatConstant, parsedRemote.Owner, parsedRemote.Repository)
+
+	service, serviceError := NewService(ServiceDependencies{
+		Logger:            logger,
+		RepositoryManager: repositoryManager,
+		GitHubClient:      githubClient,
+		GitExecutor:       executor,
+	})
+	if serviceError != nil {
+		return serviceError
+	}
+
+	migrationOptions := MigrationOptions{
+		RepositoryPath:       normalizedWorkingDirectory,
+		RepositoryRemoteName: defaultRemoteNameConstant,
+		RepositoryIdentifier: repositoryIdentifier,
+		WorkflowsDirectory:   workflowsDirectoryConstant,
+		SourceBranch:         BranchMain,
+		TargetBranch:         BranchMaster,
+		PushUpdates:          true,
+		EnableDebugLogging:   options.enableDebug,
+	}
+
+	result, migrationError := service.Execute(command.Context(), migrationOptions)
+	if migrationError != nil {
+		return fmt.Errorf(migrateCommandExecutionErrorTemplateConstant, migrationError)
+	}
+
+	builder.logSummary(logger, result)
+
+	return nil
+}
+
+func (builder *CommandBuilder) parseOptions(command *cobra.Command) (commandOptions, error) {
+	debugEnabled, _ := command.Flags().GetBool(debugFlagNameConstant)
+	return commandOptions{enableDebug: debugEnabled}, nil
+}
+
+func (builder *CommandBuilder) resolveLogger(enableDebug bool) *zap.Logger {
+	var logger *zap.Logger
+	if builder.LoggerProvider != nil {
+		logger = builder.LoggerProvider()
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if enableDebug {
+		logger = logger.WithOptions(zap.IncreaseLevel(zapcore.DebugLevel))
+	}
+	return logger
+}
+
+func (builder *CommandBuilder) resolveExecutor(logger *zap.Logger) (CommandExecutor, error) {
+	if builder.Executor != nil {
+		return builder.Executor, nil
+	}
+
+	commandRunner := execshell.NewOSCommandRunner()
+	shellExecutor, creationError := execshell.NewShellExecutor(logger, commandRunner)
+	if creationError != nil {
+		return nil, creationError
+	}
+	return shellExecutor, nil
+}
+
+func (builder *CommandBuilder) logSummary(logger *zap.Logger, result MigrationResult) {
+	if logger == nil {
+		return
+	}
+
+	logger.Info(
+		migrationCompletedMessageConstant,
+		zap.Strings(migratedWorkflowFilesFieldConstant, result.WorkflowOutcome.UpdatedFiles),
+		zap.Bool(defaultBranchUpdatedFieldConstant, result.DefaultBranchUpdated),
+		zap.Bool(pagesConfigurationUpdatedFieldConstant, result.PagesConfigurationUpdated),
+		zap.Ints(retargetedPullRequestsFieldConstant, result.RetargetedPullRequests),
+		zap.Bool(safeToDeleteFieldConstant, result.SafetyStatus.SafeToDelete),
+	)
+
+	if !result.SafetyStatus.SafeToDelete {
+		logger.Warn(safetyGatesBlockingMessageConstant, zap.Strings(safetyGateReasonsFieldConstant, result.SafetyStatus.BlockingReasons))
+	}
+}

--- a/internal/migrate/doc.go
+++ b/internal/migrate/doc.go
@@ -1,0 +1,4 @@
+// Package migrate implements the branch migration workflow that aligns repositories
+// to the desired default branch, updates GitHub configuration, and enforces safety
+// checks before destructive actions.
+package migrate

--- a/internal/migrate/pages.go
+++ b/internal/migrate/pages.go
@@ -1,0 +1,80 @@
+package migrate
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/githubcli"
+)
+
+const (
+	pagesUpdateLogMessageConstant      = "Updating GitHub Pages source branch"
+	pagesSkipLogMessageConstant        = "GitHub Pages update not required"
+	pagesSourceBranchFieldNameConstant = "pages_source_branch"
+	pagesTargetBranchFieldNameConstant = "pages_target_branch"
+	pagesSourcePathFieldNameConstant   = "pages_source_path"
+	pagesBuildTypeFieldNameConstant    = "pages_build_type"
+)
+
+// PagesManager coordinates GitHub Pages configuration updates.
+type PagesManager struct {
+	logger       *zap.Logger
+	githubClient GitHubOperations
+}
+
+// NewPagesManager constructs a PagesManager.
+func NewPagesManager(logger *zap.Logger, client GitHubOperations) *PagesManager {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &PagesManager{logger: logger, githubClient: client}
+}
+
+// EnsureLegacyBranch updates Pages configuration when legacy builds target the source branch.
+func (manager *PagesManager) EnsureLegacyBranch(executionContext context.Context, config PagesUpdateConfig) (bool, error) {
+	if manager.githubClient == nil {
+		return false, nil
+	}
+
+	status, statusError := manager.githubClient.GetPagesConfig(executionContext, config.RepositoryIdentifier)
+	if statusError != nil {
+		return false, statusError
+	}
+
+	if !status.Enabled {
+		manager.logger.Debug(pagesSkipLogMessageConstant, zap.String(pagesBuildTypeFieldNameConstant, string(status.BuildType)))
+		return false, nil
+	}
+
+	if status.BuildType != githubcli.PagesBuildTypeLegacy {
+		manager.logger.Debug(pagesSkipLogMessageConstant, zap.String(pagesBuildTypeFieldNameConstant, string(status.BuildType)))
+		return false, nil
+	}
+
+	if status.SourceBranch != string(config.SourceBranch) {
+		manager.logger.Debug(pagesSkipLogMessageConstant, zap.String(pagesSourceBranchFieldNameConstant, status.SourceBranch))
+		return false, nil
+	}
+
+	if status.SourceBranch == string(config.TargetBranch) {
+		manager.logger.Debug(pagesSkipLogMessageConstant, zap.String(pagesSourceBranchFieldNameConstant, status.SourceBranch))
+		return false, nil
+	}
+
+	updateError := manager.githubClient.UpdatePagesConfig(executionContext, config.RepositoryIdentifier, githubcli.PagesConfiguration{
+		SourceBranch: string(config.TargetBranch),
+		SourcePath:   status.SourcePath,
+	})
+	if updateError != nil {
+		return false, updateError
+	}
+
+	manager.logger.Info(pagesUpdateLogMessageConstant,
+		zap.String(pagesSourceBranchFieldNameConstant, status.SourceBranch),
+		zap.String(pagesTargetBranchFieldNameConstant, string(config.TargetBranch)),
+		zap.String(pagesSourcePathFieldNameConstant, status.SourcePath),
+	)
+
+	return true, nil
+}

--- a/internal/migrate/pages_test.go
+++ b/internal/migrate/pages_test.go
@@ -1,0 +1,153 @@
+package migrate_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/githubcli"
+	migrate "github.com/temirov/git_scripts/internal/migrate"
+)
+
+const (
+	pagesSubtestNameTemplateConstant = "%02d_%s"
+	legacyBuildTypeCaseNameConstant  = "legacy_updates"
+	disabledPagesCaseNameConstant    = "disabled"
+	workflowBuildCaseNameConstant    = "workflow_build"
+	branchMismatchCaseNameConstant   = "branch_mismatch"
+	updateFailureCaseNameConstant    = "update_failure"
+	pagesTestRepositoryIdentifier    = "owner/example"
+)
+
+type stubGitHubOperations struct {
+	getPagesFunc    func(context.Context, string) (githubcli.PagesStatus, error)
+	updatePagesFunc func(context.Context, string, githubcli.PagesConfiguration) error
+}
+
+func (stub *stubGitHubOperations) GetPagesConfig(ctx context.Context, repository string) (githubcli.PagesStatus, error) {
+	if stub.getPagesFunc != nil {
+		return stub.getPagesFunc(ctx, repository)
+	}
+	return githubcli.PagesStatus{}, nil
+}
+
+func (stub *stubGitHubOperations) UpdatePagesConfig(ctx context.Context, repository string, configuration githubcli.PagesConfiguration) error {
+	if stub.updatePagesFunc != nil {
+		return stub.updatePagesFunc(ctx, repository, configuration)
+	}
+	return nil
+}
+
+func (stub *stubGitHubOperations) ListPullRequests(context.Context, string, githubcli.PullRequestListOptions) ([]githubcli.PullRequest, error) {
+	return nil, nil
+}
+
+func (stub *stubGitHubOperations) UpdatePullRequestBase(context.Context, string, int, string) error {
+	return nil
+}
+
+func (stub *stubGitHubOperations) SetDefaultBranch(context.Context, string, string) error {
+	return nil
+}
+
+func (stub *stubGitHubOperations) CheckBranchProtection(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func TestPagesManagerScenarios(testInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		status        githubcli.PagesStatus
+		updateError   error
+		expectUpdated bool
+	}{
+		{
+			name: legacyBuildTypeCaseNameConstant,
+			status: githubcli.PagesStatus{
+				Enabled:      true,
+				BuildType:    githubcli.PagesBuildTypeLegacy,
+				SourceBranch: "main",
+				SourcePath:   "/docs",
+			},
+			expectUpdated: true,
+		},
+		{
+			name: disabledPagesCaseNameConstant,
+			status: githubcli.PagesStatus{
+				Enabled: false,
+			},
+			expectUpdated: false,
+		},
+		{
+			name: workflowBuildCaseNameConstant,
+			status: githubcli.PagesStatus{
+				Enabled:      true,
+				BuildType:    githubcli.PagesBuildTypeWorkflow,
+				SourceBranch: "main",
+			},
+			expectUpdated: false,
+		},
+		{
+			name: branchMismatchCaseNameConstant,
+			status: githubcli.PagesStatus{
+				Enabled:      true,
+				BuildType:    githubcli.PagesBuildTypeLegacy,
+				SourceBranch: "develop",
+			},
+			expectUpdated: false,
+		},
+		{
+			name: updateFailureCaseNameConstant,
+			status: githubcli.PagesStatus{
+				Enabled:      true,
+				BuildType:    githubcli.PagesBuildTypeLegacy,
+				SourceBranch: "main",
+			},
+			updateError:   errors.New("update failed"),
+			expectUpdated: false,
+		},
+	}
+
+	for index, testCase := range testCases {
+		testInstance.Run(buildPagesSubtestName(index, testCase.name), func(testInstance *testing.T) {
+			var capturedConfiguration githubcli.PagesConfiguration
+			operationsStub := &stubGitHubOperations{}
+			operationsStub.getPagesFunc = func(_ context.Context, repository string) (githubcli.PagesStatus, error) {
+				_ = repository
+				return testCase.status, nil
+			}
+			operationsStub.updatePagesFunc = func(_ context.Context, repository string, configuration githubcli.PagesConfiguration) error {
+				_ = repository
+				capturedConfiguration = configuration
+				return testCase.updateError
+			}
+
+			manager := migrate.NewPagesManager(zap.NewNop(), operationsStub)
+			updated, executionError := manager.EnsureLegacyBranch(context.Background(), migrate.PagesUpdateConfig{
+				RepositoryIdentifier: pagesTestRepositoryIdentifier,
+				SourceBranch:         migrate.BranchMain,
+				TargetBranch:         migrate.BranchMaster,
+			})
+
+			if testCase.updateError != nil {
+				require.Error(testInstance, executionError)
+				return
+			}
+
+			require.NoError(testInstance, executionError)
+			require.Equal(testInstance, testCase.expectUpdated, updated)
+			if testCase.expectUpdated {
+				require.Equal(testInstance, string(migrate.BranchMaster), capturedConfiguration.SourceBranch)
+				require.Equal(testInstance, testCase.status.SourcePath, capturedConfiguration.SourcePath)
+			}
+		})
+	}
+}
+
+func buildPagesSubtestName(index int, name string) string {
+	return fmt.Sprintf(pagesSubtestNameTemplateConstant, index, name)
+}

--- a/internal/migrate/safety.go
+++ b/internal/migrate/safety.go
@@ -1,0 +1,39 @@
+package migrate
+
+const (
+	safetyReasonOpenPullRequestsConstant = "open pull requests still target source branch"
+	safetyReasonBranchProtectedConstant  = "source branch is protected"
+	safetyReasonWorkflowMentionsConstant = "workflow files still reference source branch"
+)
+
+// SafetyInputs captures conditions that influence branch deletion safety.
+type SafetyInputs struct {
+	OpenPullRequestCount int
+	BranchProtected      bool
+	WorkflowMentions     bool
+}
+
+// SafetyStatus conveys whether it is safe to delete the source branch.
+type SafetyStatus struct {
+	SafeToDelete    bool
+	BlockingReasons []string
+}
+
+// SafetyEvaluator evaluates safety inputs to produce a status.
+type SafetyEvaluator struct{}
+
+// Evaluate determines whether it is safe to delete the source branch.
+func (SafetyEvaluator) Evaluate(inputs SafetyInputs) SafetyStatus {
+	blockingReasons := make([]string, 0, 3)
+	if inputs.OpenPullRequestCount > 0 {
+		blockingReasons = append(blockingReasons, safetyReasonOpenPullRequestsConstant)
+	}
+	if inputs.BranchProtected {
+		blockingReasons = append(blockingReasons, safetyReasonBranchProtectedConstant)
+	}
+	if inputs.WorkflowMentions {
+		blockingReasons = append(blockingReasons, safetyReasonWorkflowMentionsConstant)
+	}
+
+	return SafetyStatus{SafeToDelete: len(blockingReasons) == 0, BlockingReasons: blockingReasons}
+}

--- a/internal/migrate/safety_test.go
+++ b/internal/migrate/safety_test.go
@@ -1,0 +1,81 @@
+package migrate_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	migrate "github.com/temirov/git_scripts/internal/migrate"
+)
+
+const (
+	safetySubtestNameTemplateConstant = "%02d_%s"
+)
+
+func TestSafetyEvaluatorScenarios(testInstance *testing.T) {
+	testCases := []struct {
+		name            string
+		inputs          migrate.SafetyInputs
+		expectedSafe    bool
+		expectedReasons []string
+	}{
+		{
+			name:            "all_clear",
+			inputs:          migrate.SafetyInputs{},
+			expectedSafe:    true,
+			expectedReasons: []string{},
+		},
+		{
+			name: "open_pull_requests",
+			inputs: migrate.SafetyInputs{
+				OpenPullRequestCount: 3,
+			},
+			expectedSafe:    false,
+			expectedReasons: []string{"open pull requests still target source branch"},
+		},
+		{
+			name: "branch_protected",
+			inputs: migrate.SafetyInputs{
+				BranchProtected: true,
+			},
+			expectedSafe:    false,
+			expectedReasons: []string{"source branch is protected"},
+		},
+		{
+			name: "workflow_mentions",
+			inputs: migrate.SafetyInputs{
+				WorkflowMentions: true,
+			},
+			expectedSafe:    false,
+			expectedReasons: []string{"workflow files still reference source branch"},
+		},
+		{
+			name: "multiple_blockers",
+			inputs: migrate.SafetyInputs{
+				OpenPullRequestCount: 1,
+				BranchProtected:      true,
+				WorkflowMentions:     true,
+			},
+			expectedSafe: false,
+			expectedReasons: []string{
+				"open pull requests still target source branch",
+				"source branch is protected",
+				"workflow files still reference source branch",
+			},
+		},
+	}
+
+	evaluator := migrate.SafetyEvaluator{}
+	for index, testCase := range testCases {
+		testInstance.Run(buildSafetySubtestName(index, testCase.name), func(testInstance *testing.T) {
+			status := evaluator.Evaluate(testCase.inputs)
+			require.Equal(testInstance, testCase.expectedSafe, status.SafeToDelete)
+			require.Equal(testInstance, testCase.expectedReasons, status.BlockingReasons)
+		})
+	}
+}
+
+func buildSafetySubtestName(index int, name string) string {
+	return fmt.Sprintf(safetySubtestNameTemplateConstant, index, name)
+}

--- a/internal/migrate/service.go
+++ b/internal/migrate/service.go
@@ -1,0 +1,315 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
+	"github.com/temirov/git_scripts/internal/gitrepo"
+)
+
+const (
+	repositoryPathFieldNameConstant            = "repository_path"
+	remoteNameFieldNameConstant                = "remote_name"
+	repositoryIdentifierFieldNameConstant      = "repository_identifier"
+	workflowsDirectoryFieldNameConstant        = "workflows_directory"
+	sourceBranchFieldNameConstant              = "source_branch"
+	targetBranchFieldNameConstant              = "target_branch"
+	gitAddCommandNameConstant                  = "add"
+	gitAllFlagConstant                         = "-A"
+	gitCommitCommandNameConstant               = "commit"
+	gitMessageFlagConstant                     = "-m"
+	gitPushCommandNameConstant                 = "push"
+	workflowCommitMessageTemplateConstant      = "CI: switch workflow branch filters to %s"
+	cleanWorktreeRequiredMessageConstant       = "repository worktree must be clean before migration"
+	repositoryManagerMissingMessageConstant    = "repository manager not configured"
+	githubClientMissingMessageConstant         = "GitHub client not configured"
+	gitExecutorMissingMessageConstant          = "git executor not configured"
+	workflowRewriteErrorTemplateConstant       = "workflow rewrite failed: %w"
+	workflowStageErrorTemplateConstant         = "unable to stage workflow updates: %w"
+	workflowCommitErrorTemplateConstant        = "unable to commit workflow updates: %w"
+	workflowPushErrorTemplateConstant          = "unable to push workflow updates: %w"
+	pagesUpdateErrorTemplateConstant           = "GitHub Pages update failed: %w"
+	defaultBranchUpdateErrorTemplateConstant   = "unable to update default branch: %w"
+	pullRequestListErrorTemplateConstant       = "unable to list pull requests: %w"
+	pullRequestRetargetErrorTemplateConstant   = "unable to retarget pull request #%d: %w"
+	branchProtectionCheckErrorTemplateConstant = "unable to determine branch protection: %w"
+)
+
+// InvalidInputError describes migration option validation failures.
+type InvalidInputError struct {
+	FieldName string
+	Message   string
+}
+
+// Error describes the invalid input.
+func (inputError InvalidInputError) Error() string {
+	return fmt.Sprintf("%s: %s", inputError.FieldName, inputError.Message)
+}
+
+// ServiceDependencies describes required collaborators for migration.
+type ServiceDependencies struct {
+	Logger            *zap.Logger
+	RepositoryManager *gitrepo.RepositoryManager
+	GitHubClient      GitHubOperations
+	GitExecutor       CommandExecutor
+}
+
+// MigrationOptions configures the migrate workflow.
+type MigrationOptions struct {
+	RepositoryPath       string
+	RepositoryRemoteName string
+	RepositoryIdentifier string
+	WorkflowsDirectory   string
+	SourceBranch         BranchName
+	TargetBranch         BranchName
+	PushUpdates          bool
+	EnableDebugLogging   bool
+}
+
+// WorkflowOutcome captures workflow rewrite results.
+type WorkflowOutcome struct {
+	UpdatedFiles            []string
+	RemainingMainReferences bool
+}
+
+// MigrationResult captures the observable outcomes.
+type MigrationResult struct {
+	WorkflowOutcome           WorkflowOutcome
+	PagesConfigurationUpdated bool
+	DefaultBranchUpdated      bool
+	RetargetedPullRequests    []int
+	SafetyStatus              SafetyStatus
+}
+
+// Service orchestrates the branch migration workflow.
+type Service struct {
+	logger            *zap.Logger
+	repositoryManager *gitrepo.RepositoryManager
+	gitHubClient      GitHubOperations
+	gitExecutor       CommandExecutor
+	workflowRewriter  *WorkflowRewriter
+	pagesManager      *PagesManager
+	safetyEvaluator   SafetyEvaluator
+}
+
+var (
+	errRepositoryManagerMissing = errors.New(repositoryManagerMissingMessageConstant)
+	errGitHubClientMissing      = errors.New(githubClientMissingMessageConstant)
+	errGitExecutorMissing       = errors.New(gitExecutorMissingMessageConstant)
+	errCleanWorktreeRequired    = errors.New(cleanWorktreeRequiredMessageConstant)
+)
+
+// NewService constructs a Service with the provided dependencies.
+func NewService(dependencies ServiceDependencies) (*Service, error) {
+	if dependencies.RepositoryManager == nil {
+		return nil, errRepositoryManagerMissing
+	}
+	if dependencies.GitHubClient == nil {
+		return nil, errGitHubClientMissing
+	}
+	if dependencies.GitExecutor == nil {
+		return nil, errGitExecutorMissing
+	}
+
+	logger := dependencies.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	workflowRewriter := NewWorkflowRewriter(logger)
+	pagesManager := NewPagesManager(logger, dependencies.GitHubClient)
+
+	service := &Service{
+		logger:            logger,
+		repositoryManager: dependencies.RepositoryManager,
+		gitHubClient:      dependencies.GitHubClient,
+		gitExecutor:       dependencies.GitExecutor,
+		workflowRewriter:  workflowRewriter,
+		pagesManager:      pagesManager,
+		safetyEvaluator:   SafetyEvaluator{},
+	}
+
+	return service, nil
+}
+
+// Execute performs the migration workflow.
+func (service *Service) Execute(executionContext context.Context, options MigrationOptions) (MigrationResult, error) {
+	if validationError := service.validateOptions(options); validationError != nil {
+		return MigrationResult{}, validationError
+	}
+
+	cleanWorktree, cleanError := service.repositoryManager.CheckCleanWorktree(executionContext, options.RepositoryPath)
+	if cleanError != nil {
+		return MigrationResult{}, cleanError
+	}
+	if !cleanWorktree {
+		return MigrationResult{}, errCleanWorktreeRequired
+	}
+
+	workflowOutcome, rewriteError := service.workflowRewriter.Rewrite(executionContext, WorkflowRewriteConfig{
+		RepositoryPath:     options.RepositoryPath,
+		WorkflowsDirectory: options.WorkflowsDirectory,
+		SourceBranch:       options.SourceBranch,
+		TargetBranch:       options.TargetBranch,
+	})
+	if rewriteError != nil {
+		return MigrationResult{}, fmt.Errorf(workflowRewriteErrorTemplateConstant, rewriteError)
+	}
+
+	workflowCommitted, workflowCommitError := service.commitWorkflowChanges(executionContext, options, workflowOutcome)
+	if workflowCommitError != nil {
+		return MigrationResult{}, workflowCommitError
+	}
+
+	if workflowCommitted && options.PushUpdates {
+		if pushError := service.pushWorkflowChanges(executionContext, options); pushError != nil {
+			return MigrationResult{}, pushError
+		}
+	}
+
+	pagesUpdated, pagesError := service.pagesManager.EnsureLegacyBranch(executionContext, PagesUpdateConfig{
+		RepositoryIdentifier: options.RepositoryIdentifier,
+		SourceBranch:         options.SourceBranch,
+		TargetBranch:         options.TargetBranch,
+	})
+	if pagesError != nil {
+		return MigrationResult{}, fmt.Errorf(pagesUpdateErrorTemplateConstant, pagesError)
+	}
+
+	if err := service.gitHubClient.SetDefaultBranch(executionContext, options.RepositoryIdentifier, string(options.TargetBranch)); err != nil {
+		return MigrationResult{}, fmt.Errorf(defaultBranchUpdateErrorTemplateConstant, err)
+	}
+
+	pullRequests, listError := service.gitHubClient.ListPullRequests(executionContext, options.RepositoryIdentifier, githubcli.PullRequestListOptions{
+		State:       githubcli.PullRequestStateOpen,
+		BaseBranch:  string(options.SourceBranch),
+		ResultLimit: defaultPullRequestQueryLimit,
+	})
+	if listError != nil {
+		return MigrationResult{}, fmt.Errorf(pullRequestListErrorTemplateConstant, listError)
+	}
+
+	retargeted, retargetError := service.retargetPullRequests(executionContext, options, pullRequests)
+	if retargetError != nil {
+		return MigrationResult{}, retargetError
+	}
+
+	branchProtected, protectionError := service.gitHubClient.CheckBranchProtection(executionContext, options.RepositoryIdentifier, string(options.SourceBranch))
+	if protectionError != nil {
+		return MigrationResult{}, fmt.Errorf(branchProtectionCheckErrorTemplateConstant, protectionError)
+	}
+
+	safetyStatus := service.safetyEvaluator.Evaluate(SafetyInputs{
+		OpenPullRequestCount: len(pullRequests),
+		BranchProtected:      branchProtected,
+		WorkflowMentions:     workflowOutcome.RemainingMainReferences,
+	})
+
+	result := MigrationResult{
+		WorkflowOutcome:           workflowOutcome,
+		PagesConfigurationUpdated: pagesUpdated,
+		DefaultBranchUpdated:      true,
+		RetargetedPullRequests:    retargeted,
+		SafetyStatus:              safetyStatus,
+	}
+
+	return result, nil
+}
+
+func (service *Service) validateOptions(options MigrationOptions) error {
+	if len(strings.TrimSpace(options.RepositoryPath)) == 0 {
+		return InvalidInputError{FieldName: repositoryPathFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+	if len(strings.TrimSpace(options.RepositoryRemoteName)) == 0 {
+		return InvalidInputError{FieldName: remoteNameFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+	if len(strings.TrimSpace(options.RepositoryIdentifier)) == 0 {
+		return InvalidInputError{FieldName: repositoryIdentifierFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+	if len(strings.TrimSpace(options.WorkflowsDirectory)) == 0 {
+		return InvalidInputError{FieldName: workflowsDirectoryFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+	if len(strings.TrimSpace(string(options.SourceBranch))) == 0 {
+		return InvalidInputError{FieldName: sourceBranchFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+	if len(strings.TrimSpace(string(options.TargetBranch))) == 0 {
+		return InvalidInputError{FieldName: targetBranchFieldNameConstant, Message: requiredValueMessageConstant}
+	}
+	return nil
+}
+
+func (service *Service) commitWorkflowChanges(executionContext context.Context, options MigrationOptions, outcome WorkflowOutcome) (bool, error) {
+	if len(outcome.UpdatedFiles) == 0 {
+		return false, nil
+	}
+
+	addArguments := []string{gitAddCommandNameConstant, gitAllFlagConstant, options.WorkflowsDirectory}
+	if _, stageError := service.gitExecutor.ExecuteGit(executionContext, execshell.CommandDetails{
+		Arguments:        addArguments,
+		WorkingDirectory: options.RepositoryPath,
+	}); stageError != nil {
+		return false, fmt.Errorf(workflowStageErrorTemplateConstant, stageError)
+	}
+
+	commitMessage := fmt.Sprintf(workflowCommitMessageTemplateConstant, string(options.TargetBranch))
+	_, commitError := service.gitExecutor.ExecuteGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitCommitCommandNameConstant, gitMessageFlagConstant, commitMessage},
+		WorkingDirectory: options.RepositoryPath,
+	})
+	if commitError != nil {
+		var commandFailure execshell.CommandFailedError
+		if errors.As(commitError, &commandFailure) {
+			service.logger.Info("No workflow changes to commit", zap.String(workflowsDirectoryFieldNameConstant, options.WorkflowsDirectory))
+			return false, nil
+		}
+		return false, fmt.Errorf(workflowCommitErrorTemplateConstant, commitError)
+	}
+
+	return true, nil
+}
+
+func (service *Service) pushWorkflowChanges(executionContext context.Context, options MigrationOptions) error {
+	pushArguments := []string{gitPushCommandNameConstant, options.RepositoryRemoteName, string(options.TargetBranch)}
+	if _, pushError := service.gitExecutor.ExecuteGit(executionContext, execshell.CommandDetails{
+		Arguments:        pushArguments,
+		WorkingDirectory: options.RepositoryPath,
+	}); pushError != nil {
+		return fmt.Errorf(workflowPushErrorTemplateConstant, pushError)
+	}
+	return nil
+}
+
+func (service *Service) retargetPullRequests(executionContext context.Context, options MigrationOptions, pullRequests []githubcli.PullRequest) ([]int, error) {
+	retargeted := make([]int, 0, len(pullRequests))
+	for _, pullRequest := range pullRequests {
+		retargetError := service.gitHubClient.UpdatePullRequestBase(executionContext, options.RepositoryIdentifier, pullRequest.Number, string(options.TargetBranch))
+		if retargetError != nil {
+			return nil, fmt.Errorf(pullRequestRetargetErrorTemplateConstant, pullRequest.Number, retargetError)
+		}
+		retargeted = append(retargeted, pullRequest.Number)
+	}
+	return retargeted, nil
+}
+
+const defaultPullRequestQueryLimit = 100
+
+// WorkflowRewriteConfig describes the workflow rewrite inputs.
+type WorkflowRewriteConfig struct {
+	RepositoryPath     string
+	WorkflowsDirectory string
+	SourceBranch       BranchName
+	TargetBranch       BranchName
+}
+
+// PagesUpdateConfig describes GitHub Pages update inputs.
+type PagesUpdateConfig struct {
+	RepositoryIdentifier string
+	SourceBranch         BranchName
+	TargetBranch         BranchName
+}

--- a/internal/migrate/types.go
+++ b/internal/migrate/types.go
@@ -1,0 +1,37 @@
+package migrate
+
+import (
+	"context"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
+)
+
+const (
+	requiredValueMessageConstant = "value required"
+)
+
+// CommandExecutor coordinates git and GitHub CLI invocations.
+type CommandExecutor interface {
+	ExecuteGit(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error)
+	ExecuteGitHubCLI(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error)
+}
+
+// GitHubOperations exposes the GitHub workflows required for migration.
+type GitHubOperations interface {
+	GetPagesConfig(executionContext context.Context, repository string) (githubcli.PagesStatus, error)
+	UpdatePagesConfig(executionContext context.Context, repository string, configuration githubcli.PagesConfiguration) error
+	ListPullRequests(executionContext context.Context, repository string, options githubcli.PullRequestListOptions) ([]githubcli.PullRequest, error)
+	UpdatePullRequestBase(executionContext context.Context, repository string, pullRequestNumber int, baseBranch string) error
+	SetDefaultBranch(executionContext context.Context, repository string, branchName string) error
+	CheckBranchProtection(executionContext context.Context, repository string, branchName string) (bool, error)
+}
+
+// BranchName describes a git branch identifier.
+type BranchName string
+
+// Supported branch name constants.
+const (
+	BranchMain   BranchName = BranchName("main")
+	BranchMaster BranchName = BranchName("master")
+)

--- a/internal/migrate/workflows.go
+++ b/internal/migrate/workflows.go
@@ -1,0 +1,158 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+const (
+	workflowsDirectoryMissingMessageConstant = "workflows directory not found; skipping rewrite"
+	workflowFileFieldNameConstant            = "workflow_file"
+	workflowsRootFieldNameConstant           = "workflows_root"
+	rewriteLogMessageConstant                = "Rewriting workflow file"
+	skipRewriteLogMessageConstant            = "No rewrites required"
+	rewriteCompletionLogMessageConstant      = "Workflow rewrite completed"
+	mainBranchWordBoundaryTemplateConstant   = `\b%s\b`
+	inlineBranchesPatternTemplateConstant    = `(?m)(\s*branches\s*:\s*\[\s*)(["']?)(%s)(["']?)(\s*\])`
+	listBranchesPatternTemplateConstant      = `(?m)^(\s*-\s*)(["']?)(%s)(["']?)\s*$`
+	yamlExtensionConstant                    = ".yaml"
+	ymlExtensionConstant                     = ".yml"
+	inspectWorkflowsErrorTemplateConstant    = "unable to inspect workflows directory: %w"
+	workflowsNotDirectoryTemplateConstant    = "workflows path is not a directory: %s"
+	readWorkflowErrorTemplateConstant        = "unable to read workflow file %s: %w"
+	statWorkflowErrorTemplateConstant        = "unable to stat workflow file %s: %w"
+	writeWorkflowErrorTemplateConstant       = "unable to write workflow file %s: %w"
+)
+
+// WorkflowRewriter updates GitHub Actions workflows to target the desired branch.
+type WorkflowRewriter struct {
+	logger *zap.Logger
+}
+
+// NewWorkflowRewriter constructs a WorkflowRewriter.
+func NewWorkflowRewriter(logger *zap.Logger) *WorkflowRewriter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &WorkflowRewriter{logger: logger}
+}
+
+// Rewrite applies branch replacements across workflow files.
+func (rewriter *WorkflowRewriter) Rewrite(_ context.Context, config WorkflowRewriteConfig) (WorkflowOutcome, error) {
+	workflowsOutcome := WorkflowOutcome{UpdatedFiles: []string{}, RemainingMainReferences: false}
+
+	workflowsRoot := filepath.Join(config.RepositoryPath, config.WorkflowsDirectory)
+	directoryInfo, statError := os.Stat(workflowsRoot)
+	if statError != nil {
+		if errors.Is(statError, fs.ErrNotExist) {
+			rewriter.logger.Info(workflowsDirectoryMissingMessageConstant, zap.String(workflowsRootFieldNameConstant, workflowsRoot))
+			return workflowsOutcome, nil
+		}
+		return WorkflowOutcome{}, fmt.Errorf(inspectWorkflowsErrorTemplateConstant, statError)
+	}
+
+	if !directoryInfo.IsDir() {
+		return WorkflowOutcome{}, fmt.Errorf(workflowsNotDirectoryTemplateConstant, workflowsRoot)
+	}
+
+	sourceBranch := string(config.SourceBranch)
+	targetBranch := string(config.TargetBranch)
+
+	inlinePattern := regexp.MustCompile(fmt.Sprintf(inlineBranchesPatternTemplateConstant, regexp.QuoteMeta(sourceBranch)))
+	listPattern := regexp.MustCompile(fmt.Sprintf(listBranchesPatternTemplateConstant, regexp.QuoteMeta(sourceBranch)))
+	wordPattern := regexp.MustCompile(fmt.Sprintf(mainBranchWordBoundaryTemplateConstant, regexp.QuoteMeta(sourceBranch)))
+
+	walkError := filepath.WalkDir(workflowsRoot, func(path string, directoryEntry fs.DirEntry, walkError error) error {
+		if walkError != nil {
+			return walkError
+		}
+		if directoryEntry.IsDir() {
+			return nil
+		}
+		if !isWorkflowFile(path) {
+			return nil
+		}
+
+		fileOutcome, processingError := rewriter.processWorkflowFile(path, inlinePattern, listPattern, wordPattern, targetBranch)
+		if processingError != nil {
+			return processingError
+		}
+
+		if fileOutcome.updated {
+			relativePath, relativeError := filepath.Rel(config.RepositoryPath, path)
+			if relativeError != nil {
+				relativePath = path
+			}
+			workflowsOutcome.UpdatedFiles = append(workflowsOutcome.UpdatedFiles, relativePath)
+		}
+
+		if fileOutcome.containsSource {
+			workflowsOutcome.RemainingMainReferences = true
+		}
+
+		return nil
+	})
+
+	if walkError != nil {
+		return WorkflowOutcome{}, walkError
+	}
+
+	rewriter.logger.Info(rewriteCompletionLogMessageConstant,
+		zap.String(workflowsRootFieldNameConstant, workflowsRoot),
+		zap.Strings(migratedWorkflowFilesFieldConstant, workflowsOutcome.UpdatedFiles),
+	)
+
+	return workflowsOutcome, nil
+}
+
+type workflowFileOutcome struct {
+	updated        bool
+	containsSource bool
+}
+
+func (rewriter *WorkflowRewriter) processWorkflowFile(filePath string, inlinePattern *regexp.Regexp, listPattern *regexp.Regexp, wordPattern *regexp.Regexp, targetBranch string) (workflowFileOutcome, error) {
+	fileContent, readError := os.ReadFile(filePath)
+	if readError != nil {
+		return workflowFileOutcome{}, fmt.Errorf(readWorkflowErrorTemplateConstant, filePath, readError)
+	}
+
+	inlineReplacement := fmt.Sprintf("${1}${2}%s${4}${5}", targetBranch)
+	listReplacement := fmt.Sprintf("${1}${2}%s${4}", targetBranch)
+	updatedContent := inlinePattern.ReplaceAllString(string(fileContent), inlineReplacement)
+	updatedContent = listPattern.ReplaceAllString(updatedContent, listReplacement)
+
+	containsSource := wordPattern.MatchString(updatedContent)
+	updated := updatedContent != string(fileContent)
+
+	if !updated {
+		rewriter.logger.Debug(skipRewriteLogMessageConstant, zap.String(workflowFileFieldNameConstant, filePath))
+		return workflowFileOutcome{updated: false, containsSource: containsSource}, nil
+	}
+
+	fileInfo, infoError := os.Stat(filePath)
+	if infoError != nil {
+		return workflowFileOutcome{}, fmt.Errorf(statWorkflowErrorTemplateConstant, filePath, infoError)
+	}
+
+	writeError := os.WriteFile(filePath, []byte(updatedContent), fileInfo.Mode().Perm())
+	if writeError != nil {
+		return workflowFileOutcome{}, fmt.Errorf(writeWorkflowErrorTemplateConstant, filePath, writeError)
+	}
+
+	rewriter.logger.Info(rewriteLogMessageConstant, zap.String(workflowFileFieldNameConstant, filePath))
+
+	return workflowFileOutcome{updated: true, containsSource: containsSource}, nil
+}
+
+func isWorkflowFile(path string) bool {
+	lowerPath := strings.ToLower(path)
+	return strings.HasSuffix(lowerPath, yamlExtensionConstant) || strings.HasSuffix(lowerPath, ymlExtensionConstant)
+}

--- a/internal/migrate/workflows_test.go
+++ b/internal/migrate/workflows_test.go
@@ -1,0 +1,115 @@
+package migrate_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	migrate "github.com/temirov/git_scripts/internal/migrate"
+)
+
+const (
+	testRepositoryRelativeWorkflowsConstant = ".github/workflows"
+	testWorkflowFileNameConstant            = "ci.yml"
+	testInlineWorkflowContentConstant       = "on: { push: { branches: [main] } }\n"
+	testListWorkflowContentConstant         = "on:\n  push:\n    branches:\n      - main\n"
+	testNoRewriteWorkflowContentConstant    = "name: build\n"
+	testCommentWorkflowContentConstant      = "# run on main branch\n"
+)
+
+func TestWorkflowRewriterScenarios(testInstance *testing.T) {
+	testCases := []struct {
+		name            string
+		initialContent  string
+		expectedContent string
+		expectRewrite   bool
+		expectMentions  bool
+	}{
+		{
+			name:            "inline_branches",
+			initialContent:  testInlineWorkflowContentConstant,
+			expectedContent: "on: { push: { branches: [master] } }\n",
+			expectRewrite:   true,
+			expectMentions:  false,
+		},
+		{
+			name:            "list_item",
+			initialContent:  testListWorkflowContentConstant,
+			expectedContent: "on:\n  push:\n    branches:\n      - master\n",
+			expectRewrite:   true,
+			expectMentions:  false,
+		},
+		{
+			name:            "no_rewrite_needed",
+			initialContent:  testNoRewriteWorkflowContentConstant,
+			expectedContent: testNoRewriteWorkflowContentConstant,
+			expectRewrite:   false,
+			expectMentions:  false,
+		},
+		{
+			name:            "leftover_mentions",
+			initialContent:  testCommentWorkflowContentConstant,
+			expectedContent: testCommentWorkflowContentConstant,
+			expectRewrite:   false,
+			expectMentions:  true,
+		},
+	}
+
+	for index, testCase := range testCases {
+		testInstance.Run(buildWorkflowSubtestName(index, testCase.name), func(testInstance *testing.T) {
+			repositoryDirectory := testInstance.TempDir()
+			workflowsDirectory := filepath.Join(repositoryDirectory, testRepositoryRelativeWorkflowsConstant)
+			creationError := os.MkdirAll(workflowsDirectory, 0o755)
+			require.NoError(testInstance, creationError)
+
+			workflowPath := filepath.Join(workflowsDirectory, testWorkflowFileNameConstant)
+			writeError := os.WriteFile(workflowPath, []byte(testCase.initialContent), 0o644)
+			require.NoError(testInstance, writeError)
+
+			rewriter := migrate.NewWorkflowRewriter(zap.NewNop())
+			outcome, rewriteError := rewriter.Rewrite(context.Background(), migrate.WorkflowRewriteConfig{
+				RepositoryPath:     repositoryDirectory,
+				WorkflowsDirectory: testRepositoryRelativeWorkflowsConstant,
+				SourceBranch:       migrate.BranchMain,
+				TargetBranch:       migrate.BranchMaster,
+			})
+			require.NoError(testInstance, rewriteError)
+
+			fileBytes, readError := os.ReadFile(workflowPath)
+			require.NoError(testInstance, readError)
+			actualContent := strings.TrimSpace(string(fileBytes))
+			expectedContent := strings.TrimSpace(testCase.expectedContent)
+			require.Equal(testInstance, expectedContent, actualContent)
+
+			if testCase.expectRewrite {
+				require.Len(testInstance, outcome.UpdatedFiles, 1)
+			} else {
+				require.Len(testInstance, outcome.UpdatedFiles, 0)
+			}
+			require.Equal(testInstance, testCase.expectMentions, outcome.RemainingMainReferences)
+		})
+	}
+}
+
+func TestWorkflowRewriterMissingDirectory(testInstance *testing.T) {
+	rewriter := migrate.NewWorkflowRewriter(zap.NewNop())
+	outcome, rewriteError := rewriter.Rewrite(context.Background(), migrate.WorkflowRewriteConfig{
+		RepositoryPath:     testInstance.TempDir(),
+		WorkflowsDirectory: testRepositoryRelativeWorkflowsConstant,
+		SourceBranch:       migrate.BranchMain,
+		TargetBranch:       migrate.BranchMaster,
+	})
+	require.NoError(testInstance, rewriteError)
+	require.Empty(testInstance, outcome.UpdatedFiles)
+	require.False(testInstance, outcome.RemainingMainReferences)
+}
+
+func buildWorkflowSubtestName(index int, name string) string {
+	return fmt.Sprintf("%02d_%s", index, name)
+}

--- a/tests/migrate_integration_test.go
+++ b/tests/migrate_integration_test.go
@@ -1,0 +1,167 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
+	"github.com/temirov/git_scripts/internal/gitrepo"
+	migrate "github.com/temirov/git_scripts/internal/migrate"
+)
+
+const (
+	integrationRepositoryIdentifierConstant  = "integration/test"
+	integrationRemoteURLConstant             = "git@github.com:integration/test.git"
+	integrationWorkflowDirectoryConstant     = ".github/workflows"
+	integrationWorkflowFileNameConstant      = "ci.yml"
+	integrationWorkflowInitialContent        = "on:\n  push:\n    branches:\n      - main\n"
+	integrationWorkflowCommitMessageConstant = "CI: switch workflow branch filters to master"
+)
+
+type recordingGitHubOperations struct {
+	pagesStatus             githubcli.PagesStatus
+	updatedPagesConfig      *githubcli.PagesConfiguration
+	defaultBranchTarget     string
+	pullRequests            []githubcli.PullRequest
+	retargetedPullRequests  []int
+	branchProtectionEnabled bool
+}
+
+func (operations *recordingGitHubOperations) GetPagesConfig(_ context.Context, repository string) (githubcli.PagesStatus, error) {
+	_ = repository
+	return operations.pagesStatus, nil
+}
+
+func (operations *recordingGitHubOperations) UpdatePagesConfig(_ context.Context, repository string, configuration githubcli.PagesConfiguration) error {
+	_ = repository
+	operations.updatedPagesConfig = &configuration
+	return nil
+}
+
+func (operations *recordingGitHubOperations) ListPullRequests(_ context.Context, repository string, options githubcli.PullRequestListOptions) ([]githubcli.PullRequest, error) {
+	_ = repository
+	_ = options
+	return operations.pullRequests, nil
+}
+
+func (operations *recordingGitHubOperations) UpdatePullRequestBase(_ context.Context, repository string, pullRequestNumber int, baseBranch string) error {
+	_ = repository
+	_ = baseBranch
+	operations.retargetedPullRequests = append(operations.retargetedPullRequests, pullRequestNumber)
+	return nil
+}
+
+func (operations *recordingGitHubOperations) SetDefaultBranch(_ context.Context, repository string, branchName string) error {
+	_ = repository
+	operations.defaultBranchTarget = branchName
+	return nil
+}
+
+func (operations *recordingGitHubOperations) CheckBranchProtection(_ context.Context, repository string, branchName string) (bool, error) {
+	_ = repository
+	_ = branchName
+	return operations.branchProtectionEnabled, nil
+}
+
+func TestMigrationIntegration(testInstance *testing.T) {
+	repositoryDirectory := testInstance.TempDir()
+
+	runMigrationGitCommand(testInstance, repositoryDirectory, "init")
+	runMigrationGitCommand(testInstance, repositoryDirectory, "config", "user.name", "Integration User")
+	runMigrationGitCommand(testInstance, repositoryDirectory, "config", "user.email", "integration@example.com")
+	runMigrationGitCommand(testInstance, repositoryDirectory, "checkout", "-b", "main")
+
+	readmePath := filepath.Join(repositoryDirectory, "README.md")
+	require.NoError(testInstance, os.WriteFile(readmePath, []byte("hello\n"), 0o644))
+	runMigrationGitCommand(testInstance, repositoryDirectory, "add", "README.md")
+	runMigrationGitCommand(testInstance, repositoryDirectory, "commit", "-m", "initial commit")
+
+	runMigrationGitCommand(testInstance, repositoryDirectory, "remote", "add", "origin", integrationRemoteURLConstant)
+	runMigrationGitCommand(testInstance, repositoryDirectory, "branch", "master")
+	runMigrationGitCommand(testInstance, repositoryDirectory, "checkout", "master")
+
+	workflowsDirectory := filepath.Join(repositoryDirectory, integrationWorkflowDirectoryConstant)
+	require.NoError(testInstance, os.MkdirAll(workflowsDirectory, 0o755))
+	workflowPath := filepath.Join(workflowsDirectory, integrationWorkflowFileNameConstant)
+	require.NoError(testInstance, os.WriteFile(workflowPath, []byte(integrationWorkflowInitialContent), 0o644))
+	runMigrationGitCommand(testInstance, repositoryDirectory, "add", integrationWorkflowDirectoryConstant)
+	runMigrationGitCommand(testInstance, repositoryDirectory, "commit", "-m", "add workflow")
+
+	logger := zap.NewNop()
+	commandRunner := execshell.NewOSCommandRunner()
+	executor, creationError := execshell.NewShellExecutor(logger, commandRunner)
+	require.NoError(testInstance, creationError)
+	repositoryManager, managerError := gitrepo.NewRepositoryManager(executor)
+	require.NoError(testInstance, managerError)
+
+	githubOperations := &recordingGitHubOperations{
+		pagesStatus: githubcli.PagesStatus{
+			Enabled:      true,
+			BuildType:    githubcli.PagesBuildTypeLegacy,
+			SourceBranch: "main",
+			SourcePath:   "/docs",
+		},
+		pullRequests: []githubcli.PullRequest{{Number: 12}},
+	}
+
+	service, serviceError := migrate.NewService(migrate.ServiceDependencies{
+		Logger:            logger,
+		RepositoryManager: repositoryManager,
+		GitHubClient:      githubOperations,
+		GitExecutor:       executor,
+	})
+	require.NoError(testInstance, serviceError)
+
+	options := migrate.MigrationOptions{
+		RepositoryPath:       repositoryDirectory,
+		RepositoryRemoteName: "origin",
+		RepositoryIdentifier: integrationRepositoryIdentifierConstant,
+		WorkflowsDirectory:   integrationWorkflowDirectoryConstant,
+		SourceBranch:         migrate.BranchMain,
+		TargetBranch:         migrate.BranchMaster,
+		PushUpdates:          false,
+	}
+
+	result, migrationError := service.Execute(context.Background(), options)
+	require.NoError(testInstance, migrationError)
+
+	require.Len(testInstance, result.WorkflowOutcome.UpdatedFiles, 1)
+	require.Contains(testInstance, result.WorkflowOutcome.UpdatedFiles[0], integrationWorkflowFileNameConstant)
+	require.True(testInstance, result.PagesConfigurationUpdated)
+	require.True(testInstance, result.DefaultBranchUpdated)
+	require.ElementsMatch(testInstance, []int{12}, result.RetargetedPullRequests)
+	require.False(testInstance, result.SafetyStatus.SafeToDelete)
+	require.Contains(testInstance, result.SafetyStatus.BlockingReasons, "open pull requests still target source branch")
+
+	contentBytes, readError := os.ReadFile(workflowPath)
+	require.NoError(testInstance, readError)
+	require.Contains(testInstance, string(contentBytes), "- master")
+
+	logOutput := runMigrationGitCommand(testInstance, repositoryDirectory, "log", "-1", "--pretty=%s")
+	require.Equal(testInstance, integrationWorkflowCommitMessageConstant, logOutput)
+
+	statusOutput := runMigrationGitCommand(testInstance, repositoryDirectory, "status", "--porcelain")
+	require.Equal(testInstance, "", statusOutput)
+
+	require.NotNil(testInstance, githubOperations.updatedPagesConfig)
+	require.Equal(testInstance, string(migrate.BranchMaster), githubOperations.updatedPagesConfig.SourceBranch)
+	require.Equal(testInstance, []int{12}, githubOperations.retargetedPullRequests)
+	require.Equal(testInstance, string(migrate.BranchMaster), githubOperations.defaultBranchTarget)
+}
+
+func runMigrationGitCommand(testInstance *testing.T, repositoryPath string, arguments ...string) string {
+	testInstance.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = repositoryPath
+	outputBytes, commandError := command.CombinedOutput()
+	require.NoError(testInstance, commandError, string(outputBytes))
+	return string(bytes.TrimSpace(outputBytes))
+}


### PR DESCRIPTION
## Summary
- add a `branch migrate` Cobra command that wires the new migration workflow into the CLI
- implement the internal/migrate package to rewrite workflows, update GitHub Pages/default branch, retarget PRs, and enforce safety gates using shared helpers
- extend the GitHub client plus add unit and integration tests covering workflow rewrites, pages updates, safety checks, and the end-to-end migration flow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1f2f9c1a88327bf84488cd7e62a79