### PR TITLE
Add log format configuration to CLI logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,23 @@ A small collection of practical Bash scripts that automate common Git and GitHub
 
 ## Go-based CLI
 
-The repository now ships a Go-based command-line interface that complements the existing Bash scripts. The CLI boots a Cobra root command, hydrates configuration with Viper (covering config files and environment overrides), and emits structured Zap logs.
+The repository now ships a Go-based command-line interface that complements the existing Bash scripts. The CLI boots a Cobra root command, hydrates configuration with Viper (covering config files and environment overrides), and emits Zap logs in either structured JSON or console form.
 
 ### Usage overview
 
 ```bash
 go run . --log-level debug
+go run . --log-format console
 ```
 
-Add `--config=path/to/config.yaml` to load persisted settings. Configuration files currently support a `log_level` key, for example:
+Add `--config=path/to/config.yaml` to load persisted settings. Configuration files currently support `log_level` and `log_format` keys, for example:
 
 ```yaml
 log_level: debug
+log_format: console
 ```
 
-Environment variables prefixed with `GITSCRIPTS_` override file values. For instance, `GITSCRIPTS_LOG_LEVEL=error` forces error-only logging. The CLI assumes the same external tooling as the shell scripts: Git, the GitHub CLI (`gh` authenticated via `gh auth login`), `jq`, and core Unix utilities.
+Environment variables prefixed with `GITSCRIPTS_` override file values. For instance, `GITSCRIPTS_LOG_LEVEL=error` forces error-only logging, and `GITSCRIPTS_LOG_FORMAT=console` switches to console output globally. The CLI assumes the same external tooling as the shell scripts: Git, the GitHub CLI (`gh` authenticated via `gh auth login`), `jq`, and core Unix utilities.
 
 ### Command catalog
 

--- a/internal/utils/logger_factory_test.go
+++ b/internal/utils/logger_factory_test.go
@@ -1,8 +1,12 @@
 package utils_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"syscall"
 	"testing"
 
@@ -12,61 +16,105 @@ import (
 )
 
 const (
-	testLoggerFactoryCaseSupportedFormatConstant = "supported_log_level_%s"
-	testLoggerFactoryCaseUnsupportedConstant     = "unsupported_log_level"
-	testLoggerFactorySubtestTemplateConstant     = "%d_%s"
-	testInvalidLogLevelConstant                  = "invalid"
+	testLoggerFactoryCaseSupportedFormatConstant   = "supported_log_level_%s_format_%s"
+	testLoggerFactoryCaseUnsupportedLevelConstant  = "unsupported_log_level"
+	testLoggerFactoryCaseUnsupportedFormatConstant = "unsupported_log_format"
+	testLoggerFactorySubtestTemplateConstant       = "%d_%s"
+	testInvalidLogLevelConstant                    = "invalid"
+	testInvalidLogFormatConstant                   = "invalid"
+	testLogMessageConstant                         = "logger_factory_test_message"
 )
 
 func TestLoggerFactoryCreateLogger(testInstance *testing.T) {
 	testCases := []struct {
-		name              string
-		requestedLogLevel utils.LogLevel
-		expectError       bool
+		name                string
+		requestedLogLevel   utils.LogLevel
+		requestedLogFormat  utils.LogFormat
+		expectError         bool
+		expectStructuredLog bool
 	}{
 		{
-			name:              fmt.Sprintf(testLoggerFactoryCaseSupportedFormatConstant, utils.LogLevelDebug),
-			requestedLogLevel: utils.LogLevelDebug,
-			expectError:       false,
+			name:                fmt.Sprintf(testLoggerFactoryCaseSupportedFormatConstant, utils.LogLevelDebug, utils.LogFormatStructured),
+			requestedLogLevel:   utils.LogLevelDebug,
+			requestedLogFormat:  utils.LogFormatStructured,
+			expectError:         false,
+			expectStructuredLog: true,
 		},
 		{
-			name:              fmt.Sprintf(testLoggerFactoryCaseSupportedFormatConstant, utils.LogLevelInfo),
-			requestedLogLevel: utils.LogLevelInfo,
-			expectError:       false,
+			name:                fmt.Sprintf(testLoggerFactoryCaseSupportedFormatConstant, utils.LogLevelInfo, utils.LogFormatStructured),
+			requestedLogLevel:   utils.LogLevelInfo,
+			requestedLogFormat:  utils.LogFormatStructured,
+			expectError:         false,
+			expectStructuredLog: true,
 		},
 		{
-			name:              fmt.Sprintf(testLoggerFactoryCaseSupportedFormatConstant, utils.LogLevelWarn),
-			requestedLogLevel: utils.LogLevelWarn,
-			expectError:       false,
+			name:                fmt.Sprintf(testLoggerFactoryCaseSupportedFormatConstant, utils.LogLevelInfo, utils.LogFormatConsole),
+			requestedLogLevel:   utils.LogLevelInfo,
+			requestedLogFormat:  utils.LogFormatConsole,
+			expectError:         false,
+			expectStructuredLog: false,
 		},
 		{
-			name:              fmt.Sprintf(testLoggerFactoryCaseSupportedFormatConstant, utils.LogLevelError),
-			requestedLogLevel: utils.LogLevelError,
-			expectError:       false,
+			name:               testLoggerFactoryCaseUnsupportedLevelConstant,
+			requestedLogLevel:  utils.LogLevel(testInvalidLogLevelConstant),
+			requestedLogFormat: utils.LogFormatStructured,
+			expectError:        true,
 		},
 		{
-			name:              testLoggerFactoryCaseUnsupportedConstant,
-			requestedLogLevel: utils.LogLevel(testInvalidLogLevelConstant),
-			expectError:       true,
+			name:               testLoggerFactoryCaseUnsupportedFormatConstant,
+			requestedLogLevel:  utils.LogLevelInfo,
+			requestedLogFormat: utils.LogFormat(testInvalidLogFormatConstant),
+			expectError:        true,
 		},
 	}
 
 	for testCaseIndex, testCase := range testCases {
 		testInstance.Run(fmt.Sprintf(testLoggerFactorySubtestTemplateConstant, testCaseIndex, testCase.name), func(testInstance *testing.T) {
 			loggerFactory := utils.NewLoggerFactory()
-			logger, creationError := loggerFactory.CreateLogger(testCase.requestedLogLevel)
+
+			pipeReader, pipeWriter, pipeError := os.Pipe()
+			require.NoError(testInstance, pipeError)
+
+			originalStderr := os.Stderr
+			os.Stderr = pipeWriter
+
+			logger, creationError := loggerFactory.CreateLogger(testCase.requestedLogLevel, testCase.requestedLogFormat)
+
+			os.Stderr = originalStderr
+
 			if testCase.expectError {
 				require.Error(testInstance, creationError)
 				require.Nil(testInstance, logger)
+
+				require.NoError(testInstance, pipeWriter.Close())
+				require.NoError(testInstance, pipeReader.Close())
 				return
 			}
 
 			require.NoError(testInstance, creationError)
 			require.NotNil(testInstance, logger)
 
+			logger.Info(testLogMessageConstant)
 			syncError := logger.Sync()
 			if syncError != nil {
 				require.True(testInstance, errors.Is(syncError, syscall.ENOTSUP) || errors.Is(syncError, syscall.EINVAL))
+			}
+
+			require.NoError(testInstance, pipeWriter.Close())
+
+			capturedOutput, readError := io.ReadAll(pipeReader)
+			require.NoError(testInstance, readError)
+			require.NoError(testInstance, pipeReader.Close())
+
+			trimmedOutput := bytes.TrimSpace(capturedOutput)
+			require.NotEmpty(testInstance, trimmedOutput)
+			require.Contains(testInstance, string(trimmedOutput), testLogMessageConstant)
+
+			isJSONLog := json.Valid(trimmedOutput)
+			if testCase.expectStructuredLog {
+				require.True(testInstance, isJSONLog)
+			} else {
+				require.False(testInstance, isJSONLog)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add CLI configuration and flag to select between structured and console log output
- extend the logger factory to support both JSON and console encoders with validation
- cover format handling in logger factory tests and document the new option

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d2db4d0cb88327bdbb57b8c2cd99fe