### PR TITLE
Refactor CLI entrypoint and integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24.x'
 
       - name: Download dependencies
         run: go mod download
@@ -26,5 +26,8 @@ jobs:
       - name: Run linting
         run: make lint
 
-      - name: Run tests
-        run: make test
+      - name: Run unit tests
+        run: make test-unit
+
+      - name: Run integration tests
+        run: make test-integration

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GO_SOURCES := $(shell find . -name '*.go' -not -path "./vendor/*")
+UNIT_PACKAGES := $(shell go list ./... | grep -v '/tests$$')
 
-.PHONY: format check-format lint test ci
+.PHONY: format check-format lint test test-unit test-integration build ci
 
 format:
 	gofmt -w $(GO_SOURCES)
@@ -16,7 +17,16 @@ check-format:
 lint:
 	go vet ./...
 
-test:
-	go test ./...
+test-unit:
+	go test $(UNIT_PACKAGES)
+
+test-integration:
+	go test ./tests
+
+test: test-unit test-integration
+
+build:
+	mkdir -p bin
+	go build -o bin/git-scripts .
 
 ci: check-format lint test

--- a/cmd/cli/doc.go
+++ b/cmd/cli/doc.go
@@ -1,0 +1,5 @@
+// Package cli constructs the git_scripts command-line interface, wiring the
+// Cobra command hierarchy, configuration loader, and structured logging
+// primitives. It exposes helpers to build reusable application instances and
+// to execute the default command set as a reusable library.
+package cli

--- a/main.go
+++ b/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/temirov/git_scripts/cmd/cli"
+)
+
+const (
+	exitErrorTemplateConstant = "%v\n"
+)
+
+// main executes the git_scripts command-line application.
+func main() {
+	if executionError := cli.Execute(); executionError != nil {
+		fmt.Fprintf(os.Stderr, exitErrorTemplateConstant, executionError)
+		os.Exit(1)
+	}
+}

--- a/tests/cli_integration_test.go
+++ b/tests/cli_integration_test.go
@@ -66,7 +66,7 @@ func TestCLIIntegrationLogLevels(testInstance *testing.T) {
 
 	for testCaseIndex, testCase := range testCases {
 		testInstance.Run(fmt.Sprintf(integrationSubtestNameTemplateConstant, testCaseIndex, testCase.name), func(testInstance *testing.T) {
-			arguments := []string{"run", "./cmd/cli"}
+			arguments := []string{"run", "."}
 			environment := os.Environ()
 			tempDirectory := testInstance.TempDir()
 


### PR DESCRIPTION
## Summary
- expose the CLI wiring as a reusable package, add a root `main.go`, and document the package so `go build` emits a single binary
- teach the Makefile and CI workflow to build artefacts and run unit versus integration tests separately, while updating the README with new usage and release instructions
- refresh the integration suite to drive `go run .` across commands using table-driven subtests and temporary repositories

## Testing
- make check-format
- make lint
- make test-unit
- make test-integration

------
https://chatgpt.com/codex/tasks/task_e_68d21976e21083278a5d8fd03f46f6e8