### PR TITLE
Support apply-all confirmations with shared prompt state

### DIFF
--- a/cmd/cli/repos/helpers_test.go
+++ b/cmd/cli/repos/helpers_test.go
@@ -1,11 +1,14 @@
 package repos
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/gix/internal/repos/shared"
 )
 
 const (
@@ -53,6 +56,103 @@ func TestDetermineRepositoryRootsSanitizesInputs(testInstance *testing.T) {
 
 			resolved := determineRepositoryRoots(testCase.arguments, testCase.configured)
 			require.Equal(subTest, testCase.expectedResolved, resolved)
+		})
+	}
+}
+
+type stubConfirmationPrompter struct {
+	results []shared.ConfirmationResult
+	err     error
+	calls   int
+}
+
+func (prompter *stubConfirmationPrompter) Confirm(string) (shared.ConfirmationResult, error) {
+	prompter.calls++
+	if prompter.err != nil {
+		return shared.ConfirmationResult{}, prompter.err
+	}
+	if len(prompter.results) == 0 {
+		return shared.ConfirmationResult{}, nil
+	}
+	index := prompter.calls - 1
+	if index >= len(prompter.results) {
+		index = len(prompter.results) - 1
+	}
+	return prompter.results[index], nil
+}
+
+func TestCascadingConfirmationPrompterBehavior(testInstance *testing.T) {
+	testCases := []struct {
+		name                 string
+		initialAssumeYes     bool
+		responses            []shared.ConfirmationResult
+		promptError          error
+		expectAssumeYesAfter bool
+		expectError          bool
+		expectedPromptCalls  int
+	}{
+		{
+			name:                 "initial_assume_yes_persists",
+			initialAssumeYes:     true,
+			expectAssumeYesAfter: true,
+		},
+		{
+			name:                 "decline_does_not_set_assume_yes",
+			responses:            []shared.ConfirmationResult{{Confirmed: false}},
+			expectAssumeYesAfter: false,
+			expectedPromptCalls:  1,
+		},
+		{
+			name:                 "single_accept_does_not_set_assume_yes",
+			responses:            []shared.ConfirmationResult{{Confirmed: true}},
+			expectAssumeYesAfter: false,
+			expectedPromptCalls:  1,
+		},
+		{
+			name:                 "apply_all_sets_assume_yes",
+			responses:            []shared.ConfirmationResult{{Confirmed: true, ApplyToAll: true}},
+			expectAssumeYesAfter: true,
+			expectedPromptCalls:  1,
+		},
+		{
+			name:                 "propagates_prompt_error",
+			responses:            []shared.ConfirmationResult{{Confirmed: true}},
+			promptError:          errors.New("prompt failure"),
+			expectAssumeYesAfter: false,
+			expectError:          true,
+			expectedPromptCalls:  1,
+		},
+		{
+			name:                 "nil_base_prompter_returns_zero_result",
+			expectAssumeYesAfter: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testInstance.Run(testCase.name, func(subTest *testing.T) {
+			var basePrompter shared.ConfirmationPrompter
+			if testCase.responses != nil || testCase.promptError != nil {
+				basePrompter = &stubConfirmationPrompter{results: testCase.responses, err: testCase.promptError}
+			}
+			wrappedPrompter := newCascadingConfirmationPrompter(basePrompter, testCase.initialAssumeYes)
+
+			if testCase.responses != nil || testCase.promptError != nil {
+				_, confirmError := wrappedPrompter.Confirm("test prompt")
+				if testCase.expectError {
+					require.Error(subTest, confirmError)
+				} else {
+					require.NoError(subTest, confirmError)
+				}
+			}
+
+			require.Equal(subTest, testCase.expectAssumeYesAfter, wrappedPrompter.AssumeYes())
+
+			if stub, ok := basePrompter.(*stubConfirmationPrompter); ok {
+				require.Equal(subTest, testCase.expectedPromptCalls, stub.calls)
+			} else {
+				require.Zero(subTest, testCase.expectedPromptCalls)
+			}
 		})
 	}
 }

--- a/cmd/cli/repos/protocol.go
+++ b/cmd/cli/repos/protocol.go
@@ -139,9 +139,10 @@ func (builder *ProtocolCommandBuilder) run(command *cobra.Command, arguments []s
 		return inspectionError
 	}
 
+	trackingPrompter := newCascadingConfirmationPrompter(prompter, assumeYes)
 	protocolDependencies := conversion.Dependencies{
 		GitManager: gitManager,
-		Prompter:   prompter,
+		Prompter:   trackingPrompter,
 		Output:     command.OutOrStdout(),
 		Errors:     command.ErrOrStderr(),
 	}
@@ -158,7 +159,7 @@ func (builder *ProtocolCommandBuilder) run(command *cobra.Command, arguments []s
 			CurrentProtocol:          fromProtocol,
 			TargetProtocol:           toProtocol,
 			DryRun:                   dryRun,
-			AssumeYes:                assumeYes,
+			AssumeYes:                trackingPrompter.AssumeYes(),
 		}
 
 		conversion.Execute(command.Context(), protocolDependencies, conversionOptions)

--- a/cmd/cli/repos/protocol_test.go
+++ b/cmd/cli/repos/protocol_test.go
@@ -170,7 +170,7 @@ func TestProtocolCommandConfigurationPrecedence(testInstance *testing.T) {
 			executor := &fakeGitExecutor{}
 			manager := &fakeGitRepositoryManager{remoteURL: testCase.initialRemoteURL, currentBranch: remotesMetadataDefaultBranch, panicOnCurrentBranchLookup: true}
 			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: remotesCanonicalRepository, DefaultBranch: remotesMetadataDefaultBranch}}
-			prompter := &recordingPrompter{confirmResult: true}
+			prompter := &recordingPrompter{result: shared.ConfirmationResult{Confirmed: true}}
 
 			builder := repos.ProtocolCommandBuilder{
 				LoggerProvider: func() *zap.Logger { return zap.NewNop() },

--- a/cmd/cli/repos/remotes.go
+++ b/cmd/cli/repos/remotes.go
@@ -97,9 +97,10 @@ func (builder *RemotesCommandBuilder) run(command *cobra.Command, arguments []st
 		return inspectionError
 	}
 
+	trackingPrompter := newCascadingConfirmationPrompter(prompter, assumeYes)
 	remotesDependencies := remotes.Dependencies{
 		GitManager: gitManager,
-		Prompter:   prompter,
+		Prompter:   trackingPrompter,
 		Output:     command.OutOrStdout(),
 	}
 
@@ -115,7 +116,7 @@ func (builder *RemotesCommandBuilder) run(command *cobra.Command, arguments []st
 			CanonicalOwnerRepository: inspection.CanonicalOwnerRepo,
 			RemoteProtocol:           shared.RemoteProtocol(inspection.RemoteProtocol),
 			DryRun:                   dryRun,
-			AssumeYes:                assumeYes,
+			AssumeYes:                trackingPrompter.AssumeYes(),
 		}
 
 		remotes.Execute(command.Context(), remotesDependencies, remotesOptions)

--- a/cmd/cli/repos/remotes_test.go
+++ b/cmd/cli/repos/remotes_test.go
@@ -136,7 +136,7 @@ func TestRemotesCommandConfigurationPrecedence(testInstance *testing.T) {
 			executor := &fakeGitExecutor{}
 			manager := &fakeGitRepositoryManager{remoteURL: remotesOriginURLConstant, currentBranch: remotesMetadataDefaultBranch, panicOnCurrentBranchLookup: true}
 			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: remotesCanonicalRepository, DefaultBranch: remotesMetadataDefaultBranch}}
-			prompter := &recordingPrompter{confirmResult: true}
+			prompter := &recordingPrompter{result: shared.ConfirmationResult{Confirmed: true}}
 
 			builder := repos.RemotesCommandBuilder{
 				LoggerProvider: func() *zap.Logger { return zap.NewNop() },

--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -108,10 +108,11 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 		return inspectionError
 	}
 
+	trackingPrompter := newCascadingConfirmationPrompter(prompter, assumeYes)
 	renameDependencies := rename.Dependencies{
 		FileSystem: fileSystem,
 		GitManager: gitManager,
-		Prompter:   prompter,
+		Prompter:   trackingPrompter,
 		Clock:      shared.SystemClock{},
 		Output:     command.OutOrStdout(),
 		Errors:     command.ErrOrStderr(),
@@ -130,7 +131,7 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 			DesiredFolderName:    inspection.DesiredFolderName,
 			DryRun:               dryRun,
 			RequireCleanWorktree: requireClean,
-			AssumeYes:            assumeYes,
+			AssumeYes:            trackingPrompter.AssumeYes(),
 		}
 
 		rename.Execute(command.Context(), renameDependencies, renameOptions)

--- a/cmd/cli/repos/rename_test.go
+++ b/cmd/cli/repos/rename_test.go
@@ -159,7 +159,7 @@ func TestRenameCommandConfigurationPrecedence(testInstance *testing.T) {
 				panicOnCurrentBranchLookup: true,
 			}
 			resolver := &fakeGitHubResolver{metadata: githubcli.RepositoryMetadata{NameWithOwner: renameCanonicalRepositoryConstant, DefaultBranch: renameMetadataDefaultBranchConstant}}
-			prompter := &recordingPrompter{confirmResult: true}
+			prompter := &recordingPrompter{result: shared.ConfirmationResult{Confirmed: true}}
 			fileSystem := newRecordingFileSystem([]string{renameParentDirectoryPathConstant, renameDiscoveredRepositoryPath})
 
 			var configurationProvider func() repos.RenameConfiguration

--- a/cmd/cli/repos/test_helpers_test.go
+++ b/cmd/cli/repos/test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/temirov/gix/internal/execshell"
 	"github.com/temirov/gix/internal/githubcli"
+	"github.com/temirov/gix/internal/repos/shared"
 )
 
 type fakeRepositoryDiscoverer struct {
@@ -79,11 +80,15 @@ func (resolver *fakeGitHubResolver) ResolveRepoMetadata(context.Context, string)
 }
 
 type recordingPrompter struct {
-	confirmResult bool
-	calls         int
+	result shared.ConfirmationResult
+	err    error
+	calls  int
 }
 
-func (prompter *recordingPrompter) Confirm(string) (bool, error) {
+func (prompter *recordingPrompter) Confirm(string) (shared.ConfirmationResult, error) {
 	prompter.calls++
-	return prompter.confirmResult, nil
+	if prompter.err != nil {
+		return shared.ConfirmationResult{}, prompter.err
+	}
+	return prompter.result, nil
 }

--- a/internal/repos/prompt/io_prompter_test.go
+++ b/internal/repos/prompt/io_prompter_test.go
@@ -1,0 +1,107 @@
+package prompt_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/gix/internal/repos/prompt"
+	"github.com/temirov/gix/internal/repos/shared"
+)
+
+type failingReader struct {
+	err error
+}
+
+func (reader failingReader) Read(target []byte) (int, error) {
+	return 0, reader.err
+}
+
+type recordingWriter struct {
+	buffer bytes.Buffer
+	err    error
+	writes int
+}
+
+func (writer *recordingWriter) Write(data []byte) (int, error) {
+	writer.writes++
+	if writer.err != nil {
+		return 0, writer.err
+	}
+	return writer.buffer.Write(data)
+}
+
+const (
+	promptMessageConstant = "Confirm action? "
+)
+
+func TestIOConfirmationPrompterConfirm(testInstance *testing.T) {
+	testCases := []struct {
+		name             string
+		reader           io.Reader
+		writer           *recordingWriter
+		expectedResult   shared.ConfirmationResult
+		expectedError    error
+		expectPromptEcho bool
+	}{
+		{
+			name:             "decline_response",
+			reader:           strings.NewReader("no\n"),
+			writer:           &recordingWriter{},
+			expectedResult:   shared.ConfirmationResult{},
+			expectPromptEcho: true,
+		},
+		{
+			name:             "affirmative_short_response",
+			reader:           strings.NewReader("y\n"),
+			writer:           &recordingWriter{},
+			expectedResult:   shared.ConfirmationResult{Confirmed: true},
+			expectPromptEcho: true,
+		},
+		{
+			name:             "affirmative_apply_all_response",
+			reader:           strings.NewReader("all\n"),
+			writer:           &recordingWriter{},
+			expectedResult:   shared.ConfirmationResult{Confirmed: true, ApplyToAll: true},
+			expectPromptEcho: true,
+		},
+		{
+			name:          "read_error",
+			reader:        failingReader{err: errors.New("read failure")},
+			writer:        &recordingWriter{},
+			expectedError: errors.New("read failure"),
+		},
+		{
+			name:          "write_error",
+			reader:        strings.NewReader("y\n"),
+			writer:        &recordingWriter{err: errors.New("write failure")},
+			expectedError: errors.New("write failure"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			prompter := prompt.NewIOConfirmationPrompter(testCase.reader, testCase.writer)
+			result, err := prompter.Confirm(promptMessageConstant)
+
+			if testCase.expectedError != nil {
+				require.Error(testingInstance, err)
+				require.ErrorContains(testingInstance, err, testCase.expectedError.Error())
+				return
+			}
+
+			require.NoError(testingInstance, err)
+			require.Equal(testingInstance, testCase.expectedResult, result)
+
+			if testCase.expectPromptEcho {
+				require.NotNil(testingInstance, testCase.writer)
+				require.Equal(testingInstance, promptMessageConstant, testCase.writer.buffer.String())
+				require.Equal(testingInstance, 1, testCase.writer.writes)
+			}
+		})
+	}
+}

--- a/internal/repos/protocol/executor.go
+++ b/internal/repos/protocol/executor.go
@@ -90,12 +90,12 @@ func (executor *Executor) Execute(executionContext context.Context, options Opti
 
 	if !options.AssumeYes && executor.dependencies.Prompter != nil {
 		prompt := fmt.Sprintf(promptTemplate, options.RepositoryPath, currentProtocol, options.TargetProtocol)
-		confirmed, promptError := executor.dependencies.Prompter.Confirm(prompt)
+		confirmationResult, promptError := executor.dependencies.Prompter.Confirm(prompt)
 		if promptError != nil {
 			executor.printfError(failureMessage, targetURL, options.RepositoryPath)
 			return
 		}
-		if !confirmed {
+		if !confirmationResult.Confirmed {
 			executor.printfOutput(declinedMessage, options.RepositoryPath)
 			return
 		}

--- a/internal/repos/remotes/executor.go
+++ b/internal/repos/remotes/executor.go
@@ -86,12 +86,12 @@ func (executor *Executor) Execute(executionContext context.Context, options Opti
 
 	if !options.AssumeYes && executor.dependencies.Prompter != nil {
 		prompt := fmt.Sprintf(promptTemplate, options.RepositoryPath, trimmedOrigin, trimmedCanonical)
-		confirmed, promptError := executor.dependencies.Prompter.Confirm(prompt)
+		confirmationResult, promptError := executor.dependencies.Prompter.Confirm(prompt)
 		if promptError != nil {
 			executor.printfOutput(skipTargetMessage, options.RepositoryPath)
 			return
 		}
-		if !confirmed {
+		if !confirmationResult.Confirmed {
 			executor.printfOutput(declinedMessage, options.RepositoryPath)
 			return
 		}

--- a/internal/repos/shared/types.go
+++ b/internal/repos/shared/types.go
@@ -51,9 +51,15 @@ type FileSystem interface {
 	Abs(path string) (string, error)
 }
 
+// ConfirmationResult captures the outcome of a user confirmation prompt.
+type ConfirmationResult struct {
+	Confirmed  bool
+	ApplyToAll bool
+}
+
 // ConfirmationPrompter collects user confirmations prior to mutating actions.
 type ConfirmationPrompter interface {
-	Confirm(prompt string) (bool, error)
+	Confirm(prompt string) (ConfirmationResult, error)
 }
 
 // GitExecutor exposes the subset of shell execution used by repository services.

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -84,6 +84,9 @@ func (executor *Executor) Execute(executionContext context.Context, roots []stri
 		repositoryStates = append(repositoryStates, NewRepositoryState(inspections[inspectionIndex]))
 	}
 
+	promptState := NewPromptState(runtimeOptions.AssumeYes)
+	dispatchingPrompter := newPromptDispatcher(executor.dependencies.Prompter, promptState)
+
 	state := &State{Roots: sanitizedRoots, Repositories: repositoryStates}
 	environment := &Environment{
 		AuditService:      auditService,
@@ -91,12 +94,12 @@ func (executor *Executor) Execute(executionContext context.Context, roots []stri
 		RepositoryManager: executor.dependencies.RepositoryManager,
 		GitHubClient:      executor.dependencies.GitHubClient,
 		FileSystem:        executor.dependencies.FileSystem,
-		Prompter:          executor.dependencies.Prompter,
+		Prompter:          dispatchingPrompter,
+		PromptState:       promptState,
 		Output:            executor.dependencies.Output,
 		Errors:            executor.dependencies.Errors,
 		Logger:            executor.dependencies.Logger,
 		DryRun:            runtimeOptions.DryRun,
-		AssumeYes:         runtimeOptions.AssumeYes,
 	}
 
 	for operationIndex := range executor.operations {

--- a/internal/workflow/operation.go
+++ b/internal/workflow/operation.go
@@ -26,9 +26,9 @@ type Environment struct {
 	GitHubClient      *githubcli.Client
 	FileSystem        shared.FileSystem
 	Prompter          shared.ConfirmationPrompter
+	PromptState       *PromptState
 	Output            io.Writer
 	Errors            io.Writer
 	Logger            *zap.Logger
 	DryRun            bool
-	AssumeYes         bool
 }

--- a/internal/workflow/operations_protocol.go
+++ b/internal/workflow/operations_protocol.go
@@ -42,6 +42,11 @@ func (operation *ProtocolConversionOperation) Execute(executionContext context.C
 			continue
 		}
 
+		assumeYes := false
+		if environment.PromptState != nil {
+			assumeYes = environment.PromptState.IsAssumeYesEnabled()
+		}
+
 		options := conversion.Options{
 			RepositoryPath:           repository.Path,
 			OriginOwnerRepository:    repository.Inspection.OriginOwnerRepo,
@@ -49,7 +54,7 @@ func (operation *ProtocolConversionOperation) Execute(executionContext context.C
 			CurrentProtocol:          operation.FromProtocol,
 			TargetProtocol:           operation.ToProtocol,
 			DryRun:                   environment.DryRun,
-			AssumeYes:                environment.AssumeYes,
+			AssumeYes:                assumeYes,
 		}
 
 		conversion.Execute(executionContext, dependencies, options)

--- a/internal/workflow/operations_remote.go
+++ b/internal/workflow/operations_remote.go
@@ -41,6 +41,11 @@ func (operation *CanonicalRemoteOperation) Execute(executionContext context.Cont
 			continue
 		}
 
+		assumeYes := false
+		if environment.PromptState != nil {
+			assumeYes = environment.PromptState.IsAssumeYesEnabled()
+		}
+
 		options := remotes.Options{
 			RepositoryPath:           repository.Path,
 			CurrentOriginURL:         repository.Inspection.OriginURL,
@@ -48,7 +53,7 @@ func (operation *CanonicalRemoteOperation) Execute(executionContext context.Cont
 			CanonicalOwnerRepository: repository.Inspection.CanonicalOwnerRepo,
 			RemoteProtocol:           shared.RemoteProtocol(repository.Inspection.RemoteProtocol),
 			DryRun:                   environment.DryRun,
-			AssumeYes:                environment.AssumeYes,
+			AssumeYes:                assumeYes,
 		}
 
 		remotes.Execute(executionContext, dependencies, options)

--- a/internal/workflow/operations_rename.go
+++ b/internal/workflow/operations_rename.go
@@ -47,6 +47,11 @@ func (operation *RenameOperation) Execute(executionContext context.Context, envi
 			continue
 		}
 
+		assumeYes := false
+		if environment.PromptState != nil {
+			assumeYes = environment.PromptState.IsAssumeYesEnabled()
+		}
+
 		originalPath := repository.Path
 
 		options := rename.Options{
@@ -54,7 +59,7 @@ func (operation *RenameOperation) Execute(executionContext context.Context, envi
 			DesiredFolderName:    desiredName,
 			DryRun:               environment.DryRun,
 			RequireCleanWorktree: operation.RequireCleanWorktree,
-			AssumeYes:            environment.AssumeYes,
+			AssumeYes:            assumeYes,
 		}
 
 		rename.Execute(executionContext, dependencies, options)

--- a/internal/workflow/prompt_state.go
+++ b/internal/workflow/prompt_state.go
@@ -1,0 +1,61 @@
+package workflow
+
+import (
+	"sync/atomic"
+
+	"github.com/temirov/gix/internal/repos/shared"
+)
+
+// PromptState tracks the shared confirmation policy across operations.
+type PromptState struct {
+	assumeYes atomic.Bool
+}
+
+// NewPromptState constructs a PromptState initialized with the provided value.
+func NewPromptState(initialAssumeYes bool) *PromptState {
+	state := &PromptState{}
+	state.assumeYes.Store(initialAssumeYes)
+	return state
+}
+
+// IsAssumeYesEnabled reports whether prompts should be bypassed.
+func (state *PromptState) IsAssumeYesEnabled() bool {
+	if state == nil {
+		return false
+	}
+	return state.assumeYes.Load()
+}
+
+// EnableAssumeYes permanently enables the assume-yes behavior for subsequent prompts.
+func (state *PromptState) EnableAssumeYes() {
+	if state == nil {
+		return
+	}
+	state.assumeYes.Store(true)
+}
+
+type promptDispatcher struct {
+	basePrompter shared.ConfirmationPrompter
+	promptState  *PromptState
+}
+
+func newPromptDispatcher(base shared.ConfirmationPrompter, state *PromptState) shared.ConfirmationPrompter {
+	if base == nil {
+		return nil
+	}
+	return &promptDispatcher{basePrompter: base, promptState: state}
+}
+
+func (dispatcher *promptDispatcher) Confirm(prompt string) (shared.ConfirmationResult, error) {
+	if dispatcher.basePrompter == nil {
+		return shared.ConfirmationResult{}, nil
+	}
+	result, confirmError := dispatcher.basePrompter.Confirm(prompt)
+	if confirmError != nil {
+		return shared.ConfirmationResult{}, confirmError
+	}
+	if result.ApplyToAll && dispatcher.promptState != nil {
+		dispatcher.promptState.EnableAssumeYes()
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary
- replace boolean confirmation responses with a ConfirmationResult that carries apply-to-all decisions and update the IO prompter to recognize the new responses
- add a workflow PromptState dispatcher and CLI cascading prompter wrapper so apply-all acknowledgements flip assume-yes for subsequent operations
- refresh rename, remotes, protocol, prompt, and CLI helper tests with table-driven coverage for decline, single accept, accept-all, and error scenarios

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db0f9a29e88327b840e63e5b8cad75