### PR TITLE
Allow workflow run to reuse root configuration flag

### DIFF
--- a/internal/utils/command_context.go
+++ b/internal/utils/command_context.go
@@ -1,0 +1,37 @@
+package utils
+
+import "context"
+
+const (
+	configurationFilePathContextKeyConstant = commandContextKey("configurationFilePath")
+)
+
+type commandContextKey string
+
+// CommandContextAccessor manages values stored in command execution contexts.
+type CommandContextAccessor struct{}
+
+// NewCommandContextAccessor constructs a CommandContextAccessor instance.
+func NewCommandContextAccessor() CommandContextAccessor {
+	return CommandContextAccessor{}
+}
+
+// WithConfigurationFilePath attaches the configuration file path to the provided context.
+func (accessor CommandContextAccessor) WithConfigurationFilePath(parentContext context.Context, configurationFilePath string) context.Context {
+	if parentContext == nil {
+		parentContext = context.Background()
+	}
+	return context.WithValue(parentContext, configurationFilePathContextKeyConstant, configurationFilePath)
+}
+
+// ConfigurationFilePath extracts the configuration file path from the provided context.
+func (accessor CommandContextAccessor) ConfigurationFilePath(executionContext context.Context) (string, bool) {
+	if executionContext == nil {
+		return "", false
+	}
+	configurationFilePath, configurationFilePathAvailable := executionContext.Value(configurationFilePathContextKeyConstant).(string)
+	if !configurationFilePathAvailable {
+		return "", false
+	}
+	return configurationFilePath, true
+}

--- a/tests/workflow_integration_test.go
+++ b/tests/workflow_integration_test.go
@@ -18,6 +18,7 @@ const (
 	workflowIntegrationRunSubcommand           = "run"
 	workflowIntegrationModulePathConstant      = "."
 	workflowIntegrationLogLevelFlag            = "--log-level"
+	workflowIntegrationConfigFlag              = "--config"
 	workflowIntegrationErrorLevel              = "error"
 	workflowIntegrationGroup                   = "workflow"
 	workflowIntegrationCommand                 = "run"
@@ -54,9 +55,10 @@ const (
 	workflowIntegrationCSVHeader               = "final_github_repo,folder_name,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical\n"
 	workflowIntegrationSubtestNameTemplate     = "%d_%s"
 	workflowIntegrationDefaultCaseName         = "protocol_migrate_audit"
+	workflowIntegrationConfigFlagCaseName      = "config_flag_without_positional"
 	workflowIntegrationHelpCaseName            = "workflow_help_missing_configuration"
 	workflowIntegrationUsageSnippet            = "workflow run [workflow]"
-	workflowIntegrationMissingConfigMessage    = "workflow configuration path required"
+	workflowIntegrationMissingConfigMessage    = "workflow configuration path required; provide a positional argument or --config flag"
 )
 
 func TestWorkflowRunIntegration(testInstance *testing.T) {
@@ -65,9 +67,20 @@ func TestWorkflowRunIntegration(testInstance *testing.T) {
 	repositoryRoot := filepath.Dir(workingDirectory)
 
 	testCases := []struct {
-		name string
+		name                         string
+		includePositionalWorkflowArg bool
+		includeConfigFlag            bool
 	}{
-		{name: workflowIntegrationDefaultCaseName},
+		{
+			name:                         workflowIntegrationDefaultCaseName,
+			includePositionalWorkflowArg: true,
+			includeConfigFlag:            false,
+		},
+		{
+			name:                         workflowIntegrationConfigFlagCaseName,
+			includePositionalWorkflowArg: false,
+			includeConfigFlag:            true,
+		},
 	}
 
 	for testCaseIndex := range testCases {
@@ -101,13 +114,26 @@ func TestWorkflowRunIntegration(testInstance *testing.T) {
 				workflowIntegrationModulePathConstant,
 				workflowIntegrationLogLevelFlag,
 				workflowIntegrationErrorLevel,
+			}
+
+			if testCase.includeConfigFlag {
+				commandArguments = append(commandArguments, workflowIntegrationConfigFlag, configPath)
+			}
+
+			commandArguments = append(commandArguments,
 				workflowIntegrationGroup,
 				workflowIntegrationCommand,
-				configPath,
+			)
+
+			if testCase.includePositionalWorkflowArg {
+				commandArguments = append(commandArguments, configPath)
+			}
+
+			commandArguments = append(commandArguments,
 				workflowIntegrationRootsFlag,
 				tempDirectory,
 				workflowIntegrationYesFlag,
-			}
+			)
 
 			rawOutput := runIntegrationCommand(subtest, repositoryRoot, extendedPath, workflowIntegrationTimeout, commandArguments)
 			filteredOutput := filterStructuredOutput(rawOutput)


### PR DESCRIPTION
## Summary
- propagate the resolved configuration file path into the Cobra command context after initialization
- expose a reusable command context accessor and update the workflow run command to fall back to the stored configuration path
- cover the new behavior with an integration test that executes `workflow run` using only the `--config` flag and refresh the related help text

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5b2bab7c88327a35015f5311bb3e3