### PR TITLE
Expand tilde path handling for root sanitization

### DIFF
--- a/cmd/cli/workflow/configuration.go
+++ b/cmd/cli/workflow/configuration.go
@@ -1,6 +1,12 @@
 package workflow
 
-import "strings"
+import (
+	"strings"
+
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
+)
+
+var workflowConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
 
 // CommandConfiguration captures configuration values for workflow.
 type CommandConfiguration struct {
@@ -17,8 +23,8 @@ func DefaultCommandConfiguration() CommandConfiguration {
 	}
 }
 
-// sanitize normalizes configuration values.
-func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+// Sanitize normalizes configuration values.
+func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
 	sanitized.Roots = sanitizeRoots(configuration.Roots)
 	return sanitized
@@ -26,12 +32,13 @@ func (configuration CommandConfiguration) sanitize() CommandConfiguration {
 
 func sanitizeRoots(raw []string) []string {
 	trimmed := make([]string, 0, len(raw))
-	for _, candidate := range raw {
-		value := strings.TrimSpace(candidate)
-		if len(value) == 0 {
+	for _, rawRoot := range raw {
+		trimmedRoot := strings.TrimSpace(rawRoot)
+		if len(trimmedRoot) == 0 {
 			continue
 		}
-		trimmed = append(trimmed, value)
+		expandedRoot := workflowConfigurationHomeDirectoryExpander.Expand(trimmedRoot)
+		trimmed = append(trimmed, expandedRoot)
 	}
 	return trimmed
 }

--- a/cmd/cli/workflow/helpers.go
+++ b/cmd/cli/workflow/helpers.go
@@ -14,7 +14,8 @@ type LoggerProvider func() *zap.Logger
 // PrompterFactory constructs confirmation prompters scoped to a command.
 type PrompterFactory func(*cobra.Command) shared.ConfirmationPrompter
 
-func determineRoots(flagValues []string, configured []string, preferFlag bool) []string {
+// DetermineRoots selects the effective repository roots from flags and configuration.
+func DetermineRoots(flagValues []string, configured []string, preferFlag bool) []string {
 	if preferFlag {
 		trimmed := sanitizeRoots(flagValues)
 		if len(trimmed) > 0 {
@@ -27,9 +28,9 @@ func determineRoots(flagValues []string, configured []string, preferFlag bool) [
 		return configuredRoots
 	}
 
-	trimmed := sanitizeRoots(flagValues)
-	if len(trimmed) > 0 {
-		return trimmed
+	trimmedFlagRoots := sanitizeRoots(flagValues)
+	if len(trimmedFlagRoots) > 0 {
+		return trimmedFlagRoots
 	}
 
 	return nil

--- a/cmd/cli/workflow/helpers_test.go
+++ b/cmd/cli/workflow/helpers_test.go
@@ -1,0 +1,70 @@
+package workflow_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/cmd/cli/workflow"
+)
+
+const (
+	workflowHelpersAbsoluteSuffixConstant = "workflow-helpers-absolute"
+	workflowHelpersRelativePathConstant   = "workflow/helpers/relative"
+	workflowHelpersTildePathConstant      = "~/workflow/helpers/home"
+	workflowHelpersTildePrefixConstant    = "~/"
+	workflowHelpersWhitespace             = "   "
+)
+
+func TestDetermineRootsExpandsHomeDirectoryValues(testInstance *testing.T) {
+	testInstance.Helper()
+
+	homeDirectory, homeDirectoryError := os.UserHomeDir()
+	require.NoError(testInstance, homeDirectoryError)
+
+	trimmedTilde := strings.TrimPrefix(workflowHelpersTildePathConstant, workflowHelpersTildePrefixConstant)
+	expectedTilde := filepath.Join(homeDirectory, trimmedTilde)
+
+	temporaryRoot := testInstance.TempDir()
+	absoluteRoot := filepath.Join(temporaryRoot, workflowHelpersAbsoluteSuffixConstant)
+
+	testCases := []struct {
+		name           string
+		flagValues     []string
+		configured     []string
+		preferFlag     bool
+		expectedResult []string
+	}{
+		{
+			name:           "prefer_flag_values_with_home_expansion",
+			flagValues:     []string{workflowHelpersWhitespace + workflowHelpersTildePathConstant + workflowHelpersWhitespace},
+			configured:     []string{absoluteRoot},
+			preferFlag:     true,
+			expectedResult: []string{expectedTilde},
+		},
+		{
+			name:           "configured_values_expand_home_directory",
+			flagValues:     []string{workflowHelpersRelativePathConstant},
+			configured:     []string{workflowHelpersTildePathConstant},
+			preferFlag:     false,
+			expectedResult: []string{expectedTilde},
+		},
+		{
+			name:           "fall_back_to_flag_values_when_configuration_empty",
+			flagValues:     []string{workflowHelpersRelativePathConstant},
+			configured:     []string{workflowHelpersWhitespace},
+			preferFlag:     false,
+			expectedResult: []string{workflowHelpersRelativePathConstant},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(subTest *testing.T) {
+			result := workflow.DetermineRoots(testCase.flagValues, testCase.configured, testCase.preferFlag)
+			require.Equal(subTest, testCase.expectedResult, result)
+		})
+	}
+}

--- a/cmd/cli/workflow/run.go
+++ b/cmd/cli/workflow/run.go
@@ -134,7 +134,7 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 
 	rootValues, _ := command.Flags().GetStringSlice(rootsFlagNameConstant)
 	preferFlagRoots := command != nil && command.Flags().Changed(rootsFlagNameConstant)
-	roots := determineRoots(rootValues, commandConfiguration.Roots, preferFlagRoots)
+	roots := DetermineRoots(rootValues, commandConfiguration.Roots, preferFlagRoots)
 	if len(roots) == 0 {
 		if helpError := displayCommandHelp(command); helpError != nil {
 			return helpError
@@ -163,5 +163,5 @@ func (builder *CommandBuilder) resolveConfiguration() CommandConfiguration {
 	}
 
 	provided := builder.ConfigurationProvider()
-	return provided.sanitize()
+	return provided.Sanitize()
 }

--- a/internal/audit/command.go
+++ b/internal/audit/command.go
@@ -129,5 +129,5 @@ func (builder *CommandBuilder) resolveConfiguration() CommandConfiguration {
 		return DefaultCommandConfiguration()
 	}
 	provided := builder.ConfigurationProvider()
-	return provided.sanitize()
+	return provided.Sanitize()
 }

--- a/internal/audit/configuration.go
+++ b/internal/audit/configuration.go
@@ -1,6 +1,12 @@
 package audit
 
-import "strings"
+import (
+	"strings"
+
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
+)
+
+var auditConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
 
 // CommandConfiguration captures persistent settings for the audit command.
 type CommandConfiguration struct {
@@ -16,8 +22,8 @@ func DefaultCommandConfiguration() CommandConfiguration {
 	}
 }
 
-// sanitize trims whitespace and applies defaults to unset configuration values.
-func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+// Sanitize trims whitespace and applies defaults to unset configuration values.
+func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
 
 	sanitized.Roots = sanitizeRoots(configuration.Roots)
@@ -27,12 +33,13 @@ func (configuration CommandConfiguration) sanitize() CommandConfiguration {
 
 func sanitizeRoots(raw []string) []string {
 	sanitized := make([]string, 0, len(raw))
-	for index := range raw {
-		trimmed := strings.TrimSpace(raw[index])
+	for rawRootIndex := range raw {
+		trimmed := strings.TrimSpace(raw[rawRootIndex])
 		if len(trimmed) == 0 {
 			continue
 		}
-		sanitized = append(sanitized, trimmed)
+		expandedRoot := auditConfigurationHomeDirectoryExpander.Expand(trimmed)
+		sanitized = append(sanitized, expandedRoot)
 	}
 	return sanitized
 }

--- a/internal/audit/configuration_test.go
+++ b/internal/audit/configuration_test.go
@@ -1,0 +1,68 @@
+package audit_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/internal/audit"
+)
+
+const (
+	auditConfigurationAbsoluteSuffixConstant = "audit-configuration-absolute"
+	auditConfigurationRelativePathConstant   = "repositories/relative"
+	auditConfigurationTildePathConstant      = "~/repositories/home"
+	auditConfigurationTildePrefixConstant    = "~/"
+	auditConfigurationWhitespacePrefix       = "   "
+	auditConfigurationWhitespaceSuffix       = "  "
+)
+
+func TestCommandConfigurationSanitizeExpandsHomeDirectories(testInstance *testing.T) {
+	testInstance.Helper()
+
+	homeDirectory, homeDirectoryError := os.UserHomeDir()
+	require.NoError(testInstance, homeDirectoryError)
+
+	temporaryRoot := testInstance.TempDir()
+	absolutePath := filepath.Join(temporaryRoot, auditConfigurationAbsoluteSuffixConstant)
+	trimmedTilde := strings.TrimPrefix(auditConfigurationTildePathConstant, auditConfigurationTildePrefixConstant)
+	expectedTildePath := filepath.Join(homeDirectory, trimmedTilde)
+
+	testCases := []struct {
+		name           string
+		roots          []string
+		expectedResult []string
+	}{
+		{
+			name:           "absolute_paths_preserved",
+			roots:          []string{absolutePath},
+			expectedResult: []string{absolutePath},
+		},
+		{
+			name:           "relative_paths_preserved",
+			roots:          []string{auditConfigurationRelativePathConstant},
+			expectedResult: []string{auditConfigurationRelativePathConstant},
+		},
+		{
+			name:           "tilde_paths_expanded",
+			roots:          []string{auditConfigurationTildePathConstant},
+			expectedResult: []string{expectedTildePath},
+		},
+		{
+			name:           "whitespace_trimmed_before_expansion",
+			roots:          []string{auditConfigurationWhitespacePrefix + auditConfigurationTildePathConstant + auditConfigurationWhitespaceSuffix},
+			expectedResult: []string{expectedTildePath},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(subTest *testing.T) {
+			configuration := audit.CommandConfiguration{Roots: testCase.roots}
+			sanitized := configuration.Sanitize()
+			require.Equal(subTest, testCase.expectedResult, sanitized.Roots)
+		})
+	}
+}

--- a/internal/branches/command.go
+++ b/internal/branches/command.go
@@ -249,5 +249,5 @@ func (builder *CommandBuilder) resolveConfiguration() CommandConfiguration {
 	}
 
 	provided := builder.ConfigurationProvider()
-	return provided.sanitize()
+	return provided.Sanitize()
 }

--- a/internal/branches/configuration.go
+++ b/internal/branches/configuration.go
@@ -1,6 +1,12 @@
 package branches
 
-import "strings"
+import (
+	"strings"
+
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
+)
+
+var branchConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
 
 // CommandConfiguration captures configuration values for the branch cleanup command.
 type CommandConfiguration struct {
@@ -20,8 +26,8 @@ func DefaultCommandConfiguration() CommandConfiguration {
 	}
 }
 
-// sanitize trims configuration values without applying implicit defaults.
-func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+// Sanitize trims configuration values without applying implicit defaults.
+func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
 
 	sanitized.RemoteName = strings.TrimSpace(configuration.RemoteName)
@@ -32,12 +38,13 @@ func (configuration CommandConfiguration) sanitize() CommandConfiguration {
 
 func sanitizeRoots(raw []string) []string {
 	sanitized := make([]string, 0, len(raw))
-	for _, candidate := range raw {
-		trimmed := strings.TrimSpace(candidate)
+	for _, rootCandidate := range raw {
+		trimmed := strings.TrimSpace(rootCandidate)
 		if len(trimmed) == 0 {
 			continue
 		}
-		sanitized = append(sanitized, trimmed)
+		expandedRoot := branchConfigurationHomeDirectoryExpander.Expand(trimmed)
+		sanitized = append(sanitized, expandedRoot)
 	}
 	return sanitized
 }

--- a/internal/migrate/command.go
+++ b/internal/migrate/command.go
@@ -280,7 +280,7 @@ func (builder *CommandBuilder) resolveConfiguration() CommandConfiguration {
 	}
 
 	provided := builder.ConfigurationProvider()
-	return provided.sanitize()
+	return provided.Sanitize()
 }
 
 func (builder *CommandBuilder) logMigrationFailure(logger *zap.Logger, repositoryPath string, failure error) {

--- a/internal/migrate/configuration.go
+++ b/internal/migrate/configuration.go
@@ -1,6 +1,12 @@
 package migrate
 
-import "strings"
+import (
+	"strings"
+
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
+)
+
+var migrateConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
 
 // CommandConfiguration captures persisted configuration for branch migration.
 type CommandConfiguration struct {
@@ -16,8 +22,8 @@ func DefaultCommandConfiguration() CommandConfiguration {
 	}
 }
 
-// sanitize trims configured values and removes empty entries.
-func (configuration CommandConfiguration) sanitize() CommandConfiguration {
+// Sanitize trims configured values and removes empty entries.
+func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
 	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
 	return sanitized
@@ -25,12 +31,13 @@ func (configuration CommandConfiguration) sanitize() CommandConfiguration {
 
 func sanitizeRoots(raw []string) []string {
 	sanitized := make([]string, 0, len(raw))
-	for _, candidate := range raw {
-		trimmed := strings.TrimSpace(candidate)
+	for _, candidateRoot := range raw {
+		trimmed := strings.TrimSpace(candidateRoot)
 		if len(trimmed) == 0 {
 			continue
 		}
-		sanitized = append(sanitized, trimmed)
+		expandedRoot := migrateConfigurationHomeDirectoryExpander.Expand(trimmed)
+		sanitized = append(sanitized, expandedRoot)
 	}
 	return sanitized
 }

--- a/internal/packages/command.go
+++ b/internal/packages/command.go
@@ -249,7 +249,7 @@ func (builder *CommandBuilder) resolveConfiguration() Configuration {
 		configuration = builder.ConfigurationProvider()
 	}
 
-	return configuration.sanitize()
+	return configuration.Sanitize()
 }
 
 func (builder *CommandBuilder) resolvePurgeService(logger *zap.Logger) (PurgeExecutor, error) {

--- a/internal/packages/configuration.go
+++ b/internal/packages/configuration.go
@@ -1,6 +1,12 @@
 package packages
 
-import "strings"
+import (
+	"strings"
+
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
+)
+
+var packagesConfigurationHomeDirectoryExpander = pathutils.NewHomeExpander()
 
 const (
 	defaultTokenSourceValueConstant = "env:GITHUB_PACKAGES_TOKEN"
@@ -25,14 +31,15 @@ func DefaultConfiguration() Configuration {
 	}
 }
 
-// sanitize trims configured values and removes empty entries.
-func (configuration Configuration) sanitize() Configuration {
+// Sanitize trims configured values and removes empty entries.
+func (configuration Configuration) Sanitize() Configuration {
 	sanitized := configuration
-	sanitized.Purge = configuration.Purge.sanitize()
+	sanitized.Purge = configuration.Purge.Sanitize()
 	return sanitized
 }
 
-func (configuration PurgeConfiguration) sanitize() PurgeConfiguration {
+// Sanitize trims purge configuration values and removes empty entries.
+func (configuration PurgeConfiguration) Sanitize() PurgeConfiguration {
 	sanitized := configuration
 	sanitized.RepositoryRoots = sanitizeRoots(configuration.RepositoryRoots)
 	return sanitized
@@ -45,7 +52,8 @@ func sanitizeRoots(candidateRoots []string) []string {
 		if len(trimmedRoot) == 0 {
 			continue
 		}
-		sanitizedRoots = append(sanitizedRoots, trimmedRoot)
+		expandedRoot := packagesConfigurationHomeDirectoryExpander.Expand(trimmedRoot)
+		sanitizedRoots = append(sanitizedRoots, expandedRoot)
 	}
 	if len(sanitizedRoots) == 0 {
 		return nil

--- a/internal/packages/configuration_test.go
+++ b/internal/packages/configuration_test.go
@@ -1,0 +1,61 @@
+package packages_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/git_scripts/internal/packages"
+)
+
+const (
+	packagesConfigurationAbsoluteSuffixConstant = "packages-configuration-absolute"
+	packagesConfigurationRelativePathConstant   = "packages/repositories"
+	packagesConfigurationTildePathConstant      = "~/packages/repositories"
+	packagesConfigurationTildePrefixConstant    = "~/"
+)
+
+func TestConfigurationSanitizeExpandsHomeDirectories(testInstance *testing.T) {
+	testInstance.Helper()
+
+	homeDirectory, homeDirectoryError := os.UserHomeDir()
+	require.NoError(testInstance, homeDirectoryError)
+
+	temporaryRoot := testInstance.TempDir()
+	absolutePath := filepath.Join(temporaryRoot, packagesConfigurationAbsoluteSuffixConstant)
+	trimmedTilde := strings.TrimPrefix(packagesConfigurationTildePathConstant, packagesConfigurationTildePrefixConstant)
+	expectedTildePath := filepath.Join(homeDirectory, trimmedTilde)
+
+	testCases := []struct {
+		name           string
+		roots          []string
+		expectedResult []string
+	}{
+		{
+			name:           "absolute_paths_preserved",
+			roots:          []string{absolutePath},
+			expectedResult: []string{absolutePath},
+		},
+		{
+			name:           "relative_paths_preserved",
+			roots:          []string{packagesConfigurationRelativePathConstant},
+			expectedResult: []string{packagesConfigurationRelativePathConstant},
+		},
+		{
+			name:           "tilde_paths_expanded",
+			roots:          []string{packagesConfigurationTildePathConstant},
+			expectedResult: []string{expectedTildePath},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(subTest *testing.T) {
+			configuration := packages.Configuration{Purge: packages.PurgeConfiguration{RepositoryRoots: testCase.roots}}
+			sanitized := configuration.Sanitize()
+			require.Equal(subTest, testCase.expectedResult, sanitized.Purge.RepositoryRoots)
+		})
+	}
+}

--- a/internal/utils/path/home_expander.go
+++ b/internal/utils/path/home_expander.go
@@ -1,0 +1,83 @@
+package pathutils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	tildeSymbolConstant             = "~"
+	tildeForwardSlashPrefixConstant = "~/"
+)
+
+var tildeWithPathSeparatorPrefix = tildeSymbolConstant + string(os.PathSeparator)
+
+// HomeDirectoryProvider resolves the current user's home directory path.
+type HomeDirectoryProvider func() (string, error)
+
+// HomeExpander converts user home shortcuts to absolute paths.
+type HomeExpander struct {
+	homeDirectoryProvider HomeDirectoryProvider
+	homeDirectory         string
+	homeDirectoryError    error
+	initializationGuard   sync.Once
+}
+
+// NewHomeExpander constructs a HomeExpander using the operating system lookup.
+func NewHomeExpander() *HomeExpander {
+	return NewHomeExpanderWithProvider(os.UserHomeDir)
+}
+
+// NewHomeExpanderWithProvider constructs a HomeExpander with a custom provider.
+func NewHomeExpanderWithProvider(provider HomeDirectoryProvider) *HomeExpander {
+	if provider == nil {
+		provider = os.UserHomeDir
+	}
+	return &HomeExpander{homeDirectoryProvider: provider}
+}
+
+// Expand resolves leading tilde prefixes to the user's home directory.
+func (expander *HomeExpander) Expand(candidatePath string) string {
+	if expander == nil {
+		return candidatePath
+	}
+	if len(candidatePath) == 0 {
+		return candidatePath
+	}
+	if !strings.HasPrefix(candidatePath, tildeSymbolConstant) {
+		return candidatePath
+	}
+
+	resolvedHomeDirectory := expander.resolveHomeDirectory()
+	if len(resolvedHomeDirectory) == 0 {
+		return candidatePath
+	}
+
+	if candidatePath == tildeSymbolConstant {
+		return resolvedHomeDirectory
+	}
+
+	if strings.HasPrefix(candidatePath, tildeForwardSlashPrefixConstant) {
+		relativePath := strings.TrimPrefix(candidatePath, tildeForwardSlashPrefixConstant)
+		return filepath.Join(resolvedHomeDirectory, relativePath)
+	}
+
+	if tildeWithPathSeparatorPrefix != tildeForwardSlashPrefixConstant && strings.HasPrefix(candidatePath, tildeWithPathSeparatorPrefix) {
+		relativePath := strings.TrimPrefix(candidatePath, tildeWithPathSeparatorPrefix)
+		return filepath.Join(resolvedHomeDirectory, relativePath)
+	}
+
+	return candidatePath
+}
+
+func (expander *HomeExpander) resolveHomeDirectory() string {
+	expander.initializationGuard.Do(func() {
+		expander.homeDirectory, expander.homeDirectoryError = expander.homeDirectoryProvider()
+	})
+	if expander.homeDirectoryError != nil {
+		return ""
+	}
+	return expander.homeDirectory
+}

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -13,7 +13,10 @@ import (
 	"github.com/temirov/git_scripts/internal/githubcli"
 	"github.com/temirov/git_scripts/internal/gitrepo"
 	"github.com/temirov/git_scripts/internal/repos/shared"
+	pathutils "github.com/temirov/git_scripts/internal/utils/path"
 )
+
+var workflowExecutorHomeDirectoryExpander = pathutils.NewHomeExpander()
 
 const (
 	defaultWorkflowRootConstant            = "."
@@ -118,7 +121,8 @@ func sanitizeRoots(rawRoots []string) []string {
 		if len(trimmed) == 0 {
 			continue
 		}
-		sanitized = append(sanitized, trimmed)
+		expandedRoot := workflowExecutorHomeDirectoryExpander.Expand(trimmed)
+		sanitized = append(sanitized, expandedRoot)
 	}
 
 	if len(sanitized) == 0 {


### PR DESCRIPTION
## Summary
- add a reusable HomeExpander utility that caches the user home directory and expands `~` prefixes
- update workflow, audit, branches, migrate, and packages sanitization paths to apply the expander for configuration and flag roots
- add unit tests plus an audit integration scenario covering tilde-prefixed roots

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d8729ce53c8327bf31e7f4e0be3937