### PR TITLE
Handle ENOTTY zap logger sync errors

### DIFF
--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -668,6 +668,8 @@ func (application *Application) syncLoggerInstance(logger *zap.Logger) error {
 		return nil
 	case errors.Is(syncError, syscall.EBADF):
 		return nil
+	case errors.Is(syncError, syscall.ENOTTY):
+		return nil
 	default:
 		return syncError
 	}

--- a/internal/utils/logger_factory_test.go
+++ b/internal/utils/logger_factory_test.go
@@ -104,10 +104,17 @@ func TestLoggerFactoryCreateLogger(testInstance *testing.T) {
 			if syncError != nil {
 				// Some operating systems return syscall.ENOTSUP when Sync is not supported,
 				// others surface syscall.EINVAL when Sync is a no-op, while certain Linux
-				// environments surface syscall.EBADF for closed file descriptors. All three
-				// scenarios indicate a benign Sync outcome for zap loggers across supported
-				// platforms, so they are treated as acceptable here.
-				require.True(testInstance, errors.Is(syncError, syscall.ENOTSUP) || errors.Is(syncError, syscall.EINVAL) || errors.Is(syncError, syscall.EBADF))
+				// environments surface syscall.EBADF for closed file descriptors. Certain
+				// macOS environments propagate syscall.ENOTTY for console file descriptors.
+				// All scenarios indicate a benign Sync outcome for zap loggers across
+				// supported platforms, so they are treated as acceptable here.
+				require.True(
+					testInstance,
+					errors.Is(syncError, syscall.ENOTSUP) ||
+						errors.Is(syncError, syscall.EINVAL) ||
+						errors.Is(syncError, syscall.EBADF) ||
+						errors.Is(syncError, syscall.ENOTTY),
+				)
 			}
 
 			loggerOutputs.ConsoleLogger.Info(testConsoleLogMessageConstant)


### PR DESCRIPTION
## Summary
- treat ENOTTY responses from zap logger sync as non-fatal so CLI invocations do not fail on macOS terminals
- broaden logger factory tests to accept ENOTTY as a benign sync outcome

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68daf68f2fa8832785365a1728c54bfb