### PR TITLE
Add GHCR packages purge command

### DIFF
--- a/internal/ghcr/doc.go
+++ b/internal/ghcr/doc.go
@@ -1,0 +1,2 @@
+// Package ghcr provides helpers for interacting with the GitHub Container Registry REST API.
+package ghcr

--- a/internal/ghcr/owner_type.go
+++ b/internal/ghcr/owner_type.go
@@ -1,0 +1,52 @@
+package ghcr
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ownerTypeUserConstant              OwnerType = "user"
+	ownerTypeOrganizationConstant      OwnerType = "org"
+	usersPathSegmentConstant                     = "users"
+	organizationsPathSegmentConstant             = "orgs"
+	ownerTypeEmptyErrorMessageConstant           = "owner type must be provided"
+	ownerTypeInvalidTemplateConstant             = "owner type %q is not supported"
+)
+
+// OwnerType enumerates supported GHCR owner scopes.
+type OwnerType string
+
+// UserOwnerType identifies GitHub user-owned container packages.
+const UserOwnerType OwnerType = ownerTypeUserConstant
+
+// OrganizationOwnerType identifies organization-owned container packages.
+const OrganizationOwnerType OwnerType = ownerTypeOrganizationConstant
+
+// ParseOwnerType normalizes textual owner type values.
+func ParseOwnerType(ownerTypeValue string) (OwnerType, error) {
+	trimmedValue := strings.TrimSpace(ownerTypeValue)
+	if len(trimmedValue) == 0 {
+		return "", fmt.Errorf(ownerTypeEmptyErrorMessageConstant)
+	}
+
+	lowerCasedValue := strings.ToLower(trimmedValue)
+	switch OwnerType(lowerCasedValue) {
+	case UserOwnerType:
+		return UserOwnerType, nil
+	case OrganizationOwnerType:
+		return OrganizationOwnerType, nil
+	default:
+		return "", fmt.Errorf(ownerTypeInvalidTemplateConstant, ownerTypeValue)
+	}
+}
+
+// PathSegment resolves the REST API segment for the owner type.
+func (ownerType OwnerType) PathSegment() string {
+	switch ownerType {
+	case OrganizationOwnerType:
+		return organizationsPathSegmentConstant
+	default:
+		return usersPathSegmentConstant
+	}
+}

--- a/internal/ghcr/owner_type_test.go
+++ b/internal/ghcr/owner_type_test.go
@@ -1,0 +1,71 @@
+package ghcr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/internal/ghcr"
+)
+
+func TestParseOwnerTypeScenarios(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	testCases := []struct {
+		name                string
+		inputValue          string
+		expectedOwnerType   ghcr.OwnerType
+		expectError         bool
+		expectedPathSegment string
+	}{
+		{
+			name:                "user_owner_type",
+			inputValue:          "user",
+			expectedOwnerType:   ghcr.UserOwnerType,
+			expectError:         false,
+			expectedPathSegment: "users",
+		},
+		{
+			name:                "organization_owner_type",
+			inputValue:          "org",
+			expectedOwnerType:   ghcr.OrganizationOwnerType,
+			expectError:         false,
+			expectedPathSegment: "orgs",
+		},
+		{
+			name:                "trims_whitespace_and_lowercases",
+			inputValue:          " USER ",
+			expectedOwnerType:   ghcr.UserOwnerType,
+			expectError:         false,
+			expectedPathSegment: "users",
+		},
+		{
+			name:        "empty_value_returns_error",
+			inputValue:  " ",
+			expectError: true,
+		},
+		{
+			name:        "invalid_value_returns_error",
+			inputValue:  "team",
+			expectError: true,
+		},
+	}
+
+	for testCaseIndex := range testCases {
+		testCase := testCases[testCaseIndex]
+
+		testingInstance.Run(testCase.name, func(testingSubInstance *testing.T) {
+			testingSubInstance.Parallel()
+
+			ownerType, parseError := ghcr.ParseOwnerType(testCase.inputValue)
+			if testCase.expectError {
+				require.Error(testingSubInstance, parseError)
+				return
+			}
+
+			require.NoError(testingSubInstance, parseError)
+			require.Equal(testingSubInstance, testCase.expectedOwnerType, ownerType)
+			require.Equal(testingSubInstance, testCase.expectedPathSegment, ownerType.PathSegment())
+		})
+	}
+}

--- a/internal/ghcr/service.go
+++ b/internal/ghcr/service.go
@@ -1,0 +1,361 @@
+package ghcr
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+const (
+	defaultBaseURLConstant                       = "https://api.github.com"
+	acceptHeaderNameConstant                     = "Accept"
+	acceptHeaderValueConstant                    = "application/vnd.github+json"
+	authorizationHeaderNameConstant              = "Authorization"
+	bearerTokenTemplateConstant                  = "Bearer %s"
+	perPageQueryParameterNameConstant            = "per_page"
+	pageQueryParameterNameConstant               = "page"
+	defaultPageSizeConstant                      = 100
+	packagesPathSegmentConstant                  = "packages"
+	containerPathSegmentConstant                 = "container"
+	versionsPathSegmentConstant                  = "versions"
+	requestCreationErrorTemplateConstant         = "unable to create %s request for %s: %w"
+	requestExecutionErrorTemplateConstant        = "request execution failed: %w"
+	unexpectedStatusCodeWithBodyTemplateConstant = "unexpected status code %d for %s %s: %s"
+	responseDecodeErrorTemplateConstant          = "unable to decode package versions: %w"
+	deletionFailureTemplateConstant              = "failed to delete version %d: %s"
+	purgeStartMessageConstant                    = "Starting GHCR untagged version purge"
+	purgePageMessageConstant                     = "Fetched GHCR package versions page"
+	purgeDeleteMessageConstant                   = "Deleting untagged GHCR package version"
+	purgeDryRunSkipMessageConstant               = "Skipping deletion during dry run"
+	purgeCompleteMessageConstant                 = "Completed GHCR untagged version purge"
+	ownerLogFieldNameConstant                    = "owner"
+	packageLogFieldNameConstant                  = "package"
+	ownerTypeLogFieldNameConstant                = "owner_type"
+	dryRunLogFieldNameConstant                   = "dry_run"
+	pageLogFieldNameConstant                     = "page_number"
+	pageSizeLogFieldNameConstant                 = "page_size"
+	versionIdentifierLogFieldNameConstant        = "version_id"
+	totalVersionsLogFieldNameConstant            = "total_versions"
+	untaggedVersionsLogFieldNameConstant         = "untagged_versions"
+	deletedVersionsLogFieldNameConstant          = "deleted_versions"
+	tokenMissingErrorMessageConstant             = "authentication token must be provided"
+	ownerMissingErrorMessageConstant             = "owner must be provided"
+	packageMissingErrorMessageConstant           = "package name must be provided"
+	ownerTypeMissingErrorMessageConstant         = "owner type must be provided"
+)
+
+var deleteSuccessStatusCodes = map[int]struct{}{
+	http.StatusNoContent: {},
+	http.StatusAccepted:  {},
+}
+
+// HTTPClient abstracts the Do method of http.Client for easier testing.
+type HTTPClient interface {
+	Do(request *http.Request) (*http.Response, error)
+}
+
+// ServiceConfiguration specifies HTTP behavior for the GHCR client.
+type ServiceConfiguration struct {
+	BaseURL  string
+	PageSize int
+}
+
+// PurgeRequest captures the information required to delete untagged versions.
+type PurgeRequest struct {
+	Owner       string
+	PackageName string
+	OwnerType   OwnerType
+	Token       string
+	DryRun      bool
+}
+
+// PurgeResult contains summary statistics from a purge operation.
+type PurgeResult struct {
+	TotalVersions    int
+	UntaggedVersions int
+	DeletedVersions  int
+}
+
+// PackageVersionService interacts with the GHCR REST API.
+type PackageVersionService struct {
+	logger     *zap.Logger
+	httpClient HTTPClient
+	baseURL    string
+	pageSize   int
+}
+
+// NewPackageVersionService constructs a service with sane defaults.
+func NewPackageVersionService(logger *zap.Logger, httpClient HTTPClient, configuration ServiceConfiguration) (*PackageVersionService, error) {
+	resolvedLogger := logger
+	if resolvedLogger == nil {
+		resolvedLogger = zap.NewNop()
+	}
+
+	resolvedClient := httpClient
+	if resolvedClient == nil {
+		resolvedClient = http.DefaultClient
+	}
+
+	resolvedBaseURL := strings.TrimSpace(configuration.BaseURL)
+	if len(resolvedBaseURL) == 0 {
+		resolvedBaseURL = defaultBaseURLConstant
+	}
+
+	resolvedPageSize := configuration.PageSize
+	if resolvedPageSize <= 0 {
+		resolvedPageSize = defaultPageSizeConstant
+	}
+
+	return &PackageVersionService{
+		logger:     resolvedLogger,
+		httpClient: resolvedClient,
+		baseURL:    resolvedBaseURL,
+		pageSize:   resolvedPageSize,
+	}, nil
+}
+
+// PurgeUntaggedVersions removes untagged container versions and returns summary counts.
+func (service *PackageVersionService) PurgeUntaggedVersions(executionContext context.Context, request PurgeRequest) (PurgeResult, error) {
+	trimmedToken := strings.TrimSpace(request.Token)
+	if len(trimmedToken) == 0 {
+		return PurgeResult{}, errors.New(tokenMissingErrorMessageConstant)
+	}
+	trimmedOwner := strings.TrimSpace(request.Owner)
+	if len(trimmedOwner) == 0 {
+		return PurgeResult{}, errors.New(ownerMissingErrorMessageConstant)
+	}
+	trimmedPackageName := strings.TrimSpace(request.PackageName)
+	if len(trimmedPackageName) == 0 {
+		return PurgeResult{}, errors.New(packageMissingErrorMessageConstant)
+	}
+	if len(strings.TrimSpace(string(request.OwnerType))) == 0 {
+		return PurgeResult{}, errors.New(ownerTypeMissingErrorMessageConstant)
+	}
+
+	request.Token = trimmedToken
+	request.Owner = trimmedOwner
+	request.PackageName = trimmedPackageName
+
+	service.logger.Info(
+		purgeStartMessageConstant,
+		zap.String(ownerLogFieldNameConstant, trimmedOwner),
+		zap.String(packageLogFieldNameConstant, trimmedPackageName),
+		zap.String(ownerTypeLogFieldNameConstant, string(request.OwnerType)),
+		zap.Bool(dryRunLogFieldNameConstant, request.DryRun),
+		zap.Int(pageSizeLogFieldNameConstant, service.pageSize),
+	)
+
+	result := PurgeResult{}
+	pageNumber := 1
+	for {
+		versions, fetchError := service.fetchPage(executionContext, request, pageNumber)
+		if fetchError != nil {
+			return result, fetchError
+		}
+
+		versionCount := len(versions)
+		if versionCount == 0 {
+			break
+		}
+
+		service.logger.Debug(
+			purgePageMessageConstant,
+			zap.String(ownerLogFieldNameConstant, trimmedOwner),
+			zap.String(packageLogFieldNameConstant, trimmedPackageName),
+			zap.Int(pageLogFieldNameConstant, pageNumber),
+			zap.Int(totalVersionsLogFieldNameConstant, versionCount),
+		)
+
+		result.TotalVersions += versionCount
+
+		for versionIndex := range versions {
+			version := versions[versionIndex]
+			if version.HasTags() {
+				continue
+			}
+
+			result.UntaggedVersions++
+			service.logger.Info(
+				purgeDeleteMessageConstant,
+				zap.Int64(versionIdentifierLogFieldNameConstant, version.ID),
+				zap.Bool(dryRunLogFieldNameConstant, request.DryRun),
+			)
+
+			if request.DryRun {
+				service.logger.Debug(
+					purgeDryRunSkipMessageConstant,
+					zap.Int64(versionIdentifierLogFieldNameConstant, version.ID),
+				)
+				continue
+			}
+
+			deleteError := service.deleteVersion(executionContext, request, version.ID)
+			if deleteError != nil {
+				return result, deleteError
+			}
+			result.DeletedVersions++
+		}
+
+		pageNumber++
+	}
+
+	service.logger.Info(
+		purgeCompleteMessageConstant,
+		zap.String(ownerLogFieldNameConstant, trimmedOwner),
+		zap.String(packageLogFieldNameConstant, trimmedPackageName),
+		zap.Int(totalVersionsLogFieldNameConstant, result.TotalVersions),
+		zap.Int(untaggedVersionsLogFieldNameConstant, result.UntaggedVersions),
+		zap.Int(deletedVersionsLogFieldNameConstant, result.DeletedVersions),
+	)
+
+	return result, nil
+}
+
+func (service *PackageVersionService) fetchPage(executionContext context.Context, request PurgeRequest, pageNumber int) ([]packageVersion, error) {
+	versionsURL, urlBuildError := service.buildVersionsURL(request.OwnerType, request.Owner, request.PackageName, pageNumber)
+	if urlBuildError != nil {
+		return nil, urlBuildError
+	}
+
+	httpRequest, requestCreationError := http.NewRequestWithContext(executionContext, http.MethodGet, versionsURL, nil)
+	if requestCreationError != nil {
+		return nil, fmt.Errorf(requestCreationErrorTemplateConstant, http.MethodGet, versionsURL, requestCreationError)
+	}
+
+	httpRequest.Header.Set(acceptHeaderNameConstant, acceptHeaderValueConstant)
+	httpRequest.Header.Set(authorizationHeaderNameConstant, fmt.Sprintf(bearerTokenTemplateConstant, request.Token))
+
+	httpResponse, requestError := service.httpClient.Do(httpRequest)
+	if requestError != nil {
+		return nil, fmt.Errorf(requestExecutionErrorTemplateConstant, requestError)
+	}
+	defer httpResponse.Body.Close()
+
+	if httpResponse.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(httpResponse.Body)
+		return nil, fmt.Errorf(
+			unexpectedStatusCodeWithBodyTemplateConstant,
+			httpResponse.StatusCode,
+			http.MethodGet,
+			versionsURL,
+			strings.TrimSpace(string(responseBody)),
+		)
+	}
+
+	var versions []packageVersion
+	decodeError := json.NewDecoder(httpResponse.Body).Decode(&versions)
+	if decodeError != nil {
+		return nil, fmt.Errorf(responseDecodeErrorTemplateConstant, decodeError)
+	}
+
+	return versions, nil
+}
+
+func (service *PackageVersionService) deleteVersion(executionContext context.Context, request PurgeRequest, versionID int64) error {
+	deleteURL, urlBuildError := service.buildVersionURL(request.OwnerType, request.Owner, request.PackageName, versionID)
+	if urlBuildError != nil {
+		return urlBuildError
+	}
+
+	deleteRequest, deleteRequestCreationError := http.NewRequestWithContext(executionContext, http.MethodDelete, deleteURL, nil)
+	if deleteRequestCreationError != nil {
+		return fmt.Errorf(requestCreationErrorTemplateConstant, http.MethodDelete, deleteURL, deleteRequestCreationError)
+	}
+
+	deleteRequest.Header.Set(acceptHeaderNameConstant, acceptHeaderValueConstant)
+	deleteRequest.Header.Set(authorizationHeaderNameConstant, fmt.Sprintf(bearerTokenTemplateConstant, request.Token))
+
+	deleteResponse, deleteError := service.httpClient.Do(deleteRequest)
+	if deleteError != nil {
+		return fmt.Errorf(requestExecutionErrorTemplateConstant, deleteError)
+	}
+	defer deleteResponse.Body.Close()
+
+	if _, ok := deleteSuccessStatusCodes[deleteResponse.StatusCode]; !ok {
+		responseBody, _ := io.ReadAll(deleteResponse.Body)
+		return fmt.Errorf(deletionFailureTemplateConstant, versionID, strings.TrimSpace(string(responseBody)))
+	}
+
+	return nil
+}
+
+func (service *PackageVersionService) buildVersionsURL(ownerType OwnerType, owner string, packageName string, pageNumber int) (string, error) {
+	baseURL, parseError := url.Parse(service.baseURL)
+	if parseError != nil {
+		return "", parseError
+	}
+
+	baseURL.Path = strings.TrimSuffix(baseURL.Path, "/")
+	escapedOwner := url.PathEscape(owner)
+	escapedPackageName := url.PathEscape(packageName)
+
+	pathSegments := []string{
+		baseURL.Path,
+		ownerType.PathSegment(),
+		escapedOwner,
+		packagesPathSegmentConstant,
+		containerPathSegmentConstant,
+		escapedPackageName,
+		versionsPathSegmentConstant,
+	}
+
+	baseURL.Path = strings.Join(pathSegments, "/")
+
+	queryParameters := baseURL.Query()
+	queryParameters.Set(perPageQueryParameterNameConstant, fmt.Sprintf("%d", service.pageSize))
+	queryParameters.Set(pageQueryParameterNameConstant, fmt.Sprintf("%d", pageNumber))
+	baseURL.RawQuery = queryParameters.Encode()
+
+	return baseURL.String(), nil
+}
+
+func (service *PackageVersionService) buildVersionURL(ownerType OwnerType, owner string, packageName string, versionID int64) (string, error) {
+	baseURL, parseError := url.Parse(service.baseURL)
+	if parseError != nil {
+		return "", parseError
+	}
+
+	baseURL.Path = strings.TrimSuffix(baseURL.Path, "/")
+	escapedOwner := url.PathEscape(owner)
+	escapedPackageName := url.PathEscape(packageName)
+
+	pathSegments := []string{
+		baseURL.Path,
+		ownerType.PathSegment(),
+		escapedOwner,
+		packagesPathSegmentConstant,
+		containerPathSegmentConstant,
+		escapedPackageName,
+		versionsPathSegmentConstant,
+		fmt.Sprintf("%d", versionID),
+	}
+
+	baseURL.Path = strings.Join(pathSegments, "/")
+	baseURL.RawQuery = ""
+
+	return baseURL.String(), nil
+}
+
+type packageVersion struct {
+	ID       int64                  `json:"id"`
+	Metadata packageVersionMetadata `json:"metadata"`
+}
+
+type packageVersionMetadata struct {
+	Container packageVersionContainerMetadata `json:"container"`
+}
+
+type packageVersionContainerMetadata struct {
+	Tags []string `json:"tags"`
+}
+
+func (version packageVersion) HasTags() bool {
+	return len(version.Metadata.Container.Tags) > 0
+}

--- a/internal/ghcr/service_integration_test.go
+++ b/internal/ghcr/service_integration_test.go
@@ -1,0 +1,127 @@
+package ghcr_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/ghcr"
+)
+
+const (
+	integrationOwnerNameConstant    = "integration-owner"
+	integrationPackageNameConstant  = "integration-package"
+	integrationTokenConstant        = "integration-token"
+	untaggedVersionIdentifier       = int64(501)
+	taggedVersionIdentifier         = int64(999)
+	expectedAcceptHeaderName        = "Accept"
+	expectedAuthorizationHeaderName = "Authorization"
+	expectedAcceptHeaderValue       = "application/vnd.github+json"
+	expectedBearerHeaderTemplate    = "Bearer %s"
+	pageQueryParameterName          = "page"
+)
+
+func TestPackageVersionServiceIntegration(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	testCases := []struct {
+		name                string
+		dryRun              bool
+		expectedDeleteCount int
+	}{
+		{
+			name:                "dry_run_does_not_delete",
+			dryRun:              true,
+			expectedDeleteCount: 0,
+		},
+		{
+			name:                "deletes_when_not_dry_run",
+			dryRun:              false,
+			expectedDeleteCount: 1,
+		},
+	}
+
+	for index := range testCases {
+		testCase := testCases[index]
+
+		testingInstance.Run(testCase.name, func(testingSubInstance *testing.T) {
+			testingSubInstance.Parallel()
+
+			recordedDeleteIdentifiers := make([]int64, 0)
+			requestCount := 0
+
+			server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+				requestCount++
+				require.Equal(testingSubInstance, expectedAcceptHeaderValue, httpRequest.Header.Get(expectedAcceptHeaderName))
+				require.Equal(testingSubInstance, fmt.Sprintf(expectedBearerHeaderTemplate, integrationTokenConstant), httpRequest.Header.Get(expectedAuthorizationHeaderName))
+
+				switch httpRequest.Method {
+				case http.MethodGet:
+					handleIntegrationGet(testingSubInstance, responseWriter, httpRequest)
+				case http.MethodDelete:
+					versionIdentifier, parseError := parseVersionIdentifierFromPath(httpRequest.URL.Path)
+					require.NoError(testingSubInstance, parseError)
+					recordedDeleteIdentifiers = append(recordedDeleteIdentifiers, versionIdentifier)
+					responseWriter.WriteHeader(http.StatusNoContent)
+				default:
+					testingSubInstance.Fatalf("unexpected method %s", httpRequest.Method)
+				}
+			}))
+			defer server.Close()
+
+			service, serviceError := ghcr.NewPackageVersionService(zap.NewNop(), server.Client(), ghcr.ServiceConfiguration{
+				BaseURL:  server.URL,
+				PageSize: 2,
+			})
+			require.NoError(testingSubInstance, serviceError)
+
+			result, purgeError := service.PurgeUntaggedVersions(context.Background(), ghcr.PurgeRequest{
+				Owner:       integrationOwnerNameConstant,
+				PackageName: integrationPackageNameConstant,
+				OwnerType:   ghcr.OrganizationOwnerType,
+				Token:       integrationTokenConstant,
+				DryRun:      testCase.dryRun,
+			})
+			require.NoError(testingSubInstance, purgeError)
+			require.Equal(testingSubInstance, 2, result.TotalVersions)
+			require.Equal(testingSubInstance, 1, result.UntaggedVersions)
+			require.Equal(testingSubInstance, testCase.expectedDeleteCount, result.DeletedVersions)
+			require.Len(testingSubInstance, recordedDeleteIdentifiers, testCase.expectedDeleteCount)
+			require.GreaterOrEqual(testingSubInstance, requestCount, 2)
+		})
+	}
+}
+
+func handleIntegrationGet(testingInstance *testing.T, responseWriter http.ResponseWriter, httpRequest *http.Request) {
+	query := httpRequest.URL.Query()
+	pageValue := query.Get(pageQueryParameterName)
+	require.NotEmpty(testingInstance, pageValue)
+
+	switch pageValue {
+	case "1":
+		payload := fmt.Sprintf(`[{"id":%d,"metadata":{"container":{"tags":[]}}},{"id":%d,"metadata":{"container":{"tags":["latest"]}}}]`, untaggedVersionIdentifier, taggedVersionIdentifier)
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(payload))
+	default:
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte("[]"))
+	}
+}
+
+func parseVersionIdentifierFromPath(requestPath string) (int64, error) {
+	trimmedPath := strings.Trim(requestPath, "/")
+	segments := strings.Split(trimmedPath, "/")
+	if len(segments) == 0 {
+		return 0, fmt.Errorf("invalid path %s", requestPath)
+	}
+
+	identifierSegment := segments[len(segments)-1]
+	return strconv.ParseInt(identifierSegment, 10, 64)
+}

--- a/internal/ghcr/service_test.go
+++ b/internal/ghcr/service_test.go
@@ -1,0 +1,228 @@
+package ghcr_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/ghcr"
+)
+
+const (
+	testOwnerNameConstant        = "test-owner"
+	testPackageNameConstant      = "test-package"
+	testTokenValueConstant       = "test-token"
+	testUntaggedVersionID        = int64(1001)
+	testTaggedVersionID          = int64(1002)
+	errorMessageTemplateConstant = "request %d not configured"
+)
+
+type stubHTTPClient struct {
+	responses       []stubHTTPResponse
+	recordedMethods []string
+}
+
+type stubHTTPResponse struct {
+	response *http.Response
+	err      error
+}
+
+func (client *stubHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	client.recordedMethods = append(client.recordedMethods, request.Method)
+	if len(client.responses) == 0 {
+		return nil, fmt.Errorf(errorMessageTemplateConstant, len(client.recordedMethods))
+	}
+
+	next := client.responses[0]
+	client.responses = client.responses[1:]
+
+	if next.err != nil {
+		return nil, next.err
+	}
+
+	next.response.Request = request
+	return next.response, nil
+}
+
+func TestPackageVersionServiceInputValidation(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	httpClient := &stubHTTPClient{}
+	service, serviceError := ghcr.NewPackageVersionService(zap.NewNop(), httpClient, ghcr.ServiceConfiguration{})
+	require.NoError(testingInstance, serviceError)
+
+	testCases := []struct {
+		name          string
+		request       ghcr.PurgeRequest
+		expectedError string
+	}{
+		{
+			name: "missing_token",
+			request: ghcr.PurgeRequest{
+				Owner:       testOwnerNameConstant,
+				PackageName: testPackageNameConstant,
+				OwnerType:   ghcr.UserOwnerType,
+			},
+			expectedError: "authentication token must be provided",
+		},
+		{
+			name: "missing_owner",
+			request: ghcr.PurgeRequest{
+				Token:       testTokenValueConstant,
+				PackageName: testPackageNameConstant,
+				OwnerType:   ghcr.UserOwnerType,
+			},
+			expectedError: "owner must be provided",
+		},
+		{
+			name: "missing_package",
+			request: ghcr.PurgeRequest{
+				Owner:     testOwnerNameConstant,
+				Token:     testTokenValueConstant,
+				OwnerType: ghcr.UserOwnerType,
+			},
+			expectedError: "package name must be provided",
+		},
+		{
+			name: "missing_owner_type",
+			request: ghcr.PurgeRequest{
+				Owner:       testOwnerNameConstant,
+				Token:       testTokenValueConstant,
+				PackageName: testPackageNameConstant,
+			},
+			expectedError: "owner type must be provided",
+		},
+	}
+
+	for index := range testCases {
+		testCase := testCases[index]
+
+		testingInstance.Run(testCase.name, func(testingSubInstance *testing.T) {
+			testingSubInstance.Parallel()
+
+			_, purgeError := service.PurgeUntaggedVersions(context.Background(), testCase.request)
+			require.Error(testingSubInstance, purgeError)
+			require.ErrorContains(testingSubInstance, purgeError, testCase.expectedError)
+		})
+	}
+}
+
+func TestPackageVersionServiceHandlesHTTPFailures(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	testCases := []struct {
+		name          string
+		client        *stubHTTPClient
+		expectedError string
+	}{
+		{
+			name: "network_error",
+			client: &stubHTTPClient{
+				responses: []stubHTTPResponse{{err: errors.New("network error")}},
+			},
+			expectedError: "request execution failed",
+		},
+		{
+			name: "unexpected_status",
+			client: &stubHTTPClient{
+				responses: []stubHTTPResponse{{response: buildHTTPResponse(http.StatusInternalServerError, "failure")}},
+			},
+			expectedError: "unexpected status code 500",
+		},
+	}
+
+	for index := range testCases {
+		testCase := testCases[index]
+
+		testingInstance.Run(testCase.name, func(testingSubInstance *testing.T) {
+			testingSubInstance.Parallel()
+
+			service, serviceError := ghcr.NewPackageVersionService(zap.NewNop(), testCase.client, ghcr.ServiceConfiguration{})
+			require.NoError(testingSubInstance, serviceError)
+
+			_, purgeError := service.PurgeUntaggedVersions(context.Background(), ghcr.PurgeRequest{
+				Owner:       testOwnerNameConstant,
+				PackageName: testPackageNameConstant,
+				OwnerType:   ghcr.UserOwnerType,
+				Token:       testTokenValueConstant,
+			})
+			require.Error(testingSubInstance, purgeError)
+			require.ErrorContains(testingSubInstance, purgeError, testCase.expectedError)
+		})
+	}
+}
+
+func TestPackageVersionServiceDryRunSkipsDeletion(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	pageOneVersions := fmt.Sprintf(`[{"id":%d,"metadata":{"container":{"tags":[]}}},{"id":%d,"metadata":{"container":{"tags":["latest"]}}}]`, testUntaggedVersionID, testTaggedVersionID)
+	emptyPage := "[]"
+
+	client := &stubHTTPClient{
+		responses: []stubHTTPResponse{
+			{response: buildHTTPResponse(http.StatusOK, pageOneVersions)},
+			{response: buildHTTPResponse(http.StatusOK, emptyPage)},
+		},
+	}
+
+	service, serviceError := ghcr.NewPackageVersionService(zap.NewNop(), client, ghcr.ServiceConfiguration{PageSize: 2})
+	require.NoError(testingInstance, serviceError)
+
+	result, purgeError := service.PurgeUntaggedVersions(context.Background(), ghcr.PurgeRequest{
+		Owner:       testOwnerNameConstant,
+		PackageName: testPackageNameConstant,
+		OwnerType:   ghcr.OrganizationOwnerType,
+		Token:       testTokenValueConstant,
+		DryRun:      true,
+	})
+	require.NoError(testingInstance, purgeError)
+	require.Equal(testingInstance, 2, result.TotalVersions)
+	require.Equal(testingInstance, 1, result.UntaggedVersions)
+	require.Equal(testingInstance, 0, result.DeletedVersions)
+	require.Equal(testingInstance, []string{http.MethodGet, http.MethodGet}, client.recordedMethods)
+}
+
+func TestPackageVersionServiceDeletesUntaggedVersions(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	pageOneVersions := fmt.Sprintf(`[{"id":%d,"metadata":{"container":{"tags":[]}}}]`, testUntaggedVersionID)
+	emptyPage := "[]"
+
+	client := &stubHTTPClient{
+		responses: []stubHTTPResponse{
+			{response: buildHTTPResponse(http.StatusOK, pageOneVersions)},
+			{response: buildHTTPResponse(http.StatusNoContent, "")},
+			{response: buildHTTPResponse(http.StatusOK, emptyPage)},
+		},
+	}
+
+	service, serviceError := ghcr.NewPackageVersionService(zap.NewNop(), client, ghcr.ServiceConfiguration{PageSize: 1})
+	require.NoError(testingInstance, serviceError)
+
+	result, purgeError := service.PurgeUntaggedVersions(context.Background(), ghcr.PurgeRequest{
+		Owner:       testOwnerNameConstant,
+		PackageName: testPackageNameConstant,
+		OwnerType:   ghcr.UserOwnerType,
+		Token:       testTokenValueConstant,
+	})
+	require.NoError(testingInstance, purgeError)
+	require.Equal(testingInstance, 1, result.TotalVersions)
+	require.Equal(testingInstance, 1, result.UntaggedVersions)
+	require.Equal(testingInstance, 1, result.DeletedVersions)
+	require.Equal(testingInstance, []string{http.MethodGet, http.MethodDelete, http.MethodGet}, client.recordedMethods)
+}
+
+func buildHTTPResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}

--- a/internal/packages/command.go
+++ b/internal/packages/command.go
@@ -1,0 +1,219 @@
+package packages
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/ghcr"
+)
+
+const (
+	packagesCommandUseConstant              = "packages"
+	packagesCommandShortDescriptionConstant = "Manage GitHub Packages resources"
+	packagesCommandLongDescriptionConstant  = "packages provides commands for GitHub Packages maintenance tasks."
+	purgeCommandUseConstant                 = "purge"
+	purgeCommandShortDescriptionConstant    = "Delete untagged GHCR versions"
+	purgeCommandLongDescriptionConstant     = "purge removes untagged container versions from GitHub Container Registry."
+	unexpectedArgumentsErrorMessageConstant = "packages purge does not accept positional arguments"
+	commandExecutionErrorTemplateConstant   = "packages purge failed: %w"
+	ownerFlagNameConstant                   = "owner"
+	ownerFlagDescriptionConstant            = "GitHub user or organization that owns the package"
+	packageFlagNameConstant                 = "package"
+	packageFlagDescriptionConstant          = "Container package name in GHCR"
+	ownerTypeFlagNameConstant               = "owner-type"
+	ownerTypeFlagDescriptionConstant        = "Owner type: user or org"
+	tokenSourceFlagNameConstant             = "token-source"
+	tokenSourceFlagDescriptionConstant      = "Token source (env:NAME or file:/path)"
+	dryRunFlagNameConstant                  = "dry-run"
+	dryRunFlagDescriptionConstant           = "Preview deletions without modifying GHCR"
+	ownerTypeParseErrorTemplateConstant     = "invalid owner type: %w"
+	tokenSourceParseErrorTemplateConstant   = "invalid token source: %w"
+)
+
+// LoggerProvider supplies a zap logger instance.
+type LoggerProvider func() *zap.Logger
+
+// ConfigurationProvider returns the current packages configuration.
+type ConfigurationProvider func() Configuration
+
+// PurgeServiceResolver creates purge executors for the command.
+type PurgeServiceResolver interface {
+	Resolve(logger *zap.Logger) (PurgeExecutor, error)
+}
+
+// CommandBuilder assembles the packages command hierarchy.
+type CommandBuilder struct {
+	LoggerProvider        LoggerProvider
+	ConfigurationProvider ConfigurationProvider
+	ServiceResolver       PurgeServiceResolver
+	HTTPClient            ghcr.HTTPClient
+	ServiceBaseURL        string
+	PageSize              int
+	EnvironmentLookup     EnvironmentLookup
+	FileReader            FileReader
+	TokenResolver         TokenResolver
+}
+
+// Build constructs the packages command with the purge subcommand.
+func (builder *CommandBuilder) Build() (*cobra.Command, error) {
+	packagesCommand := &cobra.Command{
+		Use:   packagesCommandUseConstant,
+		Short: packagesCommandShortDescriptionConstant,
+		Long:  packagesCommandLongDescriptionConstant,
+	}
+
+	purgeCommand := &cobra.Command{
+		Use:   purgeCommandUseConstant,
+		Short: purgeCommandShortDescriptionConstant,
+		Long:  purgeCommandLongDescriptionConstant,
+		RunE:  builder.runPurge,
+	}
+
+	purgeCommand.Flags().String(ownerFlagNameConstant, "", ownerFlagDescriptionConstant)
+	purgeCommand.Flags().String(packageFlagNameConstant, "", packageFlagDescriptionConstant)
+	purgeCommand.Flags().String(ownerTypeFlagNameConstant, "", ownerTypeFlagDescriptionConstant)
+	purgeCommand.Flags().String(tokenSourceFlagNameConstant, "", tokenSourceFlagDescriptionConstant)
+	purgeCommand.Flags().Bool(dryRunFlagNameConstant, false, dryRunFlagDescriptionConstant)
+
+	packagesCommand.AddCommand(purgeCommand)
+
+	return packagesCommand, nil
+}
+
+func (builder *CommandBuilder) runPurge(command *cobra.Command, arguments []string) error {
+	if len(arguments) > 0 {
+		return errors.New(unexpectedArgumentsErrorMessageConstant)
+	}
+
+	purgeOptions, optionsError := builder.parsePurgeOptions(command)
+	if optionsError != nil {
+		return optionsError
+	}
+
+	logger := builder.resolveLogger()
+	purgeService, serviceError := builder.resolvePurgeService(logger)
+	if serviceError != nil {
+		return serviceError
+	}
+
+	_, executionError := purgeService.Execute(command.Context(), purgeOptions)
+	if executionError != nil {
+		return fmt.Errorf(commandExecutionErrorTemplateConstant, executionError)
+	}
+
+	return nil
+}
+
+func (builder *CommandBuilder) parsePurgeOptions(command *cobra.Command) (PurgeOptions, error) {
+	configuration := builder.resolveConfiguration()
+
+	ownerFlagValue, ownerFlagError := command.Flags().GetString(ownerFlagNameConstant)
+	if ownerFlagError != nil {
+		return PurgeOptions{}, ownerFlagError
+	}
+	ownerValue := selectStringValue(ownerFlagValue, configuration.Purge.Owner)
+
+	packageFlagValue, packageFlagError := command.Flags().GetString(packageFlagNameConstant)
+	if packageFlagError != nil {
+		return PurgeOptions{}, packageFlagError
+	}
+	packageValue := selectStringValue(packageFlagValue, configuration.Purge.PackageName)
+
+	ownerTypeFlagValue, ownerTypeFlagError := command.Flags().GetString(ownerTypeFlagNameConstant)
+	if ownerTypeFlagError != nil {
+		return PurgeOptions{}, ownerTypeFlagError
+	}
+	ownerTypeValue := selectStringValue(ownerTypeFlagValue, configuration.Purge.OwnerType)
+	parsedOwnerType, ownerTypeParseError := ghcr.ParseOwnerType(ownerTypeValue)
+	if ownerTypeParseError != nil {
+		return PurgeOptions{}, fmt.Errorf(ownerTypeParseErrorTemplateConstant, ownerTypeParseError)
+	}
+
+	tokenSourceFlagValue, tokenSourceFlagError := command.Flags().GetString(tokenSourceFlagNameConstant)
+	if tokenSourceFlagError != nil {
+		return PurgeOptions{}, tokenSourceFlagError
+	}
+	tokenSourceValue := selectStringValue(tokenSourceFlagValue, configuration.Purge.TokenSource)
+	if len(strings.TrimSpace(tokenSourceValue)) == 0 {
+		tokenSourceValue = defaultTokenSourceValueConstant
+	}
+	parsedTokenSource, tokenParseError := ParseTokenSource(tokenSourceValue)
+	if tokenParseError != nil {
+		return PurgeOptions{}, fmt.Errorf(tokenSourceParseErrorTemplateConstant, tokenParseError)
+	}
+
+	dryRunValue := configuration.Purge.DryRun
+	if command.Flags().Changed(dryRunFlagNameConstant) {
+		flagDryRunValue, dryRunFlagError := command.Flags().GetBool(dryRunFlagNameConstant)
+		if dryRunFlagError != nil {
+			return PurgeOptions{}, dryRunFlagError
+		}
+		dryRunValue = flagDryRunValue
+	}
+
+	purgeOptions := PurgeOptions{
+		Owner:       ownerValue,
+		PackageName: packageValue,
+		OwnerType:   parsedOwnerType,
+		TokenSource: parsedTokenSource,
+		DryRun:      dryRunValue,
+	}
+
+	return purgeOptions, nil
+}
+
+func (builder *CommandBuilder) resolveLogger() *zap.Logger {
+	if builder.LoggerProvider == nil {
+		return zap.NewNop()
+	}
+
+	logger := builder.LoggerProvider()
+	if logger == nil {
+		return zap.NewNop()
+	}
+
+	return logger
+}
+
+func (builder *CommandBuilder) resolveConfiguration() Configuration {
+	if builder.ConfigurationProvider == nil {
+		return DefaultConfiguration()
+	}
+
+	configuration := builder.ConfigurationProvider()
+	if len(strings.TrimSpace(configuration.Purge.TokenSource)) == 0 {
+		configuration.Purge.TokenSource = defaultTokenSourceValueConstant
+	}
+
+	return configuration
+}
+
+func (builder *CommandBuilder) resolvePurgeService(logger *zap.Logger) (PurgeExecutor, error) {
+	if builder.ServiceResolver != nil {
+		return builder.ServiceResolver.Resolve(logger)
+	}
+
+	defaultResolver := &DefaultPurgeServiceResolver{
+		HTTPClient:        builder.HTTPClient,
+		ServiceBaseURL:    builder.ServiceBaseURL,
+		PageSize:          builder.PageSize,
+		EnvironmentLookup: builder.EnvironmentLookup,
+		FileReader:        builder.FileReader,
+		TokenResolver:     builder.TokenResolver,
+	}
+
+	return defaultResolver.Resolve(logger)
+}
+
+func selectStringValue(flagValue string, configurationValue string) string {
+	trimmedFlagValue := strings.TrimSpace(flagValue)
+	if len(trimmedFlagValue) > 0 {
+		return trimmedFlagValue
+	}
+
+	return strings.TrimSpace(configurationValue)
+}

--- a/internal/packages/command_test.go
+++ b/internal/packages/command_test.go
@@ -1,0 +1,161 @@
+package packages_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/ghcr"
+	packages "github.com/temirov/git_scripts/internal/packages"
+)
+
+func TestCommandBuilderParsesConfigurationDefaults(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	configuration := packages.Configuration{
+		Purge: packages.PurgeConfiguration{
+			Owner:       "config-owner",
+			PackageName: "config-package",
+			OwnerType:   "org",
+			TokenSource: "env:CONFIG_TOKEN",
+			DryRun:      true,
+		},
+	}
+
+	executor := &stubPurgeExecutor{result: ghcr.PurgeResult{TotalVersions: 1}}
+	resolver := &stubServiceResolver{executor: executor}
+
+	builder := packages.CommandBuilder{
+		LoggerProvider:        func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() packages.Configuration { return configuration },
+		ServiceResolver:       resolver,
+	}
+
+	command, buildError := builder.Build()
+	require.NoError(testingInstance, buildError)
+
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"purge"})
+	executionError := command.Execute()
+	require.NoError(testingInstance, executionError)
+
+	require.True(testingInstance, executor.called)
+	require.Equal(testingInstance, "config-owner", executor.options.Owner)
+	require.Equal(testingInstance, "config-package", executor.options.PackageName)
+	require.Equal(testingInstance, ghcr.OrganizationOwnerType, executor.options.OwnerType)
+	require.True(testingInstance, executor.options.DryRun)
+	require.Equal(testingInstance, "CONFIG_TOKEN", executor.options.TokenSource.Reference)
+}
+
+func TestCommandBuilderFlagOverrides(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	configuration := packages.Configuration{Purge: packages.PurgeConfiguration{OwnerType: "user"}}
+	executor := &stubPurgeExecutor{result: ghcr.PurgeResult{TotalVersions: 2}}
+	resolver := &stubServiceResolver{executor: executor}
+
+	builder := packages.CommandBuilder{
+		LoggerProvider:        func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() packages.Configuration { return configuration },
+		ServiceResolver:       resolver,
+	}
+
+	command, buildError := builder.Build()
+	require.NoError(testingInstance, buildError)
+
+	command.SetContext(context.Background())
+	args := []string{
+		"purge",
+		"--owner", "flag-owner",
+		"--package", "flag-package",
+		"--owner-type", "org",
+		"--token-source", "file:/tmp/token",
+	}
+	command.SetArgs(args)
+	executionError := command.Execute()
+	require.NoError(testingInstance, executionError)
+
+	require.True(testingInstance, executor.called)
+	require.Equal(testingInstance, "flag-owner", executor.options.Owner)
+	require.Equal(testingInstance, "flag-package", executor.options.PackageName)
+	require.Equal(testingInstance, ghcr.OrganizationOwnerType, executor.options.OwnerType)
+	require.Equal(testingInstance, packages.TokenSourceTypeFile, executor.options.TokenSource.Type)
+	require.Equal(testingInstance, "/tmp/token", executor.options.TokenSource.Reference)
+	require.Equal(testingInstance, configuration.Purge.DryRun, executor.options.DryRun)
+}
+
+func TestCommandBuilderHandlesExecutionError(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	executor := &stubPurgeExecutor{err: errors.New("failure")}
+	resolver := &stubServiceResolver{executor: executor}
+
+	builder := packages.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() packages.Configuration {
+			return packages.Configuration{Purge: packages.PurgeConfiguration{OwnerType: "user"}}
+		},
+		ServiceResolver: resolver,
+	}
+
+	command, buildError := builder.Build()
+	require.NoError(testingInstance, buildError)
+
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"purge", "--owner", "o", "--package", "p", "--token-source", "env:VAR"})
+	executionError := command.Execute()
+	require.Error(testingInstance, executionError)
+	require.ErrorContains(testingInstance, executionError, "packages purge failed")
+}
+
+func TestCommandBuilderValidatesArguments(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	builder := packages.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() packages.Configuration {
+			return packages.Configuration{Purge: packages.PurgeConfiguration{OwnerType: "user"}}
+		},
+		ServiceResolver: &stubServiceResolver{executor: &stubPurgeExecutor{}},
+	}
+
+	command, buildError := builder.Build()
+	require.NoError(testingInstance, buildError)
+
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"purge", "unexpected"})
+	executionError := command.Execute()
+	require.Error(testingInstance, executionError)
+	require.ErrorContains(testingInstance, executionError, "does not accept positional arguments")
+}
+
+type stubServiceResolver struct {
+	executor *stubPurgeExecutor
+	err      error
+}
+
+func (resolver *stubServiceResolver) Resolve(logger *zap.Logger) (packages.PurgeExecutor, error) {
+	if resolver.err != nil {
+		return nil, resolver.err
+	}
+	return resolver.executor, nil
+}
+
+type stubPurgeExecutor struct {
+	options packages.PurgeOptions
+	result  ghcr.PurgeResult
+	err     error
+	called  bool
+}
+
+func (executor *stubPurgeExecutor) Execute(executionContext context.Context, options packages.PurgeOptions) (ghcr.PurgeResult, error) {
+	executor.called = true
+	executor.options = options
+	if executor.err != nil {
+		return ghcr.PurgeResult{}, executor.err
+	}
+	return executor.result, nil
+}

--- a/internal/packages/configuration.go
+++ b/internal/packages/configuration.go
@@ -1,0 +1,43 @@
+package packages
+
+const (
+	configurationKeyPackagesConstant = "packages"
+	purgeConfigurationKeyConstant    = configurationKeyPackagesConstant + ".purge"
+	purgeOwnerKeyConstant            = purgeConfigurationKeyConstant + ".owner"
+	purgePackageNameKeyConstant      = purgeConfigurationKeyConstant + ".package"
+	purgeOwnerTypeKeyConstant        = purgeConfigurationKeyConstant + ".owner_type"
+	purgeTokenSourceKeyConstant      = purgeConfigurationKeyConstant + ".token_source"
+	purgeDryRunKeyConstant           = purgeConfigurationKeyConstant + ".dry_run"
+	defaultTokenSourceValueConstant  = "env:GITHUB_PACKAGES_TOKEN"
+)
+
+// Configuration aggregates settings for packages commands.
+type Configuration struct {
+	Purge PurgeConfiguration `mapstructure:"purge"`
+}
+
+// PurgeConfiguration stores options for purging container versions.
+type PurgeConfiguration struct {
+	Owner       string `mapstructure:"owner"`
+	PackageName string `mapstructure:"package"`
+	OwnerType   string `mapstructure:"owner_type"`
+	TokenSource string `mapstructure:"token_source"`
+	DryRun      bool   `mapstructure:"dry_run"`
+}
+
+// DefaultConfiguration supplies baseline values for packages configuration.
+func DefaultConfiguration() Configuration {
+	return Configuration{
+		Purge: PurgeConfiguration{
+			TokenSource: defaultTokenSourceValueConstant,
+		},
+	}
+}
+
+// DefaultConfigurationValues provides Viper defaults for packages settings.
+func DefaultConfigurationValues() map[string]any {
+	return map[string]any{
+		purgeTokenSourceKeyConstant: defaultTokenSourceValueConstant,
+		purgeDryRunKeyConstant:      false,
+	}
+}

--- a/internal/packages/doc.go
+++ b/internal/packages/doc.go
@@ -1,0 +1,2 @@
+// Package packages exposes Cobra commands and services for GitHub Packages maintenance.
+package packages

--- a/internal/packages/resolver.go
+++ b/internal/packages/resolver.go
@@ -1,0 +1,41 @@
+package packages
+
+import (
+	"github.com/temirov/git_scripts/internal/ghcr"
+	"go.uber.org/zap"
+)
+
+// DefaultPurgeServiceResolver builds purge services using GHCR APIs and token resolution.
+type DefaultPurgeServiceResolver struct {
+	HTTPClient        ghcr.HTTPClient
+	ServiceBaseURL    string
+	PageSize          int
+	EnvironmentLookup EnvironmentLookup
+	FileReader        FileReader
+	TokenResolver     TokenResolver
+}
+
+// Resolve creates a purge executor using configured collaborators or sensible defaults.
+func (resolver *DefaultPurgeServiceResolver) Resolve(logger *zap.Logger) (PurgeExecutor, error) {
+	serviceConfiguration := ghcr.ServiceConfiguration{
+		BaseURL:  resolver.ServiceBaseURL,
+		PageSize: resolver.PageSize,
+	}
+
+	packageService, serviceCreationError := ghcr.NewPackageVersionService(logger, resolver.HTTPClient, serviceConfiguration)
+	if serviceCreationError != nil {
+		return nil, serviceCreationError
+	}
+
+	resolvedTokenResolver := resolver.TokenResolver
+	if resolvedTokenResolver == nil {
+		resolvedTokenResolver = NewTokenResolver(resolver.EnvironmentLookup, resolver.FileReader)
+	}
+
+	purgeService, purgeServiceError := NewPurgeService(logger, packageService, resolvedTokenResolver)
+	if purgeServiceError != nil {
+		return nil, purgeServiceError
+	}
+
+	return purgeService, nil
+}

--- a/internal/packages/service.go
+++ b/internal/packages/service.go
@@ -1,0 +1,136 @@
+package packages
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/temirov/git_scripts/internal/ghcr"
+)
+
+const (
+	packageServiceMissingErrorMessageConstant    = "package version service must be provided"
+	tokenResolverMissingErrorMessageConstant     = "token resolver must be provided"
+	ownerOptionMissingErrorMessageConstant       = "owner option must be provided"
+	packageOptionMissingErrorMessageConstant     = "package option must be provided"
+	ownerTypeOptionMissingErrorMessageConstant   = "owner type option must be provided"
+	tokenSourceOptionMissingErrorMessageConstant = "token source reference must be provided"
+	purgeServiceStartMessageConstant             = "Executing packages purge operation"
+	purgeServiceSummaryMessageConstant           = "Packages purge operation completed"
+	ownerLogFieldNameConstant                    = "owner"
+	packageLogFieldNameConstant                  = "package"
+	ownerTypeLogFieldNameConstant                = "owner_type"
+	dryRunLogFieldNameConstant                   = "dry_run"
+	deletedVersionsLogFieldNameConstant          = "deleted_versions"
+	untaggedVersionsLogFieldNameConstant         = "untagged_versions"
+	totalVersionsLogFieldNameConstant            = "total_versions"
+	tokenResolutionErrorTemplateConstant         = "unable to resolve authentication token: %w"
+	purgeExecutionErrorTemplateConstant          = "unable to purge package versions: %w"
+)
+
+// PackageVersionAPI describes the GHCR operations used by the purge service.
+type PackageVersionAPI interface {
+	PurgeUntaggedVersions(executionContext context.Context, request ghcr.PurgeRequest) (ghcr.PurgeResult, error)
+}
+
+// PurgeOptions represents validated inputs for package purging.
+type PurgeOptions struct {
+	Owner       string
+	PackageName string
+	OwnerType   ghcr.OwnerType
+	TokenSource TokenSourceConfiguration
+	DryRun      bool
+}
+
+// PurgeExecutor defines the behavior required by the command layer.
+type PurgeExecutor interface {
+	Execute(executionContext context.Context, options PurgeOptions) (ghcr.PurgeResult, error)
+}
+
+// PurgeService orchestrates configuration validation, token resolution, and API invocation.
+type PurgeService struct {
+	logger         *zap.Logger
+	packageService PackageVersionAPI
+	tokenResolver  TokenResolver
+}
+
+// NewPurgeService constructs a purge service with required collaborators.
+func NewPurgeService(logger *zap.Logger, packageService PackageVersionAPI, tokenResolver TokenResolver) (*PurgeService, error) {
+	if packageService == nil {
+		return nil, errors.New(packageServiceMissingErrorMessageConstant)
+	}
+	if tokenResolver == nil {
+		return nil, errors.New(tokenResolverMissingErrorMessageConstant)
+	}
+
+	resolvedLogger := logger
+	if resolvedLogger == nil {
+		resolvedLogger = zap.NewNop()
+	}
+
+	return &PurgeService{
+		logger:         resolvedLogger,
+		packageService: packageService,
+		tokenResolver:  tokenResolver,
+	}, nil
+}
+
+// Execute performs the purge workflow for the provided options.
+func (service *PurgeService) Execute(executionContext context.Context, options PurgeOptions) (ghcr.PurgeResult, error) {
+	trimmedOwner := strings.TrimSpace(options.Owner)
+	if len(trimmedOwner) == 0 {
+		return ghcr.PurgeResult{}, errors.New(ownerOptionMissingErrorMessageConstant)
+	}
+
+	trimmedPackageName := strings.TrimSpace(options.PackageName)
+	if len(trimmedPackageName) == 0 {
+		return ghcr.PurgeResult{}, errors.New(packageOptionMissingErrorMessageConstant)
+	}
+
+	if len(strings.TrimSpace(string(options.OwnerType))) == 0 {
+		return ghcr.PurgeResult{}, errors.New(ownerTypeOptionMissingErrorMessageConstant)
+	}
+
+	trimmedTokenSource := strings.TrimSpace(options.TokenSource.Reference)
+	if len(trimmedTokenSource) == 0 {
+		return ghcr.PurgeResult{}, errors.New(tokenSourceOptionMissingErrorMessageConstant)
+	}
+
+	service.logger.Info(
+		purgeServiceStartMessageConstant,
+		zap.String(ownerLogFieldNameConstant, trimmedOwner),
+		zap.String(packageLogFieldNameConstant, trimmedPackageName),
+		zap.String(ownerTypeLogFieldNameConstant, string(options.OwnerType)),
+		zap.Bool(dryRunLogFieldNameConstant, options.DryRun),
+	)
+
+	resolvedToken, tokenResolutionError := service.tokenResolver.ResolveToken(executionContext, options.TokenSource)
+	if tokenResolutionError != nil {
+		return ghcr.PurgeResult{}, fmt.Errorf(tokenResolutionErrorTemplateConstant, tokenResolutionError)
+	}
+
+	purgeRequest := ghcr.PurgeRequest{
+		Owner:       trimmedOwner,
+		PackageName: trimmedPackageName,
+		OwnerType:   options.OwnerType,
+		Token:       resolvedToken,
+		DryRun:      options.DryRun,
+	}
+
+	purgeResult, purgeError := service.packageService.PurgeUntaggedVersions(executionContext, purgeRequest)
+	if purgeError != nil {
+		return ghcr.PurgeResult{}, fmt.Errorf(purgeExecutionErrorTemplateConstant, purgeError)
+	}
+
+	service.logger.Info(
+		purgeServiceSummaryMessageConstant,
+		zap.Int(totalVersionsLogFieldNameConstant, purgeResult.TotalVersions),
+		zap.Int(untaggedVersionsLogFieldNameConstant, purgeResult.UntaggedVersions),
+		zap.Int(deletedVersionsLogFieldNameConstant, purgeResult.DeletedVersions),
+	)
+
+	return purgeResult, nil
+}

--- a/internal/packages/service_test.go
+++ b/internal/packages/service_test.go
@@ -1,0 +1,147 @@
+package packages_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/temirov/git_scripts/internal/ghcr"
+	packages "github.com/temirov/git_scripts/internal/packages"
+)
+
+func TestPurgeServiceValidatesOptions(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	packageService := &stubPackageVersionAPI{}
+	tokenResolver := &stubTokenResolver{token: "resolved-token"}
+	service, serviceError := packages.NewPurgeService(zap.NewNop(), packageService, tokenResolver)
+	require.NoError(testingInstance, serviceError)
+
+	testCases := []struct {
+		name          string
+		options       packages.PurgeOptions
+		expectedError string
+	}{
+		{
+			name:          "missing_owner",
+			options:       packages.PurgeOptions{PackageName: "package", OwnerType: ghcr.UserOwnerType, TokenSource: packages.TokenSourceConfiguration{Reference: "VAR"}},
+			expectedError: "owner option must be provided",
+		},
+		{
+			name:          "missing_package",
+			options:       packages.PurgeOptions{Owner: "owner", OwnerType: ghcr.UserOwnerType, TokenSource: packages.TokenSourceConfiguration{Reference: "VAR"}},
+			expectedError: "package option must be provided",
+		},
+		{
+			name:          "missing_owner_type",
+			options:       packages.PurgeOptions{Owner: "owner", PackageName: "package", TokenSource: packages.TokenSourceConfiguration{Reference: "VAR"}},
+			expectedError: "owner type option must be provided",
+		},
+		{
+			name:          "missing_token_source_reference",
+			options:       packages.PurgeOptions{Owner: "owner", PackageName: "package", OwnerType: ghcr.UserOwnerType},
+			expectedError: "token source reference must be provided",
+		},
+	}
+
+	for index := range testCases {
+		testCase := testCases[index]
+
+		testingInstance.Run(testCase.name, func(testingSubInstance *testing.T) {
+			testingSubInstance.Parallel()
+
+			_, executionError := service.Execute(context.Background(), testCase.options)
+			require.Error(testingSubInstance, executionError)
+			require.ErrorContains(testingSubInstance, executionError, testCase.expectedError)
+		})
+	}
+}
+
+func TestPurgeServicePropagatesTokenErrors(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	packageService := &stubPackageVersionAPI{}
+	tokenResolver := &stubTokenResolver{err: errors.New("resolution failed")}
+	service, serviceError := packages.NewPurgeService(zap.NewNop(), packageService, tokenResolver)
+	require.NoError(testingInstance, serviceError)
+
+	_, executionError := service.Execute(context.Background(), packages.PurgeOptions{
+		Owner:       "owner",
+		PackageName: "package",
+		OwnerType:   ghcr.OrganizationOwnerType,
+		TokenSource: packages.TokenSourceConfiguration{Type: packages.TokenSourceTypeEnvironment, Reference: "VAR"},
+	})
+	require.Error(testingInstance, executionError)
+	require.ErrorContains(testingInstance, executionError, "unable to resolve authentication token")
+}
+
+func TestPurgeServiceInvokesPackageService(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	observedCore, observedLogs := observer.New(zap.DebugLevel)
+	logger := zap.New(observedCore)
+
+	packageService := &stubPackageVersionAPI{
+		result: ghcr.PurgeResult{TotalVersions: 10, UntaggedVersions: 3, DeletedVersions: 2},
+	}
+	tokenResolver := &stubTokenResolver{token: "resolved-token"}
+
+	service, serviceError := packages.NewPurgeService(logger, packageService, tokenResolver)
+	require.NoError(testingInstance, serviceError)
+
+	options := packages.PurgeOptions{
+		Owner:       "owner",
+		PackageName: "package",
+		OwnerType:   ghcr.OrganizationOwnerType,
+		TokenSource: packages.TokenSourceConfiguration{Type: packages.TokenSourceTypeEnvironment, Reference: "ENV"},
+		DryRun:      true,
+	}
+
+	result, executionError := service.Execute(context.Background(), options)
+	require.NoError(testingInstance, executionError)
+	require.Equal(testingInstance, packageService.result, result)
+	require.True(testingInstance, packageService.called)
+	require.Equal(testingInstance, options.Owner, packageService.request.Owner)
+	require.Equal(testingInstance, options.PackageName, packageService.request.PackageName)
+	require.Equal(testingInstance, options.OwnerType, packageService.request.OwnerType)
+	require.Equal(testingInstance, options.DryRun, packageService.request.DryRun)
+	require.Equal(testingInstance, tokenResolver.token, packageService.request.Token)
+	require.Equal(testingInstance, options.TokenSource, tokenResolver.source)
+
+	infoLogs := observedLogs.FilterLevelExact(zap.InfoLevel)
+	require.GreaterOrEqual(testingInstance, infoLogs.Len(), 2)
+}
+
+type stubPackageVersionAPI struct {
+	request ghcr.PurgeRequest
+	result  ghcr.PurgeResult
+	err     error
+	called  bool
+}
+
+func (service *stubPackageVersionAPI) PurgeUntaggedVersions(executionContext context.Context, request ghcr.PurgeRequest) (ghcr.PurgeResult, error) {
+	service.called = true
+	service.request = request
+	if service.err != nil {
+		return ghcr.PurgeResult{}, service.err
+	}
+	return service.result, nil
+}
+
+type stubTokenResolver struct {
+	token  string
+	err    error
+	source packages.TokenSourceConfiguration
+}
+
+func (resolver *stubTokenResolver) ResolveToken(resolutionContext context.Context, source packages.TokenSourceConfiguration) (string, error) {
+	resolver.source = source
+	if resolver.err != nil {
+		return "", resolver.err
+	}
+	return resolver.token, nil
+}

--- a/internal/packages/token_source.go
+++ b/internal/packages/token_source.go
@@ -1,0 +1,140 @@
+package packages
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	tokenSourceSeparatorConstant               = ":"
+	environmentTokenSourceTypeValueConstant    = "env"
+	fileTokenSourceTypeValueConstant           = "file"
+	tokenSourceMissingErrorMessageConstant     = "token source must be provided"
+	environmentNameMissingErrorMessageConstant = "environment variable name must be provided"
+	filePathMissingErrorMessageConstant        = "token file path must be provided"
+	environmentLookupNilErrorMessageConstant   = "environment lookup function not configured"
+	fileReaderNilErrorMessageConstant          = "file reader function not configured"
+	environmentTokenMissingTemplateConstant    = "environment variable %s is not set"
+	fileReadErrorTemplateConstant              = "unable to read token file %s: %w"
+	fileTokenEmptyErrorTemplateConstant        = "token file %s is empty"
+	unsupportedTokenSourceTemplateConstant     = "unsupported token source type %q"
+)
+
+// TokenSourceType enumerates the supported token retrieval mechanisms.
+type TokenSourceType string
+
+// Token source type enumerations.
+const (
+	TokenSourceTypeEnvironment TokenSourceType = TokenSourceType(environmentTokenSourceTypeValueConstant)
+	TokenSourceTypeFile        TokenSourceType = TokenSourceType(fileTokenSourceTypeValueConstant)
+)
+
+// TokenSourceConfiguration specifies how to locate a credentials token.
+type TokenSourceConfiguration struct {
+	Type      TokenSourceType
+	Reference string
+}
+
+// TokenResolver retrieves authentication tokens from configured sources.
+type TokenResolver interface {
+	ResolveToken(resolutionContext context.Context, source TokenSourceConfiguration) (string, error)
+}
+
+// EnvironmentLookup obtains an environment variable value.
+type EnvironmentLookup func(key string) (string, bool)
+
+// FileReader reads the contents of a file path.
+type FileReader func(path string) ([]byte, error)
+
+// NewTokenResolver creates a token resolver with optional dependency overrides.
+func NewTokenResolver(environmentLookup EnvironmentLookup, fileReader FileReader) TokenResolver {
+	resolvedEnvironmentLookup := environmentLookup
+	if resolvedEnvironmentLookup == nil {
+		resolvedEnvironmentLookup = os.LookupEnv
+	}
+
+	resolvedFileReader := fileReader
+	if resolvedFileReader == nil {
+		resolvedFileReader = os.ReadFile
+	}
+
+	return &tokenResolver{
+		environmentLookup: resolvedEnvironmentLookup,
+		fileReader:        resolvedFileReader,
+	}
+}
+
+// ParseTokenSource interprets textual token source declarations.
+func ParseTokenSource(sourceValue string) (TokenSourceConfiguration, error) {
+	trimmedValue := strings.TrimSpace(sourceValue)
+	if len(trimmedValue) == 0 {
+		return TokenSourceConfiguration{}, fmt.Errorf(tokenSourceMissingErrorMessageConstant)
+	}
+
+	components := strings.SplitN(trimmedValue, tokenSourceSeparatorConstant, 2)
+	if len(components) == 1 {
+		return TokenSourceConfiguration{
+			Type:      TokenSourceTypeEnvironment,
+			Reference: trimmedValue,
+		}, nil
+	}
+
+	sourceType := strings.ToLower(strings.TrimSpace(components[0]))
+	reference := strings.TrimSpace(components[1])
+
+	switch sourceType {
+	case environmentTokenSourceTypeValueConstant:
+		if len(reference) == 0 {
+			return TokenSourceConfiguration{}, fmt.Errorf(environmentNameMissingErrorMessageConstant)
+		}
+		return TokenSourceConfiguration{Type: TokenSourceTypeEnvironment, Reference: reference}, nil
+	case fileTokenSourceTypeValueConstant:
+		if len(reference) == 0 {
+			return TokenSourceConfiguration{}, fmt.Errorf(filePathMissingErrorMessageConstant)
+		}
+		return TokenSourceConfiguration{Type: TokenSourceTypeFile, Reference: reference}, nil
+	default:
+		return TokenSourceConfiguration{}, fmt.Errorf(unsupportedTokenSourceTemplateConstant, sourceType)
+	}
+}
+
+type tokenResolver struct {
+	environmentLookup EnvironmentLookup
+	fileReader        FileReader
+}
+
+func (resolver *tokenResolver) ResolveToken(resolutionContext context.Context, source TokenSourceConfiguration) (string, error) {
+	_ = resolutionContext
+	switch source.Type {
+	case TokenSourceTypeEnvironment:
+		if resolver.environmentLookup == nil {
+			return "", fmt.Errorf(environmentLookupNilErrorMessageConstant)
+		}
+		value, found := resolver.environmentLookup(source.Reference)
+		if !found {
+			return "", fmt.Errorf(environmentTokenMissingTemplateConstant, source.Reference)
+		}
+		trimmedValue := strings.TrimSpace(value)
+		if len(trimmedValue) == 0 {
+			return "", fmt.Errorf(environmentTokenMissingTemplateConstant, source.Reference)
+		}
+		return trimmedValue, nil
+	case TokenSourceTypeFile:
+		if resolver.fileReader == nil {
+			return "", fmt.Errorf(fileReaderNilErrorMessageConstant)
+		}
+		contents, readError := resolver.fileReader(source.Reference)
+		if readError != nil {
+			return "", fmt.Errorf(fileReadErrorTemplateConstant, source.Reference, readError)
+		}
+		trimmedValue := strings.TrimSpace(string(contents))
+		if len(trimmedValue) == 0 {
+			return "", fmt.Errorf(fileTokenEmptyErrorTemplateConstant, source.Reference)
+		}
+		return trimmedValue, nil
+	default:
+		return "", fmt.Errorf(unsupportedTokenSourceTemplateConstant, source.Type)
+	}
+}

--- a/internal/packages/token_source_test.go
+++ b/internal/packages/token_source_test.go
@@ -1,0 +1,159 @@
+package packages_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	packages "github.com/temirov/git_scripts/internal/packages"
+)
+
+func TestParseTokenSourceScenarios(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	testCases := []struct {
+		name         string
+		input        string
+		expectedType packages.TokenSourceType
+		expectedRef  string
+		expectError  bool
+	}{
+		{
+			name:         "environment_with_prefix",
+			input:        "env:GITHUB_TOKEN",
+			expectedType: packages.TokenSourceTypeEnvironment,
+			expectedRef:  "GITHUB_TOKEN",
+		},
+		{
+			name:         "file_token_source",
+			input:        "file:/tmp/token.txt",
+			expectedType: packages.TokenSourceTypeFile,
+			expectedRef:  "/tmp/token.txt",
+		},
+		{
+			name:         "environment_without_prefix",
+			input:        "TOKEN_NAME",
+			expectedType: packages.TokenSourceTypeEnvironment,
+			expectedRef:  "TOKEN_NAME",
+		},
+		{
+			name:        "missing_value",
+			input:       " ",
+			expectError: true,
+		},
+		{
+			name:        "unsupported_type",
+			input:       "secret:TOKEN",
+			expectError: true,
+		},
+		{
+			name:        "missing_environment_reference",
+			input:       "env:",
+			expectError: true,
+		},
+		{
+			name:        "missing_file_reference",
+			input:       "file:",
+			expectError: true,
+		},
+	}
+
+	for index := range testCases {
+		testCase := testCases[index]
+
+		testingInstance.Run(testCase.name, func(testingSubInstance *testing.T) {
+			testingSubInstance.Parallel()
+
+			configuration, parseError := packages.ParseTokenSource(testCase.input)
+			if testCase.expectError {
+				require.Error(testingSubInstance, parseError)
+				return
+			}
+
+			require.NoError(testingSubInstance, parseError)
+			require.Equal(testingSubInstance, testCase.expectedType, configuration.Type)
+			require.Equal(testingSubInstance, testCase.expectedRef, configuration.Reference)
+		})
+	}
+}
+
+func TestTokenResolverResolvesValues(testingInstance *testing.T) {
+	testingInstance.Parallel()
+
+	environment := map[string]string{
+		"TOKEN_PRESENT": " secret-token ",
+	}
+
+	fileContents := map[string][]byte{
+		"/tmp/token.txt": []byte("file-token\n"),
+	}
+
+	environmentLookup := func(key string) (string, bool) {
+		value, found := environment[key]
+		return value, found
+	}
+
+	fileReader := func(path string) ([]byte, error) {
+		content, found := fileContents[path]
+		if !found {
+			return nil, errors.New("missing file")
+		}
+		return content, nil
+	}
+
+	resolver := packages.NewTokenResolver(environmentLookup, fileReader)
+
+	testCases := []struct {
+		name          string
+		configuration packages.TokenSourceConfiguration
+		expected      string
+		expectError   bool
+	}{
+		{
+			name:          "environment_success",
+			configuration: packages.TokenSourceConfiguration{Type: packages.TokenSourceTypeEnvironment, Reference: "TOKEN_PRESENT"},
+			expected:      "secret-token",
+		},
+		{
+			name:          "environment_missing",
+			configuration: packages.TokenSourceConfiguration{Type: packages.TokenSourceTypeEnvironment, Reference: "MISSING"},
+			expectError:   true,
+		},
+		{
+			name:          "file_success",
+			configuration: packages.TokenSourceConfiguration{Type: packages.TokenSourceTypeFile, Reference: "/tmp/token.txt"},
+			expected:      "file-token",
+		},
+		{
+			name:          "file_missing",
+			configuration: packages.TokenSourceConfiguration{Type: packages.TokenSourceTypeFile, Reference: "/tmp/missing.txt"},
+			expectError:   true,
+		},
+		{
+			name:          "file_empty",
+			configuration: packages.TokenSourceConfiguration{Type: packages.TokenSourceTypeFile, Reference: "/tmp/empty.txt"},
+			expectError:   true,
+		},
+	}
+
+	fileContents["/tmp/empty.txt"] = []byte("   \n")
+
+	for index := range testCases {
+		testCase := testCases[index]
+
+		testingInstance.Run(testCase.name, func(testingSubInstance *testing.T) {
+			testingSubInstance.Parallel()
+
+			value, resolutionError := resolver.ResolveToken(context.Background(), testCase.configuration)
+			if testCase.expectError {
+				require.Error(testingSubInstance, resolutionError)
+				return
+			}
+
+			require.NoError(testingSubInstance, resolutionError)
+			require.Equal(testingSubInstance, testCase.expected, value)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a `packages purge` Cobra command backed by Viper configuration defaults
- implement a GHCR package version service to paginate versions and delete untagged images
- support token source parsing and resolution for environment and file inputs with comprehensive tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1ff790b90832795f42b6a0fc72af4