### PR TITLE
Add release tooling and packages integration coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 *.csv
+bin/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 GO_SOURCES := $(shell find . -name '*.go' -not -path "./vendor/*")
 UNIT_PACKAGES := $(shell go list ./... | grep -v '/tests$$')
+RELEASE_TARGETS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+RELEASE_DIRECTORY := dist
+RELEASE_BINARY_NAME := git-scripts
 
-.PHONY: format check-format lint test test-unit test-integration build ci
+.PHONY: format check-format lint test test-unit test-integration build release ci
 
 format:
 	gofmt -w $(GO_SOURCES)
@@ -28,5 +31,16 @@ test: test-unit test-integration
 build:
 	mkdir -p bin
 	go build -o bin/git-scripts .
+
+release:
+	rm -rf $(RELEASE_DIRECTORY)
+	mkdir -p $(RELEASE_DIRECTORY)
+	for target in $(RELEASE_TARGETS); do \
+		os=$${target%/*}; \
+		arch=$${target#*/}; \
+		output_path=$(RELEASE_DIRECTORY)/$(RELEASE_BINARY_NAME)-$$os-$$arch; \
+		echo "Building $$output_path"; \
+		CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -o $$output_path .; \
+	done
 
 ci: check-format lint test

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The binary exposes the same helpers as the historical shell scripts:
   go run . branch migrate --debug
   ```
 
-* **GitHub Packages maintenance** — purge untagged GHCR images using stored configuration or command flags.
+* **GitHub Packages maintenance** — purge untagged GHCR images using stored configuration or command flags. The packages
+  configuration supports overrides such as `service_base_url` (for GitHub Enterprise or integration testing) and `page_size`.
 
   ```bash
   go run . packages purge \
@@ -63,20 +64,43 @@ The binary exposes the same helpers as the historical shell scripts:
     --dry-run
   ```
 
+  ```yaml
+  # packages.yaml
+  packages:
+    purge:
+      owner: my-org
+      package: my-image
+      owner_type: org
+      token_source: env:GITHUB_PACKAGES_TOKEN
+      service_base_url: https://github.example.com/api/v3
+      page_size: 50
+  ```
+
+  ```bash
+  go run . --config packages.yaml packages purge
+  ```
+
 ### Building and releasing
 
-`go build` now produces a single binary from the repository root:
+`go build` at the repository root produces a single binary that embeds every command:
 
 ```bash
 go build
 ./git_scripts --help
 ```
 
-For reproducible artifacts, use the dedicated Make target:
+`make build` writes the binary to `./bin/git-scripts` for repeatable local installs:
 
 ```bash
 make build
 ./bin/git-scripts --help
+```
+
+Use `make release` to cross-compile ready-to-upload artifacts. The target emits platform-specific binaries in `./dist`:
+
+```bash
+make release
+ls dist
 ```
 
 ### Migration notes
@@ -92,7 +116,8 @@ make build
 * `make test-unit` — executes fast unit tests across all Go packages.
 * `make test-integration` — runs the end-to-end suite under `./tests`.
 * `make test` — runs both unit and integration tests.
-* `make build` — creates the release binary in `bin/git-scripts`.
+* `make build` — creates the local binary in `bin/git-scripts`.
+* `make release` — cross-compiles platform-specific binaries in `dist/`.
 
 ## Prerequisites
 

--- a/cmd/cli/doc.go
+++ b/cmd/cli/doc.go
@@ -1,5 +1,8 @@
-// Package cli constructs the git_scripts command-line interface, wiring the
-// Cobra command hierarchy, configuration loader, and structured logging
-// primitives. It exposes helpers to build reusable application instances and
-// to execute the default command set as a reusable library.
+// Package cli constructs the git_scripts command-line interface.
+//
+// It wires the Cobra root command with configuration loading, structured
+// logging, and command registration for the audit, branch cleanup, migration,
+// and packages subcommands. The package exposes the Application type used by
+// main along with NewApplication and Execute helpers so the CLI can be reused
+// programmatically.
 package cli

--- a/internal/audit/doc.go
+++ b/internal/audit/doc.go
@@ -1,5 +1,7 @@
-// Package audit provides repository auditing and maintenance workflows for the
-// git_scripts command-line interface. The package discovers git repositories,
-// inspects their metadata, and coordinates actions such as reporting,
-// renaming, remote updates, and protocol conversions.
+// Package audit implements repository discovery, reporting, and reconciliation
+// workflows used by the git_scripts CLI.
+//
+// It exposes CommandBuilder for wiring Cobra commands, Service for driving the
+// workflow programmatically, and supporting abstractions for Git, GitHub, file
+// system, and prompting collaborators.
 package audit

--- a/internal/branches/doc.go
+++ b/internal/branches/doc.go
@@ -1,2 +1,6 @@
-// Package branches provides functionality for cleaning up Git branches associated with closed pull requests.
+// Package branches provides pull-request branch cleanup services for git_scripts.
+//
+// It offers CommandBuilder for the Cobra command, Service for orchestrating
+// deletions through Git and the GitHub CLI, and supporting options and
+// interfaces to enable testing and reuse.
 package branches

--- a/internal/execshell/doc.go
+++ b/internal/execshell/doc.go
@@ -1,3 +1,6 @@
-// Package execshell provides structured helpers for invoking external command line tools
-// such as git, gh, and curl while capturing output details and emitting structured logs.
+// Package execshell provides structured helpers for invoking external tools.
+//
+// It wraps os/exec with logging and timeouts via ShellExecutor, exposes
+// OSCommandRunner for default process execution, and defines abstractions used
+// throughout git_scripts to run git, gh, and other CLIs in a testable manner.
 package execshell

--- a/internal/ghcr/doc.go
+++ b/internal/ghcr/doc.go
@@ -1,2 +1,7 @@
-// Package ghcr provides helpers for interacting with the GitHub Container Registry REST API.
+// Package ghcr provides typed clients for the GitHub Container Registry APIs.
+//
+// It defines OwnerType helpers, PurgeRequest and PurgeResult models, and the
+// PackageVersionService which performs paginated listing and deletion of
+// container versions. The package powers the packages CLI commands and can be
+// reused for GitHub Enterprise endpoints.
 package ghcr

--- a/internal/githubcli/doc.go
+++ b/internal/githubcli/doc.go
@@ -1,3 +1,6 @@
-// Package githubcli implements opinionated helpers for invoking the GitHub CLI using
-// the execshell executor and provides typed representations for common gh workflows.
+// Package githubcli wraps the GitHub CLI for git_scripts workflows.
+//
+// It layers typed request and response structures for gh subcommands, exposes
+// interfaces consumed by other packages, and integrates with execshell so
+// interactions with GitHub can be mocked during testing.
 package githubcli

--- a/internal/gitrepo/doc.go
+++ b/internal/gitrepo/doc.go
@@ -1,3 +1,6 @@
-// Package gitrepo contains helpers for interrogating and manipulating Git repositories
-// using the execshell executor as the transport layer.
+// Package gitrepo contains helpers for interrogating and manipulating Git repositories.
+//
+// It exposes RepositoryManager for inspecting branches, remotes, and status,
+// along with supporting utilities consumed by audit and migrate services that
+// need structured Git operations.
 package gitrepo

--- a/internal/migrate/doc.go
+++ b/internal/migrate/doc.go
@@ -1,4 +1,6 @@
-// Package migrate implements the branch migration workflow that aligns repositories
-// to the desired default branch, updates GitHub configuration, and enforces safety
-// checks before destructive actions.
+// Package migrate implements default-branch migration orchestration.
+//
+// It coordinates Git operations, GitHub API updates, and safety checks through
+// the Service type, and exposes CommandBuilder plus supporting option structs
+// so the workflow can run from the CLI or be embedded in other tools.
 package migrate

--- a/internal/packages/command.go
+++ b/internal/packages/command.go
@@ -180,13 +180,28 @@ func (builder *CommandBuilder) resolveLogger() *zap.Logger {
 }
 
 func (builder *CommandBuilder) resolveConfiguration() Configuration {
-	if builder.ConfigurationProvider == nil {
-		return DefaultConfiguration()
+	configuration := DefaultConfiguration()
+	if builder.ConfigurationProvider != nil {
+		configuration = builder.ConfigurationProvider()
 	}
 
-	configuration := builder.ConfigurationProvider()
 	if len(strings.TrimSpace(configuration.Purge.TokenSource)) == 0 {
 		configuration.Purge.TokenSource = defaultTokenSourceValueConstant
+	}
+
+	configuration.Purge.ServiceBaseURL = strings.TrimSpace(configuration.Purge.ServiceBaseURL)
+	if configuration.Purge.PageSize < 0 {
+		configuration.Purge.PageSize = 0
+	}
+
+	trimmedServiceBaseURL := strings.TrimSpace(builder.ServiceBaseURL)
+	if len(trimmedServiceBaseURL) == 0 {
+		trimmedServiceBaseURL = configuration.Purge.ServiceBaseURL
+	}
+	builder.ServiceBaseURL = trimmedServiceBaseURL
+
+	if builder.PageSize <= 0 && configuration.Purge.PageSize > 0 {
+		builder.PageSize = configuration.Purge.PageSize
 	}
 
 	return configuration

--- a/internal/packages/configuration.go
+++ b/internal/packages/configuration.go
@@ -1,14 +1,18 @@
 package packages
 
 const (
-	configurationKeyPackagesConstant = "packages"
-	purgeConfigurationKeyConstant    = configurationKeyPackagesConstant + ".purge"
-	purgeOwnerKeyConstant            = purgeConfigurationKeyConstant + ".owner"
-	purgePackageNameKeyConstant      = purgeConfigurationKeyConstant + ".package"
-	purgeOwnerTypeKeyConstant        = purgeConfigurationKeyConstant + ".owner_type"
-	purgeTokenSourceKeyConstant      = purgeConfigurationKeyConstant + ".token_source"
-	purgeDryRunKeyConstant           = purgeConfigurationKeyConstant + ".dry_run"
-	defaultTokenSourceValueConstant  = "env:GITHUB_PACKAGES_TOKEN"
+	configurationKeyPackagesConstant   = "packages"
+	purgeConfigurationKeyConstant      = configurationKeyPackagesConstant + ".purge"
+	purgeOwnerKeyConstant              = purgeConfigurationKeyConstant + ".owner"
+	purgePackageNameKeyConstant        = purgeConfigurationKeyConstant + ".package"
+	purgeOwnerTypeKeyConstant          = purgeConfigurationKeyConstant + ".owner_type"
+	purgeTokenSourceKeyConstant        = purgeConfigurationKeyConstant + ".token_source"
+	purgeDryRunKeyConstant             = purgeConfigurationKeyConstant + ".dry_run"
+	purgeServiceBaseURLKeyConstant     = purgeConfigurationKeyConstant + ".service_base_url"
+	purgePageSizeKeyConstant           = purgeConfigurationKeyConstant + ".page_size"
+	defaultTokenSourceValueConstant    = "env:GITHUB_PACKAGES_TOKEN"
+	defaultServiceBaseURLValueConstant = ""
+	defaultPageSizeValueConstant       = 0
 )
 
 // Configuration aggregates settings for packages commands.
@@ -18,18 +22,22 @@ type Configuration struct {
 
 // PurgeConfiguration stores options for purging container versions.
 type PurgeConfiguration struct {
-	Owner       string `mapstructure:"owner"`
-	PackageName string `mapstructure:"package"`
-	OwnerType   string `mapstructure:"owner_type"`
-	TokenSource string `mapstructure:"token_source"`
-	DryRun      bool   `mapstructure:"dry_run"`
+	Owner          string `mapstructure:"owner"`
+	PackageName    string `mapstructure:"package"`
+	OwnerType      string `mapstructure:"owner_type"`
+	TokenSource    string `mapstructure:"token_source"`
+	DryRun         bool   `mapstructure:"dry_run"`
+	ServiceBaseURL string `mapstructure:"service_base_url"`
+	PageSize       int    `mapstructure:"page_size"`
 }
 
 // DefaultConfiguration supplies baseline values for packages configuration.
 func DefaultConfiguration() Configuration {
 	return Configuration{
 		Purge: PurgeConfiguration{
-			TokenSource: defaultTokenSourceValueConstant,
+			TokenSource:    defaultTokenSourceValueConstant,
+			ServiceBaseURL: defaultServiceBaseURLValueConstant,
+			PageSize:       defaultPageSizeValueConstant,
 		},
 	}
 }
@@ -37,7 +45,9 @@ func DefaultConfiguration() Configuration {
 // DefaultConfigurationValues provides Viper defaults for packages settings.
 func DefaultConfigurationValues() map[string]any {
 	return map[string]any{
-		purgeTokenSourceKeyConstant: defaultTokenSourceValueConstant,
-		purgeDryRunKeyConstant:      false,
+		purgeTokenSourceKeyConstant:    defaultTokenSourceValueConstant,
+		purgeDryRunKeyConstant:         false,
+		purgeServiceBaseURLKeyConstant: defaultServiceBaseURLValueConstant,
+		purgePageSizeKeyConstant:       defaultPageSizeValueConstant,
 	}
 }

--- a/internal/packages/doc.go
+++ b/internal/packages/doc.go
@@ -1,2 +1,7 @@
-// Package packages exposes Cobra commands and services for GitHub Packages maintenance.
+// Package packages manages GitHub Packages maintenance from the CLI.
+//
+// It provides CommandBuilder for wiring Cobra commands, PurgeService for
+// deleting untagged container versions, configuration helpers (including
+// service_base_url and page_size overrides), and token resolution utilities
+// that integrate with GHCR and external credentials.
 package packages

--- a/internal/utils/doc.go
+++ b/internal/utils/doc.go
@@ -1,2 +1,5 @@
 // Package utils exposes reusable helpers consumed by multiple commands.
+//
+// It currently houses ConfigurationLoader and LoggerFactory abstractions that
+// integrate Viper, environment variables, and zap logging for the CLI.
 package utils

--- a/tests/packages_integration_test.go
+++ b/tests/packages_integration_test.go
@@ -1,0 +1,273 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	packagesIntegrationOwnerConstant                    = "integration-org"
+	packagesIntegrationPackageConstant                  = "tooling"
+	packagesIntegrationOwnerTypeConstant                = "org"
+	packagesIntegrationTokenEnvNameConstant             = "PACKAGES_TOKEN"
+	packagesIntegrationTokenReferenceConstant           = "env:PACKAGES_TOKEN"
+	packagesIntegrationTokenValueConstant               = "packages-token-value"
+	packagesIntegrationConfigFileNameConstant           = "config.yaml"
+	packagesIntegrationConfigTemplateConstant           = "log_level: error\npackages:\n  purge:\n    owner: %s\n    package: %s\n    owner_type: %s\n    token_source: %s\n    dry_run: %t\n    service_base_url: %s\n    page_size: %d\n"
+	packagesIntegrationSubtestNameTemplateConstant      = "%d_%s"
+	packagesIntegrationRunSubcommandConstant            = "run"
+	packagesIntegrationModulePathConstant               = "."
+	packagesIntegrationConfigFlagTemplateConstant       = "--config=%s"
+	packagesIntegrationPackagesCommandNameConstant      = "packages"
+	packagesIntegrationPurgeCommandNameConstant         = "purge"
+	packagesIntegrationPageSizeConstant                 = 3
+	packagesIntegrationTaggedVersionIDConstant          = 101
+	packagesIntegrationFirstUntaggedVersionIDConstant   = 202
+	packagesIntegrationSecondUntaggedVersionIDConstant  = 303
+	packagesIntegrationVersionsResponseTemplateConstant = `[
+{"id":%d,"metadata":{"container":{"tags":["stable"]}}},
+{"id":%d,"metadata":{"container":{"tags":[]}}},
+{"id":%d,"metadata":{"container":{"tags":[]}}}
+]`
+	packagesIntegrationVersionsPathTemplateConstant  = "/orgs/%s/packages/container/%s/versions"
+	packagesIntegrationDeletePathTemplateConstant    = "/orgs/%s/packages/container/%s/versions/%d"
+	packagesIntegrationAuthorizationTemplateConstant = "Bearer %s"
+)
+
+type packagesIntegrationListRequest struct {
+	path    string
+	page    int
+	perPage int
+}
+
+type packagesIntegrationDeleteRequest struct {
+	path      string
+	versionID int64
+}
+
+type packagesIntegrationServer struct {
+	mutex                sync.Mutex
+	pageOnePayload       string
+	listRequests         []packagesIntegrationListRequest
+	deleteRequests       []packagesIntegrationDeleteRequest
+	authorizationHeaders []string
+}
+
+func newPackagesIntegrationServer(pageOnePayload string) *packagesIntegrationServer {
+	return &packagesIntegrationServer{pageOnePayload: pageOnePayload}
+}
+
+func (server *packagesIntegrationServer) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	server.mutex.Lock()
+	server.authorizationHeaders = append(server.authorizationHeaders, request.Header.Get("Authorization"))
+	server.mutex.Unlock()
+
+	switch request.Method {
+	case http.MethodGet:
+		pageValue := request.URL.Query().Get("page")
+		perPageValue := request.URL.Query().Get("per_page")
+		pageNumber, pageParseError := strconv.Atoi(pageValue)
+		if pageParseError != nil {
+			responseWriter.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(responseWriter, "invalid page: %v", pageParseError)
+			return
+		}
+
+		perPageNumber, perPageParseError := strconv.Atoi(perPageValue)
+		if perPageParseError != nil {
+			responseWriter.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(responseWriter, "invalid per_page: %v", perPageParseError)
+			return
+		}
+
+		listRequest := packagesIntegrationListRequest{
+			path:    request.URL.Path,
+			page:    pageNumber,
+			perPage: perPageNumber,
+		}
+
+		server.mutex.Lock()
+		server.listRequests = append(server.listRequests, listRequest)
+		server.mutex.Unlock()
+
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if pageNumber == 1 {
+			_, _ = fmt.Fprint(responseWriter, server.pageOnePayload)
+			return
+		}
+
+		_, _ = fmt.Fprint(responseWriter, "[]")
+	case http.MethodDelete:
+		pathSegments := strings.Split(strings.Trim(request.URL.Path, "/"), "/")
+		if len(pathSegments) == 0 {
+			responseWriter.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprint(responseWriter, "missing identifier")
+			return
+		}
+
+		identifierText := pathSegments[len(pathSegments)-1]
+		versionID, parseError := strconv.ParseInt(identifierText, 10, 64)
+		if parseError != nil {
+			responseWriter.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(responseWriter, "invalid version identifier: %v", parseError)
+			return
+		}
+
+		deleteRequest := packagesIntegrationDeleteRequest{
+			path:      request.URL.Path,
+			versionID: versionID,
+		}
+
+		server.mutex.Lock()
+		server.deleteRequests = append(server.deleteRequests, deleteRequest)
+		server.mutex.Unlock()
+
+		responseWriter.WriteHeader(http.StatusNoContent)
+	default:
+		responseWriter.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (server *packagesIntegrationServer) snapshotListRequests() []packagesIntegrationListRequest {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+	requests := make([]packagesIntegrationListRequest, len(server.listRequests))
+	copy(requests, server.listRequests)
+	return requests
+}
+
+func (server *packagesIntegrationServer) snapshotDeleteRequests() []packagesIntegrationDeleteRequest {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+	requests := make([]packagesIntegrationDeleteRequest, len(server.deleteRequests))
+	copy(requests, server.deleteRequests)
+	return requests
+}
+
+func (server *packagesIntegrationServer) snapshotAuthorizationHeaders() []string {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+	headers := make([]string, len(server.authorizationHeaders))
+	copy(headers, server.authorizationHeaders)
+	return headers
+}
+
+func TestPackagesCommandIntegration(testInstance *testing.T) {
+	workingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+	repositoryRoot := filepath.Dir(workingDirectory)
+
+	pageOnePayload := fmt.Sprintf(
+		packagesIntegrationVersionsResponseTemplateConstant,
+		packagesIntegrationTaggedVersionIDConstant,
+		packagesIntegrationFirstUntaggedVersionIDConstant,
+		packagesIntegrationSecondUntaggedVersionIDConstant,
+	)
+
+	testCases := []struct {
+		name              string
+		dryRun            bool
+		expectedDeleteIDs []int64
+	}{
+		{
+			name:              "purge_deletes_untagged_versions",
+			dryRun:            false,
+			expectedDeleteIDs: []int64{packagesIntegrationFirstUntaggedVersionIDConstant, packagesIntegrationSecondUntaggedVersionIDConstant},
+		},
+		{
+			name:              "dry_run_skips_deletion",
+			dryRun:            true,
+			expectedDeleteIDs: nil,
+		},
+	}
+
+	for testCaseIndex, testCase := range testCases {
+		subtestName := fmt.Sprintf(packagesIntegrationSubtestNameTemplateConstant, testCaseIndex, testCase.name)
+		testInstance.Run(subtestName, func(subtest *testing.T) {
+			serverState := newPackagesIntegrationServer(pageOnePayload)
+			server := httptest.NewServer(serverState)
+			defer server.Close()
+
+			configDirectory := subtest.TempDir()
+			configPath := filepath.Join(configDirectory, packagesIntegrationConfigFileNameConstant)
+			configContent := fmt.Sprintf(
+				packagesIntegrationConfigTemplateConstant,
+				packagesIntegrationOwnerConstant,
+				packagesIntegrationPackageConstant,
+				packagesIntegrationOwnerTypeConstant,
+				packagesIntegrationTokenReferenceConstant,
+				testCase.dryRun,
+				server.URL,
+				packagesIntegrationPageSizeConstant,
+			)
+
+			writeError := os.WriteFile(configPath, []byte(configContent), 0o600)
+			require.NoError(subtest, writeError)
+
+			subtest.Setenv(packagesIntegrationTokenEnvNameConstant, packagesIntegrationTokenValueConstant)
+
+			arguments := []string{
+				packagesIntegrationRunSubcommandConstant,
+				packagesIntegrationModulePathConstant,
+				fmt.Sprintf(packagesIntegrationConfigFlagTemplateConstant, configPath),
+				packagesIntegrationPackagesCommandNameConstant,
+				packagesIntegrationPurgeCommandNameConstant,
+			}
+
+			pathVariable := os.Getenv("PATH")
+			_ = runCommand(subtest, repositoryRoot, pathVariable, arguments)
+
+			listRequests := serverState.snapshotListRequests()
+			require.Len(subtest, listRequests, 2)
+
+			expectedVersionsPath := fmt.Sprintf(
+				packagesIntegrationVersionsPathTemplateConstant,
+				packagesIntegrationOwnerConstant,
+				packagesIntegrationPackageConstant,
+			)
+
+			require.Equal(subtest, expectedVersionsPath, listRequests[0].path)
+			require.Equal(subtest, 1, listRequests[0].page)
+			require.Equal(subtest, packagesIntegrationPageSizeConstant, listRequests[0].perPage)
+
+			require.Equal(subtest, expectedVersionsPath, listRequests[1].path)
+			require.Equal(subtest, 2, listRequests[1].page)
+			require.Equal(subtest, packagesIntegrationPageSizeConstant, listRequests[1].perPage)
+
+			deleteRequests := serverState.snapshotDeleteRequests()
+			if len(testCase.expectedDeleteIDs) == 0 {
+				require.Empty(subtest, deleteRequests)
+			} else {
+				require.Len(subtest, deleteRequests, len(testCase.expectedDeleteIDs))
+				for deleteIndex, deleteRequest := range deleteRequests {
+					expectedIdentifier := testCase.expectedDeleteIDs[deleteIndex]
+					require.Equal(subtest, expectedIdentifier, deleteRequest.versionID)
+					expectedDeletePath := fmt.Sprintf(
+						packagesIntegrationDeletePathTemplateConstant,
+						packagesIntegrationOwnerConstant,
+						packagesIntegrationPackageConstant,
+						expectedIdentifier,
+					)
+					require.Equal(subtest, expectedDeletePath, deleteRequest.path)
+				}
+			}
+
+			authorizationHeaders := serverState.snapshotAuthorizationHeaders()
+			expectedAuthorization := fmt.Sprintf(packagesIntegrationAuthorizationTemplateConstant, packagesIntegrationTokenValueConstant)
+			expectedHeaderCount := len(listRequests) + len(deleteRequests)
+			require.Len(subtest, authorizationHeaders, expectedHeaderCount)
+			for _, headerValue := range authorizationHeaders {
+				require.Equal(subtest, expectedAuthorization, headerValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a cross-platform `make release` target and ignore build artifacts
- document the CLI usage, GHCR configuration overrides, and package responsibilities
- extend packages configuration and docs to support custom GHCR endpoints
- add an end-to-end packages CLI integration test covering dry-run and purge flows

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d24496897c832793ac00fbea10c5fd