### PR TITLE
Add rename command configuration defaults and tests

### DIFF
--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -193,6 +193,9 @@ func NewApplication() *Application {
 			return application.logger
 		},
 		HumanReadableLoggingProvider: application.humanReadableLoggingEnabled,
+		ConfigurationProvider: func() repos.RenameConfiguration {
+			return application.configuration.Tools.Repos.Rename
+		},
 	}
 	renameCommand, renameBuildError := renameBuilder.Build()
 	if renameBuildError == nil {

--- a/cmd/cli/repos/remotes_test.go
+++ b/cmd/cli/repos/remotes_test.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/zap"
 
 	repos "github.com/temirov/git_scripts/cmd/cli/repos"
-	"github.com/temirov/git_scripts/internal/execshell"
 	"github.com/temirov/git_scripts/internal/githubcli"
 	"github.com/temirov/git_scripts/internal/repos/shared"
 )
@@ -109,74 +108,4 @@ func TestRemotesCommandConfigurationPrecedence(testInstance *testing.T) {
 			require.Equal(subtest, testCase.expectRemoteUpdates, len(manager.setCalls))
 		})
 	}
-}
-
-type fakeRepositoryDiscoverer struct {
-	repositories  []string
-	receivedRoots []string
-}
-
-func (discoverer *fakeRepositoryDiscoverer) DiscoverRepositories(roots []string) ([]string, error) {
-	discoverer.receivedRoots = append([]string{}, roots...)
-	return append([]string{}, discoverer.repositories...), nil
-}
-
-type fakeGitExecutor struct{}
-
-func (executor *fakeGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
-	if len(details.Arguments) > 0 && details.Arguments[0] == "rev-parse" {
-		return execshell.ExecutionResult{StandardOutput: "true\n"}, nil
-	}
-	return execshell.ExecutionResult{StandardOutput: ""}, nil
-}
-
-func (executor *fakeGitExecutor) ExecuteGitHubCLI(_ context.Context, _ execshell.CommandDetails) (execshell.ExecutionResult, error) {
-	return execshell.ExecutionResult{StandardOutput: ""}, nil
-}
-
-type fakeGitRepositoryManager struct {
-	remoteURL     string
-	currentBranch string
-	setCalls      []remoteUpdateCall
-}
-
-type remoteUpdateCall struct {
-	repositoryPath string
-	remoteURL      string
-}
-
-func (manager *fakeGitRepositoryManager) CheckCleanWorktree(context.Context, string) (bool, error) {
-	return true, nil
-}
-
-func (manager *fakeGitRepositoryManager) GetCurrentBranch(context.Context, string) (string, error) {
-	return manager.currentBranch, nil
-}
-
-func (manager *fakeGitRepositoryManager) GetRemoteURL(context.Context, string, string) (string, error) {
-	return manager.remoteURL, nil
-}
-
-func (manager *fakeGitRepositoryManager) SetRemoteURL(_ context.Context, repositoryPath string, _ string, remoteURL string) error {
-	manager.setCalls = append(manager.setCalls, remoteUpdateCall{repositoryPath: repositoryPath, remoteURL: remoteURL})
-	manager.remoteURL = remoteURL
-	return nil
-}
-
-type fakeGitHubResolver struct {
-	metadata githubcli.RepositoryMetadata
-}
-
-func (resolver *fakeGitHubResolver) ResolveRepoMetadata(context.Context, string) (githubcli.RepositoryMetadata, error) {
-	return resolver.metadata, nil
-}
-
-type recordingPrompter struct {
-	confirmResult bool
-	calls         int
-}
-
-func (prompter *recordingPrompter) Confirm(string) (bool, error) {
-	prompter.calls++
-	return prompter.confirmResult, nil
 }

--- a/cmd/cli/repos/rename_test.go
+++ b/cmd/cli/repos/rename_test.go
@@ -1,0 +1,213 @@
+package repos_test
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	repos "github.com/temirov/git_scripts/cmd/cli/repos"
+	"github.com/temirov/git_scripts/internal/githubcli"
+	"github.com/temirov/git_scripts/internal/repos/shared"
+)
+
+const (
+	renameDryRunFlagConstant            = "--dry-run"
+	renameAssumeYesFlagConstant         = "--yes"
+	renameRequireCleanFlagConstant      = "--require-clean"
+	renameConfiguredRootConstant        = "/tmp/rename-config-root"
+	renameCLIRepositoryRootConstant     = "/tmp/rename-cli-root"
+	renameParentDirectoryPathConstant   = "/tmp"
+	renameExistingFolderNameConstant    = "rename-folder-current"
+	renameDesiredFolderNameConstant     = "rename-folder-canonical"
+	renameOriginURLConstant             = "https://github.com/example/rename-folder-current.git"
+	renameCanonicalRepositoryConstant   = "example/" + renameDesiredFolderNameConstant
+	renameMetadataDefaultBranchConstant = "main"
+	renameLocalBranchConstant           = "feature/example"
+)
+
+var (
+	renameDiscoveredRepositoryPath = filepath.Join(renameParentDirectoryPathConstant, renameExistingFolderNameConstant)
+)
+
+func TestRenameCommandConfigurationPrecedence(testInstance *testing.T) {
+	testCases := []struct {
+		name                string
+		configuration       *repos.RenameConfiguration
+		arguments           []string
+		expectedRoots       []string
+		expectedPromptCalls int
+		expectedRenameCalls int
+		expectedCleanChecks int
+	}{
+		{
+			name:                "defaults_apply_without_configuration",
+			configuration:       nil,
+			arguments:           []string{},
+			expectedRoots:       []string{"."},
+			expectedPromptCalls: 1,
+			expectedRenameCalls: 1,
+			expectedCleanChecks: 0,
+		},
+		{
+			name: "configuration_enables_dry_run",
+			configuration: &repos.RenameConfiguration{
+				DryRun:               true,
+				AssumeYes:            true,
+				RequireCleanWorktree: true,
+				RepositoryRoots:      []string{renameConfiguredRootConstant},
+			},
+			arguments:           []string{},
+			expectedRoots:       []string{renameConfiguredRootConstant},
+			expectedPromptCalls: 0,
+			expectedRenameCalls: 0,
+			expectedCleanChecks: 1,
+		},
+		{
+			name: "flags_override_configuration",
+			configuration: &repos.RenameConfiguration{
+				DryRun:               false,
+				AssumeYes:            false,
+				RequireCleanWorktree: false,
+				RepositoryRoots:      []string{renameConfiguredRootConstant},
+			},
+			arguments: []string{
+				renameDryRunFlagConstant,
+				renameAssumeYesFlagConstant,
+				renameRequireCleanFlagConstant,
+				renameCLIRepositoryRootConstant,
+			},
+			expectedRoots:       []string{renameCLIRepositoryRootConstant},
+			expectedPromptCalls: 0,
+			expectedRenameCalls: 0,
+			expectedCleanChecks: 1,
+		},
+		{
+			name: "flag_enables_assume_yes_without_dry_run",
+			configuration: &repos.RenameConfiguration{
+				DryRun:               false,
+				AssumeYes:            false,
+				RequireCleanWorktree: false,
+				RepositoryRoots:      []string{renameConfiguredRootConstant},
+			},
+			arguments: []string{
+				renameAssumeYesFlagConstant,
+			},
+			expectedRoots:       []string{renameConfiguredRootConstant},
+			expectedPromptCalls: 0,
+			expectedRenameCalls: 1,
+			expectedCleanChecks: 0,
+		},
+	}
+
+	for testCaseIndex := range testCases {
+		testCase := testCases[testCaseIndex]
+		testInstance.Run(testCase.name, func(subtest *testing.T) {
+			discoverer := &fakeRepositoryDiscoverer{repositories: []string{renameDiscoveredRepositoryPath}}
+			executor := &fakeGitExecutor{}
+			manager := &fakeGitRepositoryManager{
+				remoteURL:        renameOriginURLConstant,
+				currentBranch:    renameLocalBranchConstant,
+				cleanWorktree:    true,
+				cleanWorktreeSet: true,
+			}
+			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: renameCanonicalRepositoryConstant, DefaultBranch: renameMetadataDefaultBranchConstant}}
+			prompter := &recordingPrompter{confirmResult: true}
+			fileSystem := newRecordingFileSystem([]string{renameParentDirectoryPathConstant, renameDiscoveredRepositoryPath})
+
+			var configurationProvider func() repos.RenameConfiguration
+			if testCase.configuration != nil {
+				configurationCopy := *testCase.configuration
+				configurationProvider = func() repos.RenameConfiguration {
+					return configurationCopy
+				}
+			}
+
+			builder := repos.RenameCommandBuilder{
+				LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+				Discoverer:     discoverer,
+				GitExecutor:    executor,
+				GitManager:     manager,
+				GitHubResolver: resolver,
+				FileSystem:     fileSystem,
+				PrompterFactory: func(*cobra.Command) shared.ConfirmationPrompter {
+					return prompter
+				},
+				HumanReadableLoggingProvider: func() bool { return false },
+				ConfigurationProvider:        configurationProvider,
+			}
+
+			command, buildError := builder.Build()
+			require.NoError(subtest, buildError)
+
+			command.SetContext(context.Background())
+			command.SetOut(&bytes.Buffer{})
+			command.SetErr(&bytes.Buffer{})
+			command.SetArgs(testCase.arguments)
+
+			executionError := command.Execute()
+			require.NoError(subtest, executionError)
+
+			require.Equal(subtest, testCase.expectedRoots, discoverer.receivedRoots)
+			require.Equal(subtest, testCase.expectedPromptCalls, prompter.calls)
+			require.Equal(subtest, testCase.expectedRenameCalls, len(fileSystem.renameOperations))
+			require.Equal(subtest, testCase.expectedCleanChecks, manager.checkCleanCalls)
+		})
+	}
+}
+
+type renameOperation struct {
+	oldPath string
+	newPath string
+}
+
+type recordingFileSystem struct {
+	existingPaths    map[string]bool
+	renameOperations []renameOperation
+}
+
+func newRecordingFileSystem(initialPaths []string) *recordingFileSystem {
+	pathMap := make(map[string]bool, len(initialPaths))
+	for _, path := range initialPaths {
+		pathMap[path] = true
+	}
+	return &recordingFileSystem{existingPaths: pathMap}
+}
+
+func (fileSystem *recordingFileSystem) Stat(path string) (fs.FileInfo, error) {
+	if fileSystem.existingPaths[path] {
+		return staticFileInfo{name: path}, nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (fileSystem *recordingFileSystem) Rename(oldPath string, newPath string) error {
+	if !fileSystem.existingPaths[oldPath] {
+		return fs.ErrNotExist
+	}
+	fileSystem.renameOperations = append(fileSystem.renameOperations, renameOperation{oldPath: oldPath, newPath: newPath})
+	delete(fileSystem.existingPaths, oldPath)
+	fileSystem.existingPaths[newPath] = true
+	return nil
+}
+
+func (fileSystem *recordingFileSystem) Abs(path string) (string, error) {
+	return path, nil
+}
+
+type staticFileInfo struct {
+	name string
+}
+
+func (info staticFileInfo) Name() string  { return info.name }
+func (staticFileInfo) Size() int64        { return 0 }
+func (staticFileInfo) Mode() fs.FileMode  { return fs.ModeDir }
+func (staticFileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (staticFileInfo) IsDir() bool        { return true }
+func (staticFileInfo) Sys() any           { return nil }

--- a/cmd/cli/repos/test_helpers_test.go
+++ b/cmd/cli/repos/test_helpers_test.go
@@ -1,0 +1,85 @@
+package repos_test
+
+import (
+	"context"
+
+	"github.com/temirov/git_scripts/internal/execshell"
+	"github.com/temirov/git_scripts/internal/githubcli"
+)
+
+type fakeRepositoryDiscoverer struct {
+	repositories  []string
+	receivedRoots []string
+}
+
+func (discoverer *fakeRepositoryDiscoverer) DiscoverRepositories(roots []string) ([]string, error) {
+	discoverer.receivedRoots = append([]string{}, roots...)
+	return append([]string{}, discoverer.repositories...), nil
+}
+
+type fakeGitExecutor struct{}
+
+func (executor *fakeGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	if len(details.Arguments) > 0 && details.Arguments[0] == "rev-parse" {
+		return execshell.ExecutionResult{StandardOutput: "true\n"}, nil
+	}
+	return execshell.ExecutionResult{StandardOutput: ""}, nil
+}
+
+func (executor *fakeGitExecutor) ExecuteGitHubCLI(_ context.Context, _ execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{StandardOutput: ""}, nil
+}
+
+type remoteUpdateCall struct {
+	repositoryPath string
+	remoteURL      string
+}
+
+type fakeGitRepositoryManager struct {
+	remoteURL        string
+	currentBranch    string
+	setCalls         []remoteUpdateCall
+	cleanWorktree    bool
+	cleanWorktreeSet bool
+	checkCleanCalls  int
+}
+
+func (manager *fakeGitRepositoryManager) CheckCleanWorktree(context.Context, string) (bool, error) {
+	manager.checkCleanCalls++
+	if manager.cleanWorktreeSet {
+		return manager.cleanWorktree, nil
+	}
+	return true, nil
+}
+
+func (manager *fakeGitRepositoryManager) GetCurrentBranch(context.Context, string) (string, error) {
+	return manager.currentBranch, nil
+}
+
+func (manager *fakeGitRepositoryManager) GetRemoteURL(context.Context, string, string) (string, error) {
+	return manager.remoteURL, nil
+}
+
+func (manager *fakeGitRepositoryManager) SetRemoteURL(_ context.Context, repositoryPath string, _ string, remoteURL string) error {
+	manager.setCalls = append(manager.setCalls, remoteUpdateCall{repositoryPath: repositoryPath, remoteURL: remoteURL})
+	manager.remoteURL = remoteURL
+	return nil
+}
+
+type fakeGitHubResolver struct {
+	metadata githubcli.RepositoryMetadata
+}
+
+func (resolver *fakeGitHubResolver) ResolveRepoMetadata(context.Context, string) (githubcli.RepositoryMetadata, error) {
+	return resolver.metadata, nil
+}
+
+type recordingPrompter struct {
+	confirmResult bool
+	calls         int
+}
+
+func (prompter *recordingPrompter) Confirm(string) (bool, error) {
+	prompter.calls++
+	return prompter.confirmResult, nil
+}


### PR DESCRIPTION
## Summary
- add rename configuration with defaults and sanitizers for repository tools configuration
- wire the rename configuration through the CLI application and command builder
- ensure the rename command honors configuration precedence and add table-driven tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d6194e8dfc83279ce248fd14d5634e