### PR TITLE
Add CLI configuration initialization workflow

### DIFF
--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -26,61 +26,83 @@ import (
 )
 
 const (
-	applicationNameConstant                             = "gix"
-	applicationShortDescriptionConstant                 = "Command-line interface for gix utilities"
-	applicationLongDescriptionConstant                  = "gix ships reusable helpers that integrate Git, GitHub CLI, and related tooling."
-	configFileFlagNameConstant                          = "config"
-	configFileFlagUsageConstant                         = "Optional path to a configuration file (YAML or JSON)."
-	logLevelFlagNameConstant                            = "log-level"
-	logLevelFlagUsageConstant                           = "Override the configured log level."
-	logFormatFlagNameConstant                           = "log-format"
-	logFormatFlagUsageConstant                          = "Override the configured log format (structured or console)."
-	commonConfigurationKeyConstant                      = "common"
-	commonLogLevelConfigKeyConstant                     = commonConfigurationKeyConstant + ".log_level"
-	commonLogFormatConfigKeyConstant                    = commonConfigurationKeyConstant + ".log_format"
-	commonDryRunConfigKeyConstant                       = commonConfigurationKeyConstant + ".dry_run"
-	commonAssumeYesConfigKeyConstant                    = commonConfigurationKeyConstant + ".assume_yes"
-	commonRequireCleanConfigKeyConstant                 = commonConfigurationKeyConstant + ".require_clean"
-	environmentPrefixConstant                           = "GIX"
-	configurationNameConstant                           = "config"
-	configurationTypeConstant                           = "yaml"
-	configurationInitializedMessageConstant             = "configuration initialized"
-	configurationLogLevelFieldConstant                  = "log_level"
-	configurationLogFormatFieldConstant                 = "log_format"
-	configurationFileFieldConstant                      = "config_file"
-	configurationLoadErrorTemplateConstant              = "unable to load configuration: %w"
-	loggerCreationErrorTemplateConstant                 = "unable to create logger: %w"
-	loggerSyncErrorTemplateConstant                     = "unable to flush logger: %w"
-	configurationInitializedConsoleTemplateConstant     = "%s | log level=%s | log format=%s | config file=%s"
-	rootCommandInfoMessageConstant                      = "gix CLI executed"
-	rootCommandDebugMessageConstant                     = "gix CLI diagnostics"
-	logFieldCommandNameConstant                         = "command_name"
-	logFieldArgumentCountConstant                       = "argument_count"
-	logFieldArgumentsConstant                           = "arguments"
-	loggerNotInitializedMessageConstant                 = "logger not initialized"
-	defaultConfigurationSearchPathConstant              = "."
-	userConfigurationDirectoryNameConstant              = ".gix"
-	configurationSearchPathEnvironmentVariableConstant  = "GIX_CONFIG_SEARCH_PATH"
-	auditOperationNameConstant                          = "audit"
-	packagesPurgeOperationNameConstant                  = "repo-packages-purge"
-	branchCleanupOperationNameConstant                  = "repo-prs-purge"
-	reposRenameOperationNameConstant                    = "repo-folders-rename"
-	reposRemotesOperationNameConstant                   = "repo-remote-update"
-	reposProtocolOperationNameConstant                  = "repo-protocol-convert"
-	workflowCommandOperationNameConstant                = "workflow"
-	branchMigrateOperationNameConstant                  = "branch-migrate"
-	operationDecodeErrorMessageConstant                 = "unable to decode operation defaults"
-	operationNameLogFieldConstant                       = "operation"
-	operationErrorLogFieldConstant                      = "error"
-	duplicateOperationConfigurationTemplateConstant     = "duplicate configuration for operation %q"
-	missingOperationConfigurationTemplateConstant       = "missing configuration for operation %q"
-	missingOperationConfigurationSkippedMessageConstant = "operation configuration missing; continuing without defaults"
-	unknownCommandNamePlaceholderConstant               = "unknown"
-	dryRunOptionKeyConstant                             = "dry_run"
-	assumeYesOptionKeyConstant                          = "assume_yes"
-	requireCleanOptionKeyConstant                       = "require_clean"
-	branchFlagNameConstant                              = "branch"
-	branchFlagUsageConstant                             = "Branch name for command context"
+	applicationNameConstant                                          = "gix"
+	applicationShortDescriptionConstant                              = "Command-line interface for gix utilities"
+	applicationLongDescriptionConstant                               = "gix ships reusable helpers that integrate Git, GitHub CLI, and related tooling."
+	configFileFlagNameConstant                                       = "config"
+	configFileFlagUsageConstant                                      = "Optional path to a configuration file (YAML or JSON)."
+	logLevelFlagNameConstant                                         = "log-level"
+	logLevelFlagUsageConstant                                        = "Override the configured log level."
+	logFormatFlagNameConstant                                        = "log-format"
+	logFormatFlagUsageConstant                                       = "Override the configured log format (structured or console)."
+	configurationInitializationFlagNameConstant                      = "init"
+	configurationInitializationFlagUsageConstant                     = "Write the embedded default configuration to the selected scope (local or user)."
+	configurationInitializationDefaultScopeConstant                  = "local"
+	configurationInitializationForceFlagNameConstant                 = "force"
+	configurationInitializationForceFlagUsageConstant                = "Overwrite an existing configuration file when initializing."
+	configurationInitializationScopeLocalConstant                    = "local"
+	configurationInitializationScopeUserConstant                     = "user"
+	configurationInitializationUnsupportedScopeTemplateConstant      = "unsupported initialization scope %q"
+	configurationInitializationWorkingDirectoryErrorTemplateConstant = "unable to determine working directory: %w"
+	configurationInitializationWorkingDirectoryEmptyErrorConstant    = "working directory is empty"
+	configurationInitializationHomeDirectoryErrorTemplateConstant    = "unable to determine user home directory: %w"
+	configurationInitializationHomeDirectoryEmptyErrorConstant       = "user home directory is empty"
+	configurationInitializationContentUnavailableErrorConstant       = "embedded configuration content is unavailable"
+	configurationInitializationDirectoryErrorTemplateConstant        = "unable to ensure configuration directory %s: %w"
+	configurationInitializationExistingFileTemplateConstant          = "configuration file already exists at %s (use --force to overwrite)"
+	configurationInitializationExistingDirectoryTemplateConstant     = "configuration path %s is a directory"
+	configurationInitializationDirectoryConflictTemplateConstant     = "configuration directory path %s is not a directory"
+	configurationInitializationWriteErrorTemplateConstant            = "unable to write configuration file %s: %w"
+	configurationInitializationSuccessMessageConstant                = "configuration file created"
+	commonConfigurationKeyConstant                                   = "common"
+	commonLogLevelConfigKeyConstant                                  = commonConfigurationKeyConstant + ".log_level"
+	commonLogFormatConfigKeyConstant                                 = commonConfigurationKeyConstant + ".log_format"
+	commonDryRunConfigKeyConstant                                    = commonConfigurationKeyConstant + ".dry_run"
+	commonAssumeYesConfigKeyConstant                                 = commonConfigurationKeyConstant + ".assume_yes"
+	commonRequireCleanConfigKeyConstant                              = commonConfigurationKeyConstant + ".require_clean"
+	environmentPrefixConstant                                        = "GIX"
+	configurationNameConstant                                        = "config"
+	configurationTypeConstant                                        = "yaml"
+	configurationFileNameConstant                                    = configurationNameConstant + "." + configurationTypeConstant
+	configurationDirectoryPermissionConstant                         = 0o755
+	configurationFilePermissionConstant                              = 0o600
+	configurationInitializedMessageConstant                          = "configuration initialized"
+	configurationLogLevelFieldConstant                               = "log_level"
+	configurationLogFormatFieldConstant                              = "log_format"
+	configurationFileFieldConstant                                   = "config_file"
+	configurationLoadErrorTemplateConstant                           = "unable to load configuration: %w"
+	loggerCreationErrorTemplateConstant                              = "unable to create logger: %w"
+	loggerSyncErrorTemplateConstant                                  = "unable to flush logger: %w"
+	configurationInitializedConsoleTemplateConstant                  = "%s | log level=%s | log format=%s | config file=%s"
+	rootCommandInfoMessageConstant                                   = "gix CLI executed"
+	rootCommandDebugMessageConstant                                  = "gix CLI diagnostics"
+	logFieldCommandNameConstant                                      = "command_name"
+	logFieldArgumentCountConstant                                    = "argument_count"
+	logFieldArgumentsConstant                                        = "arguments"
+	loggerNotInitializedMessageConstant                              = "logger not initialized"
+	defaultConfigurationSearchPathConstant                           = "."
+	userConfigurationDirectoryNameConstant                           = ".gix"
+	configurationSearchPathEnvironmentVariableConstant               = "GIX_CONFIG_SEARCH_PATH"
+	auditOperationNameConstant                                       = "audit"
+	packagesPurgeOperationNameConstant                               = "repo-packages-purge"
+	branchCleanupOperationNameConstant                               = "repo-prs-purge"
+	reposRenameOperationNameConstant                                 = "repo-folders-rename"
+	reposRemotesOperationNameConstant                                = "repo-remote-update"
+	reposProtocolOperationNameConstant                               = "repo-protocol-convert"
+	workflowCommandOperationNameConstant                             = "workflow"
+	branchMigrateOperationNameConstant                               = "branch-migrate"
+	operationDecodeErrorMessageConstant                              = "unable to decode operation defaults"
+	operationNameLogFieldConstant                                    = "operation"
+	operationErrorLogFieldConstant                                   = "error"
+	duplicateOperationConfigurationTemplateConstant                  = "duplicate configuration for operation %q"
+	missingOperationConfigurationTemplateConstant                    = "missing configuration for operation %q"
+	missingOperationConfigurationSkippedMessageConstant              = "operation configuration missing; continuing without defaults"
+	unknownCommandNamePlaceholderConstant                            = "unknown"
+	dryRunOptionKeyConstant                                          = "dry_run"
+	assumeYesOptionKeyConstant                                       = "assume_yes"
+	requireCleanOptionKeyConstant                                    = "require_clean"
+	branchFlagNameConstant                                           = "branch"
+	branchFlagUsageConstant                                          = "Branch name for command context"
 )
 
 var commandOperationRequirements = map[string][]string{
@@ -144,6 +166,11 @@ type ApplicationOperationConfiguration struct {
 // OperationConfigurations stores reusable operation defaults indexed by normalized operation name.
 type OperationConfigurations struct {
 	entries map[string]map[string]any
+}
+
+type configurationInitializationPlan struct {
+	DirectoryPath string
+	FilePath      string
 }
 
 func newOperationConfigurations(definitions []ApplicationOperationConfiguration) (OperationConfigurations, error) {
@@ -227,20 +254,22 @@ func normalizeOperationName(raw string) string {
 
 // Application wires the Cobra root command, configuration loader, and structured logger.
 type Application struct {
-	rootCommand             *cobra.Command
-	configurationLoader     *utils.ConfigurationLoader
-	loggerFactory           loggerOutputsFactory
-	logger                  *zap.Logger
-	consoleLogger           *zap.Logger
-	configuration           ApplicationConfiguration
-	configurationMetadata   utils.LoadedConfiguration
-	configurationFilePath   string
-	logLevelFlagValue       string
-	logFormatFlagValue      string
-	commandContextAccessor  utils.CommandContextAccessor
-	operationConfigurations OperationConfigurations
-	rootFlagValues          *flagutils.RootFlagValues
-	branchFlagValues        *flagutils.BranchFlagValues
+	rootCommand                       *cobra.Command
+	configurationLoader               *utils.ConfigurationLoader
+	loggerFactory                     loggerOutputsFactory
+	logger                            *zap.Logger
+	consoleLogger                     *zap.Logger
+	configuration                     ApplicationConfiguration
+	configurationMetadata             utils.LoadedConfiguration
+	configurationFilePath             string
+	logLevelFlagValue                 string
+	logFormatFlagValue                string
+	commandContextAccessor            utils.CommandContextAccessor
+	operationConfigurations           OperationConfigurations
+	rootFlagValues                    *flagutils.RootFlagValues
+	branchFlagValues                  *flagutils.BranchFlagValues
+	configurationInitializationScope  string
+	configurationInitializationForced bool
 }
 
 // NewApplication assembles a fully wired CLI application instance.
@@ -280,6 +309,22 @@ func NewApplication() *Application {
 	cobraCommand.PersistentFlags().StringVar(&application.configurationFilePath, configFileFlagNameConstant, "", configFileFlagUsageConstant)
 	cobraCommand.PersistentFlags().StringVar(&application.logLevelFlagValue, logLevelFlagNameConstant, "", logLevelFlagUsageConstant)
 	cobraCommand.PersistentFlags().StringVar(&application.logFormatFlagValue, logFormatFlagNameConstant, "", logFormatFlagUsageConstant)
+	cobraCommand.PersistentFlags().StringVar(
+		&application.configurationInitializationScope,
+		configurationInitializationFlagNameConstant,
+		configurationInitializationDefaultScopeConstant,
+		configurationInitializationFlagUsageConstant,
+	)
+	initializationFlag := cobraCommand.PersistentFlags().Lookup(configurationInitializationFlagNameConstant)
+	if initializationFlag != nil {
+		initializationFlag.NoOptDefVal = configurationInitializationDefaultScopeConstant
+	}
+	cobraCommand.PersistentFlags().BoolVar(
+		&application.configurationInitializationForced,
+		configurationInitializationForceFlagNameConstant,
+		false,
+		configurationInitializationForceFlagUsageConstant,
+	)
 
 	application.rootFlagValues = flagutils.BindRootFlags(
 		cobraCommand,
@@ -869,9 +914,153 @@ func collectRequiredOperationConfigurationNames() []string {
 	return orderedNames
 }
 
+func (application *Application) handleConfigurationInitialization(command *cobra.Command) (bool, error) {
+	if !application.configurationInitializationRequested(command) {
+		return false, nil
+	}
+
+	initializationScope := strings.TrimSpace(application.configurationInitializationScope)
+	if len(initializationScope) == 0 {
+		initializationScope = configurationInitializationDefaultScopeConstant
+	}
+
+	initializationPlan, planError := application.resolveConfigurationInitializationPlan(initializationScope)
+	if planError != nil {
+		return true, planError
+	}
+
+	configurationContent, _ := EmbeddedDefaultConfiguration()
+	if len(configurationContent) == 0 {
+		return true, errors.New(configurationInitializationContentUnavailableErrorConstant)
+	}
+
+	if writeError := application.writeConfigurationFile(initializationPlan, configurationContent); writeError != nil {
+		return true, writeError
+	}
+
+	application.logger.Info(
+		configurationInitializationSuccessMessageConstant,
+		zap.String(configurationFileFieldConstant, initializationPlan.FilePath),
+	)
+
+	return true, nil
+}
+
+func (application *Application) configurationInitializationRequested(command *cobra.Command) bool {
+	return application.persistentFlagChanged(command, configurationInitializationFlagNameConstant)
+}
+
+func (application *Application) resolveConfigurationInitializationPlan(initializationScope string) (configurationInitializationPlan, error) {
+	normalizedScope := strings.ToLower(strings.TrimSpace(initializationScope))
+	switch normalizedScope {
+	case "", configurationInitializationScopeLocalConstant:
+		workingDirectoryPath, workingDirectoryError := os.Getwd()
+		if workingDirectoryError != nil {
+			return configurationInitializationPlan{}, fmt.Errorf(configurationInitializationWorkingDirectoryErrorTemplateConstant, workingDirectoryError)
+		}
+
+		trimmedWorkingDirectoryPath := strings.TrimSpace(workingDirectoryPath)
+		if len(trimmedWorkingDirectoryPath) == 0 {
+			return configurationInitializationPlan{}, fmt.Errorf(
+				configurationInitializationWorkingDirectoryErrorTemplateConstant,
+				errors.New(configurationInitializationWorkingDirectoryEmptyErrorConstant),
+			)
+		}
+
+		return configurationInitializationPlan{
+			DirectoryPath: trimmedWorkingDirectoryPath,
+			FilePath:      filepath.Join(trimmedWorkingDirectoryPath, configurationFileNameConstant),
+		}, nil
+	case configurationInitializationScopeUserConstant:
+		userHomeDirectoryPath, userHomeDirectoryError := os.UserHomeDir()
+		if userHomeDirectoryError != nil {
+			return configurationInitializationPlan{}, fmt.Errorf(configurationInitializationHomeDirectoryErrorTemplateConstant, userHomeDirectoryError)
+		}
+
+		trimmedHomeDirectoryPath := strings.TrimSpace(userHomeDirectoryPath)
+		if len(trimmedHomeDirectoryPath) == 0 {
+			return configurationInitializationPlan{}, fmt.Errorf(
+				configurationInitializationHomeDirectoryErrorTemplateConstant,
+				errors.New(configurationInitializationHomeDirectoryEmptyErrorConstant),
+			)
+		}
+
+		configurationDirectoryPath := filepath.Join(trimmedHomeDirectoryPath, userConfigurationDirectoryNameConstant)
+
+		return configurationInitializationPlan{
+			DirectoryPath: configurationDirectoryPath,
+			FilePath:      filepath.Join(configurationDirectoryPath, configurationFileNameConstant),
+		}, nil
+	default:
+		trimmedScope := strings.TrimSpace(initializationScope)
+		if len(trimmedScope) == 0 {
+			trimmedScope = initializationScope
+		}
+		return configurationInitializationPlan{}, fmt.Errorf(configurationInitializationUnsupportedScopeTemplateConstant, trimmedScope)
+	}
+}
+
+func (application *Application) writeConfigurationFile(initializationPlan configurationInitializationPlan, configurationContent []byte) error {
+	if len(configurationContent) == 0 {
+		return errors.New(configurationInitializationContentUnavailableErrorConstant)
+	}
+
+	directoryPath := strings.TrimSpace(initializationPlan.DirectoryPath)
+	if len(directoryPath) == 0 {
+		return fmt.Errorf(
+			configurationInitializationDirectoryErrorTemplateConstant,
+			initializationPlan.DirectoryPath,
+			errors.New(configurationInitializationWorkingDirectoryEmptyErrorConstant),
+		)
+	}
+
+	directoryInfo, directoryStatError := os.Stat(directoryPath)
+	switch {
+	case directoryStatError == nil:
+		if !directoryInfo.IsDir() {
+			return fmt.Errorf(configurationInitializationDirectoryConflictTemplateConstant, directoryPath)
+		}
+	case errors.Is(directoryStatError, os.ErrNotExist):
+		if createError := os.MkdirAll(directoryPath, configurationDirectoryPermissionConstant); createError != nil {
+			return fmt.Errorf(configurationInitializationDirectoryErrorTemplateConstant, directoryPath, createError)
+		}
+	default:
+		return fmt.Errorf(configurationInitializationDirectoryErrorTemplateConstant, directoryPath, directoryStatError)
+	}
+
+	fileInfo, fileStatError := os.Stat(initializationPlan.FilePath)
+	switch {
+	case fileStatError == nil:
+		if fileInfo.IsDir() {
+			return fmt.Errorf(configurationInitializationExistingDirectoryTemplateConstant, initializationPlan.FilePath)
+		}
+		if !application.configurationInitializationForced {
+			return fmt.Errorf(configurationInitializationExistingFileTemplateConstant, initializationPlan.FilePath)
+		}
+	case errors.Is(fileStatError, os.ErrNotExist):
+	default:
+		return fmt.Errorf(configurationInitializationWriteErrorTemplateConstant, initializationPlan.FilePath, fileStatError)
+	}
+
+	writeError := os.WriteFile(initializationPlan.FilePath, configurationContent, configurationFilePermissionConstant)
+	if writeError != nil {
+		return fmt.Errorf(configurationInitializationWriteErrorTemplateConstant, initializationPlan.FilePath, writeError)
+	}
+
+	return nil
+}
+
 func (application *Application) runRootCommand(command *cobra.Command, arguments []string) error {
 	if application.logger == nil {
 		return errors.New(loggerNotInitializedMessageConstant)
+	}
+
+	initializationHandled, initializationError := application.handleConfigurationInitialization(command)
+	if initializationError != nil {
+		return initializationError
+	}
+	if initializationHandled {
+		return nil
 	}
 
 	application.logger.Info(

--- a/cmd/cli/application_test.go
+++ b/cmd/cli/application_test.go
@@ -25,46 +25,57 @@ import (
 )
 
 const (
-	testConfigurationFileNameConstant                = "config.yaml"
-	testConfigurationHeaderConstant                  = "common:\n  log_level: info\n  log_format: structured\noperations:\n"
-	testConsoleConfigurationHeaderConstant           = "common:\n  log_level: info\n  log_format: console\noperations:\n"
-	testOperationBlockTemplateConstant               = "  - operation: %s\n    with:\n%s"
-	testOperationRootsTemplateConstant               = "      roots:\n        - %s\n"
-	testOperationRootDirectoryConstant               = "/tmp/config-root"
-	testConfigurationSearchPathEnvironmentName       = "GIX_CONFIG_SEARCH_PATH"
-	testPackagesCommandNameConstant                  = "repo-packages-purge"
-	testBranchMigrateCommandNameConstant             = "branch-migrate"
-	testBranchCleanupCommandNameConstant             = "repo-prs-purge"
-	testReposRemotesCommandNameConstant              = "repo-remote-update"
-	testReposProtocolCommandNameConstant             = "repo-protocol-convert"
-	testReposRenameCommandNameConstant               = "repo-folders-rename"
-	testAuditCommandNameConstant                     = "audit"
-	testWorkflowCommandNameConstant                  = "workflow"
-	embeddedDefaultsBranchCleanupTestNameConstant    = "BranchCleanupDefaults"
-	embeddedDefaultsPackagesTestNameConstant         = "PackagesDefaults"
-	embeddedDefaultsReposRemotesTestNameConstant     = "ReposRemotesDefaults"
-	embeddedDefaultsReposProtocolTestNameConstant    = "ReposProtocolDefaults"
-	embeddedDefaultsReposRenameTestNameConstant      = "ReposRenameDefaults"
-	embeddedDefaultsWorkflowTestNameConstant         = "WorkflowDefaults"
-	embeddedDefaultsBranchMigrateTestNameConstant    = "BranchMigrateDefaults"
-	embeddedDefaultsAuditTestNameConstant            = "AuditDefaults"
-	embeddedDefaultRootPathConstant                  = "."
-	embeddedDefaultRemoteNameConstant                = "origin"
-	embeddedDefaultPullRequestLimitConstant          = 100
-	configurationInitializedMessageTextConstant      = "configuration initialized"
-	configurationInitializedConsoleTemplateConstant  = "%s | log level=%s | log format=%s | config file=%s"
-	configurationLogLevelFieldNameConstant           = "log_level"
-	configurationLogFormatFieldNameConstant          = "log_format"
-	configurationFileFieldNameConstant               = "config_file"
-	testUserConfigurationDirectoryNameConstant       = ".gix"
-	testXDGConfigHomeDirectoryNameConstant           = "config"
-	testCaseWorkingDirectoryPreferredMessageConstant = "WorkingDirectoryPreferred"
-	testCaseXDGDirectoryFallbackMessageConstant      = "XDGDirectoryFallback"
-	testCaseHomeDirectoryFallbackMessageConstant     = "HomeDirectoryFallback"
-	applicationSearchPathSubtestNameTemplateConstant = "%d_%s"
-	configurationDirectoryRoleWorkingConstant        = "working"
-	configurationDirectoryRoleXDGConstant            = "xdg"
-	configurationDirectoryRoleHomeConstant           = "home"
+	testConfigurationFileNameConstant                        = "config.yaml"
+	testConfigurationHeaderConstant                          = "common:\n  log_level: info\n  log_format: structured\noperations:\n"
+	testConsoleConfigurationHeaderConstant                   = "common:\n  log_level: info\n  log_format: console\noperations:\n"
+	testOperationBlockTemplateConstant                       = "  - operation: %s\n    with:\n%s"
+	testOperationRootsTemplateConstant                       = "      roots:\n        - %s\n"
+	testOperationRootDirectoryConstant                       = "/tmp/config-root"
+	testConfigurationSearchPathEnvironmentName               = "GIX_CONFIG_SEARCH_PATH"
+	testPackagesCommandNameConstant                          = "repo-packages-purge"
+	testBranchMigrateCommandNameConstant                     = "branch-migrate"
+	testBranchCleanupCommandNameConstant                     = "repo-prs-purge"
+	testReposRemotesCommandNameConstant                      = "repo-remote-update"
+	testReposProtocolCommandNameConstant                     = "repo-protocol-convert"
+	testReposRenameCommandNameConstant                       = "repo-folders-rename"
+	testAuditCommandNameConstant                             = "audit"
+	testWorkflowCommandNameConstant                          = "workflow"
+	embeddedDefaultsBranchCleanupTestNameConstant            = "BranchCleanupDefaults"
+	embeddedDefaultsPackagesTestNameConstant                 = "PackagesDefaults"
+	embeddedDefaultsReposRemotesTestNameConstant             = "ReposRemotesDefaults"
+	embeddedDefaultsReposProtocolTestNameConstant            = "ReposProtocolDefaults"
+	embeddedDefaultsReposRenameTestNameConstant              = "ReposRenameDefaults"
+	embeddedDefaultsWorkflowTestNameConstant                 = "WorkflowDefaults"
+	embeddedDefaultsBranchMigrateTestNameConstant            = "BranchMigrateDefaults"
+	embeddedDefaultsAuditTestNameConstant                    = "AuditDefaults"
+	embeddedDefaultRootPathConstant                          = "."
+	embeddedDefaultRemoteNameConstant                        = "origin"
+	embeddedDefaultPullRequestLimitConstant                  = 100
+	configurationInitializedMessageTextConstant              = "configuration initialized"
+	configurationInitializedConsoleTemplateConstant          = "%s | log level=%s | log format=%s | config file=%s"
+	configurationLogLevelFieldNameConstant                   = "log_level"
+	configurationLogFormatFieldNameConstant                  = "log_format"
+	configurationFileFieldNameConstant                       = "config_file"
+	testUserConfigurationDirectoryNameConstant               = ".gix"
+	testXDGConfigHomeDirectoryNameConstant                   = "config"
+	testCaseWorkingDirectoryPreferredMessageConstant         = "WorkingDirectoryPreferred"
+	testCaseXDGDirectoryFallbackMessageConstant              = "XDGDirectoryFallback"
+	testCaseHomeDirectoryFallbackMessageConstant             = "HomeDirectoryFallback"
+	applicationSearchPathSubtestNameTemplateConstant         = "%d_%s"
+	configurationDirectoryRoleWorkingConstant                = "working"
+	configurationDirectoryRoleXDGConstant                    = "xdg"
+	configurationDirectoryRoleHomeConstant                   = "home"
+	configurationInitializationLocalTestNameConstant         = "LocalScope"
+	configurationInitializationUserTestNameConstant          = "UserScope"
+	configurationInitializationForceRequiredTestNameConstant = "ForceRequired"
+	configurationInitializationForceEnabledTestNameConstant  = "ForceEnabled"
+	configurationInitializationArgumentsLocalConstant        = "--init"
+	configurationInitializationArgumentsUserConstant         = "--init=user"
+	configurationInitializationForceFlagConstant             = "--force"
+	configurationInitializationExistingContentConstant       = "common:\n  log_level: info\n"
+	configurationInitializationErrorMessageFragmentConstant  = "already exists"
+	configurationInitializationApplicationNameConstant       = "gix"
+	configurationInitializationUserHomeEnvNameConstant       = "HOME"
 )
 
 var requiredOperationNames = []string{
@@ -235,6 +246,137 @@ func TestApplicationInitializationLoggingModes(testInstance *testing.T) {
 			require.NoError(t, initializationError)
 
 			testCase.assertion(t, capturedOutput, configurationPath)
+		})
+	}
+}
+
+func TestApplicationConfigurationInitializationCreatesConfiguration(testInstance *testing.T) {
+	embeddedConfigurationContent, _ := cli.EmbeddedDefaultConfiguration()
+	require.NotEmpty(testInstance, embeddedConfigurationContent)
+
+	testCases := []struct {
+		name      string
+		arguments []string
+		setup     func(*testing.T) string
+	}{
+		{
+			name:      configurationInitializationLocalTestNameConstant,
+			arguments: []string{configurationInitializationArgumentsLocalConstant},
+			setup: func(t *testing.T) string {
+				workingDirectory := t.TempDir()
+				originalWorkingDirectory, workingDirectoryError := os.Getwd()
+				require.NoError(t, workingDirectoryError)
+				require.NoError(t, os.Chdir(workingDirectory))
+				t.Cleanup(func() {
+					require.NoError(t, os.Chdir(originalWorkingDirectory))
+				})
+
+				return filepath.Join(workingDirectory, testConfigurationFileNameConstant)
+			},
+		},
+		{
+			name:      configurationInitializationUserTestNameConstant,
+			arguments: []string{configurationInitializationArgumentsUserConstant},
+			setup: func(t *testing.T) string {
+				workingDirectory := t.TempDir()
+				originalWorkingDirectory, workingDirectoryError := os.Getwd()
+				require.NoError(t, workingDirectoryError)
+				require.NoError(t, os.Chdir(workingDirectory))
+				t.Cleanup(func() {
+					require.NoError(t, os.Chdir(originalWorkingDirectory))
+				})
+
+				homeDirectory := t.TempDir()
+				t.Setenv(configurationInitializationUserHomeEnvNameConstant, homeDirectory)
+
+				return filepath.Join(homeDirectory, testUserConfigurationDirectoryNameConstant, testConfigurationFileNameConstant)
+			},
+		},
+	}
+
+	for testCaseIndex, testCase := range testCases {
+		testInstance.Run(fmt.Sprintf(applicationSearchPathSubtestNameTemplateConstant, testCaseIndex, testCase.name), func(t *testing.T) {
+			expectedConfigurationPath := testCase.setup(t)
+
+			originalArguments := os.Args
+			os.Args = append([]string{configurationInitializationApplicationNameConstant}, testCase.arguments...)
+			t.Cleanup(func() {
+				os.Args = originalArguments
+			})
+
+			application := cli.NewApplication()
+			executionError := application.Execute()
+			require.NoError(t, executionError)
+
+			fileContent, readError := os.ReadFile(expectedConfigurationPath)
+			require.NoError(t, readError)
+			require.Equal(t, embeddedConfigurationContent, fileContent)
+		})
+	}
+}
+
+func TestApplicationConfigurationInitializationForceHandling(testInstance *testing.T) {
+	embeddedConfigurationContent, _ := cli.EmbeddedDefaultConfiguration()
+	require.NotEmpty(testInstance, embeddedConfigurationContent)
+
+	testCases := []struct {
+		name        string
+		arguments   []string
+		expectError bool
+	}{
+		{
+			name:        configurationInitializationForceRequiredTestNameConstant,
+			arguments:   []string{configurationInitializationArgumentsLocalConstant},
+			expectError: true,
+		},
+		{
+			name: configurationInitializationForceEnabledTestNameConstant,
+			arguments: []string{
+				configurationInitializationArgumentsLocalConstant,
+				configurationInitializationForceFlagConstant,
+			},
+			expectError: false,
+		},
+	}
+
+	for testCaseIndex, testCase := range testCases {
+		testInstance.Run(fmt.Sprintf(applicationSearchPathSubtestNameTemplateConstant, testCaseIndex, testCase.name), func(t *testing.T) {
+			workingDirectory := t.TempDir()
+			originalWorkingDirectory, workingDirectoryError := os.Getwd()
+			require.NoError(t, workingDirectoryError)
+			require.NoError(t, os.Chdir(workingDirectory))
+			t.Cleanup(func() {
+				require.NoError(t, os.Chdir(originalWorkingDirectory))
+			})
+
+			configurationPath := filepath.Join(workingDirectory, testConfigurationFileNameConstant)
+			writeError := os.WriteFile(configurationPath, []byte(configurationInitializationExistingContentConstant), 0o600)
+			require.NoError(t, writeError)
+
+			originalArguments := os.Args
+			os.Args = append([]string{configurationInitializationApplicationNameConstant}, testCase.arguments...)
+			t.Cleanup(func() {
+				os.Args = originalArguments
+			})
+
+			application := cli.NewApplication()
+			executionError := application.Execute()
+
+			if testCase.expectError {
+				require.Error(t, executionError)
+				require.Contains(t, executionError.Error(), configurationInitializationErrorMessageFragmentConstant)
+
+				fileContent, readError := os.ReadFile(configurationPath)
+				require.NoError(t, readError)
+				require.Equal(t, configurationInitializationExistingContentConstant, string(fileContent))
+				return
+			}
+
+			require.NoError(t, executionError)
+
+			fileContent, readError := os.ReadFile(configurationPath)
+			require.NoError(t, readError)
+			require.Equal(t, embeddedConfigurationContent, fileContent)
 		})
 	}
 }

--- a/tests/configuration_initialization_integration_test.go
+++ b/tests/configuration_initialization_integration_test.go
@@ -1,0 +1,172 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	configurationInitializationLocalCaseNameConstant        = "local_scope"
+	configurationInitializationUserCaseNameConstant         = "user_scope"
+	configurationInitializationOverwriteCaseNameConstant    = "overwrite_protection"
+	configurationInitializationForceCaseNameConstant        = "force_overwrite"
+	configurationInitializationLocalArgumentConstant        = "--init"
+	configurationInitializationUserArgumentConstant         = "--init=user"
+	configurationInitializationForceFlagConstant            = "--force"
+	configurationInitializationHomeEnvNameConstant          = "HOME"
+	configurationInitializationUserDirectoryNameConstant    = ".gix"
+	configurationInitializationErrorMessageFragmentConstant = "already exists"
+)
+
+type configurationInitializationEnvironment struct {
+	workingDirectory          string
+	environmentOverrides      map[string]string
+	expectedConfigurationPath string
+}
+
+func TestCLIConfigurationInitializationCreatesFiles(testInstance *testing.T) {
+	currentWorkingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+	repositoryRootDirectory := filepath.Dir(currentWorkingDirectory)
+
+	binaryPath := buildIntegrationBinary(testInstance, repositoryRootDirectory)
+
+	testCases := []struct {
+		name      string
+		arguments []string
+		prepare   func(*testing.T) configurationInitializationEnvironment
+	}{
+		{
+			name:      configurationInitializationLocalCaseNameConstant,
+			arguments: []string{configurationInitializationLocalArgumentConstant},
+			prepare: func(t *testing.T) configurationInitializationEnvironment {
+				workingDirectory := t.TempDir()
+				expectedPath := filepath.Join(workingDirectory, integrationConfigFileNameConstant)
+				return configurationInitializationEnvironment{
+					workingDirectory:          workingDirectory,
+					environmentOverrides:      map[string]string{},
+					expectedConfigurationPath: expectedPath,
+				}
+			},
+		},
+		{
+			name:      configurationInitializationUserCaseNameConstant,
+			arguments: []string{configurationInitializationUserArgumentConstant},
+			prepare: func(t *testing.T) configurationInitializationEnvironment {
+				workingDirectory := t.TempDir()
+				homeDirectory := t.TempDir()
+				expectedPath := filepath.Join(homeDirectory, configurationInitializationUserDirectoryNameConstant, integrationConfigFileNameConstant)
+				return configurationInitializationEnvironment{
+					workingDirectory: workingDirectory,
+					environmentOverrides: map[string]string{
+						configurationInitializationHomeEnvNameConstant: homeDirectory,
+					},
+					expectedConfigurationPath: expectedPath,
+				}
+			},
+		},
+	}
+
+	for testCaseIndex, testCase := range testCases {
+		testInstance.Run(fmt.Sprintf(integrationSubtestNameTemplateConstant, testCaseIndex, testCase.name), func(t *testing.T) {
+			environmentDetails := testCase.prepare(t)
+
+			outputText, runError := runBinaryIntegrationCommand(
+				t,
+				binaryPath,
+				environmentDetails.workingDirectory,
+				environmentDetails.environmentOverrides,
+				integrationCommandTimeout,
+				testCase.arguments,
+			)
+			require.NoError(t, runError, outputText)
+
+			fileContent, readError := os.ReadFile(environmentDetails.expectedConfigurationPath)
+			require.NoError(t, readError)
+			require.NotEmpty(t, fileContent)
+
+			configurationDirectory := filepath.Dir(environmentDetails.expectedConfigurationPath)
+			directoryInfo, statError := os.Stat(configurationDirectory)
+			require.NoError(t, statError)
+			require.True(t, directoryInfo.IsDir())
+		})
+	}
+}
+
+func TestCLIConfigurationInitializationOverwriteProtection(testInstance *testing.T) {
+	currentWorkingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+	repositoryRootDirectory := filepath.Dir(currentWorkingDirectory)
+
+	binaryPath := buildIntegrationBinary(testInstance, repositoryRootDirectory)
+
+	testCases := []struct {
+		name            string
+		secondArguments []string
+		expectError     bool
+	}{
+		{
+			name:            configurationInitializationOverwriteCaseNameConstant,
+			secondArguments: []string{configurationInitializationLocalArgumentConstant},
+			expectError:     true,
+		},
+		{
+			name: configurationInitializationForceCaseNameConstant,
+			secondArguments: []string{
+				configurationInitializationLocalArgumentConstant,
+				configurationInitializationForceFlagConstant,
+			},
+			expectError: false,
+		},
+	}
+
+	for testCaseIndex, testCase := range testCases {
+		testInstance.Run(fmt.Sprintf(integrationSubtestNameTemplateConstant, testCaseIndex, testCase.name), func(t *testing.T) {
+			workingDirectory := t.TempDir()
+
+			firstOutput, firstError := runBinaryIntegrationCommand(
+				t,
+				binaryPath,
+				workingDirectory,
+				map[string]string{},
+				integrationCommandTimeout,
+				[]string{configurationInitializationLocalArgumentConstant},
+			)
+			require.NoError(t, firstError, firstOutput)
+
+			configurationPath := filepath.Join(workingDirectory, integrationConfigFileNameConstant)
+			initialContent, readError := os.ReadFile(configurationPath)
+			require.NoError(t, readError)
+			require.NotEmpty(t, initialContent)
+
+			secondOutput, secondError := runBinaryIntegrationCommand(
+				t,
+				binaryPath,
+				workingDirectory,
+				map[string]string{},
+				integrationCommandTimeout,
+				testCase.secondArguments,
+			)
+
+			if testCase.expectError {
+				require.Error(t, secondError)
+				require.Contains(t, secondOutput, configurationInitializationErrorMessageFragmentConstant)
+
+				resultingContent, verifyError := os.ReadFile(configurationPath)
+				require.NoError(t, verifyError)
+				require.Equal(t, initialContent, resultingContent)
+				return
+			}
+
+			require.NoError(t, secondError, secondOutput)
+
+			resultingContent, verifyError := os.ReadFile(configurationPath)
+			require.NoError(t, verifyError)
+			require.NotEmpty(t, resultingContent)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add persistent `--init` and `--force` flags to the CLI and route them through new configuration initialization helpers
- write the embedded default configuration to the requested scope while guarding against accidental overwrites
- extend unit and integration coverage to exercise initialization, scope selection, and overwrite handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e0072b0e5c8327b32001d1039ce189