### PR TITLE
Add owner-aware repo rename support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ with the registered command names and flags.
 | Command                 | Summary                                                       | Key flags / example                                                                                                                |
 |-------------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | `audit`                 | Audit and reconcile local GitHub repositories                 | Flags: `--root`, `--log-level`. Example: `go run . audit --log-level=debug --root ~/Development`                                    |
-| `repo-folders-rename`   | Rename repository directories to match canonical GitHub names | Flags: `--dry-run`, `--yes`, `--require-clean`. Example: `go run . repo-folders-rename --yes --require-clean --root ~/Development`        |
+| `repo-folders-rename`   | Rename repository directories to match canonical GitHub names | Flags: `--dry-run`, `--yes`, `--require-clean`, `--owner`. Example: `go run . repo-folders-rename --yes --require-clean --owner --root ~/Development`        |
 | `repo-remote-update`    | Update origin URLs to match canonical GitHub repositories     | Flags: `--dry-run`, `--yes`. Example: `go run . repo-remote-update --dry-run --root ~/Development`                                        |
 | `repo-protocol-convert` | Convert repository origin remotes between protocols           | Flags: `--from`, `--to`, `--dry-run`, `--yes`. Example: `go run . repo-protocol-convert --from https --to ssh --yes --root ~/Development` |
 | `repo-prs-purge`        | Remove remote and local branches for closed pull requests     | Flags: `--remote`, `--limit`, `--dry-run`. Example: `go run . repo-prs-purge --remote origin --limit 100 --root ~/Development`            |
@@ -156,6 +156,7 @@ operations:
       dry_run: false
       assume_yes: true
       require_clean: true
+      include_owner: false
       roots:
         - ~/Development
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ with the registered command names and flags.
 |-------------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | `audit`                 | Audit and reconcile local GitHub repositories                 | Flags: `--root`, `--log-level`. Example: `go run . audit --log-level=debug --root ~/Development`                                    |
 | `repo-folders-rename`   | Rename repository directories to match canonical GitHub names | Flags: `--dry-run`, `--yes`, `--require-clean`, `--owner`. Example: `go run . repo-folders-rename --yes --require-clean --owner --root ~/Development`        |
-| `repo-remote-update`    | Update origin URLs to match canonical GitHub repositories     | Flags: `--dry-run`, `--yes`. Example: `go run . repo-remote-update --dry-run --root ~/Development`                                        |
+| `repo-remote-update`    | Update origin URLs to match canonical GitHub repositories     | Flags: `--dry-run`, `--yes`, `--owner`. Example: `go run . repo-remote-update --dry-run --owner canonical --root ~/Development`          |
 | `repo-protocol-convert` | Convert repository origin remotes between protocols           | Flags: `--from`, `--to`, `--dry-run`, `--yes`. Example: `go run . repo-protocol-convert --from https --to ssh --yes --root ~/Development` |
 | `repo-prs-purge`        | Remove remote and local branches for closed pull requests     | Flags: `--remote`, `--limit`, `--dry-run`. Example: `go run . repo-prs-purge --remote origin --limit 100 --root ~/Development`            |
 | `branch-migrate`        | Migrate repository defaults from main to master               | Flags: `--from`, `--to`. Example: `go run . branch-migrate --from main --to master --root ~/Development/project-repo`                     |
@@ -139,6 +139,7 @@ operations:
     with: &repo_remotes_defaults
       dry_run: false
       assume_yes: true
+      owner: canonical
       roots:
         - ~/Development
 

--- a/cmd/cli/application_internal_test.go
+++ b/cmd/cli/application_internal_test.go
@@ -43,6 +43,7 @@ func TestApplicationCommonDefaultsApplied(t *testing.T) {
 	require.True(t, renameConfiguration.DryRun)
 	require.True(t, renameConfiguration.AssumeYes)
 	require.True(t, renameConfiguration.RequireCleanWorktree)
+	require.False(t, renameConfiguration.IncludeOwner)
 
 	workflowConfiguration := application.workflowCommandConfiguration()
 	require.True(t, workflowConfiguration.DryRun)
@@ -58,6 +59,7 @@ func TestApplicationOperationOverridesTakePriority(t *testing.T) {
 				"dry_run":       false,
 				"assume_yes":    false,
 				"require_clean": false,
+				"include_owner": true,
 				"roots":         []string{"/tmp/rename"},
 			},
 		},
@@ -89,6 +91,7 @@ func TestApplicationOperationOverridesTakePriority(t *testing.T) {
 	require.False(t, renameConfiguration.DryRun)
 	require.False(t, renameConfiguration.AssumeYes)
 	require.False(t, renameConfiguration.RequireCleanWorktree)
+	require.True(t, renameConfiguration.IncludeOwner)
 
 	workflowConfiguration := application.workflowCommandConfiguration()
 	require.False(t, workflowConfiguration.DryRun)

--- a/cmd/cli/default_config.yaml
+++ b/cmd/cli/default_config.yaml
@@ -32,6 +32,7 @@ operations:
     with:
       roots:
         - .
+      include_owner: false
   - operation: workflow
     with:
       roots:

--- a/cmd/cli/default_config.yaml
+++ b/cmd/cli/default_config.yaml
@@ -24,6 +24,7 @@ operations:
     with:
       roots:
         - .
+      owner: ""
   - operation: repo-protocol-convert
     with:
       roots:

--- a/cmd/cli/repos/configuration.go
+++ b/cmd/cli/repos/configuration.go
@@ -35,6 +35,7 @@ type RenameConfiguration struct {
 	AssumeYes            bool     `mapstructure:"assume_yes"`
 	RequireCleanWorktree bool     `mapstructure:"require_clean"`
 	RepositoryRoots      []string `mapstructure:"roots"`
+	IncludeOwner         bool     `mapstructure:"include_owner"`
 }
 
 // DefaultToolsConfiguration returns baseline configuration values for repository commands.
@@ -57,6 +58,7 @@ func DefaultToolsConfiguration() ToolsConfiguration {
 			AssumeYes:            false,
 			RequireCleanWorktree: false,
 			RepositoryRoots:      nil,
+			IncludeOwner:         false,
 		},
 	}
 }

--- a/cmd/cli/repos/configuration.go
+++ b/cmd/cli/repos/configuration.go
@@ -17,6 +17,7 @@ type ToolsConfiguration struct {
 type RemotesConfiguration struct {
 	DryRun          bool     `mapstructure:"dry_run"`
 	AssumeYes       bool     `mapstructure:"assume_yes"`
+	Owner           string   `mapstructure:"owner"`
 	RepositoryRoots []string `mapstructure:"roots"`
 }
 
@@ -44,6 +45,7 @@ func DefaultToolsConfiguration() ToolsConfiguration {
 		Remotes: RemotesConfiguration{
 			DryRun:          false,
 			AssumeYes:       false,
+			Owner:           "",
 			RepositoryRoots: nil,
 		},
 		Protocol: ProtocolConfiguration{
@@ -67,6 +69,7 @@ func DefaultToolsConfiguration() ToolsConfiguration {
 func (configuration RemotesConfiguration) sanitize() RemotesConfiguration {
 	sanitized := configuration
 	sanitized.RepositoryRoots = rootutils.SanitizeConfigured(configuration.RepositoryRoots)
+	sanitized.Owner = strings.TrimSpace(configuration.Owner)
 	return sanitized
 }
 

--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -133,12 +133,13 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 		}
 
 		renameOptions := rename.Options{
-			RepositoryPath:       inspection.Path,
-			DesiredFolderName:    plan.FolderName,
-			DryRun:               dryRun,
-			RequireCleanWorktree: requireClean,
-			AssumeYes:            trackingPrompter.AssumeYes(),
-			IncludeOwner:         plan.IncludeOwner,
+			RepositoryPath:          inspection.Path,
+			DesiredFolderName:       plan.FolderName,
+			DryRun:                  dryRun,
+			RequireCleanWorktree:    requireClean,
+			AssumeYes:               trackingPrompter.AssumeYes(),
+			IncludeOwner:            plan.IncludeOwner,
+			EnsureParentDirectories: plan.IncludeOwner,
 		}
 
 		rename.Execute(command.Context(), renameDependencies, renameOptions)

--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -18,6 +18,8 @@ const (
 	renameLongDescription         = "repo-folders-rename normalizes repository directory names to match canonical GitHub repositories."
 	renameRequireCleanFlagName    = "require-clean"
 	renameRequireCleanDescription = "Require clean worktrees before applying renames"
+	renameIncludeOwnerFlagName    = "owner"
+	renameIncludeOwnerDescription = "Include repository owner in the target directory path"
 )
 
 // RenameCommandBuilder assembles the repo-folders-rename command.
@@ -44,6 +46,7 @@ func (builder *RenameCommandBuilder) Build() (*cobra.Command, error) {
 	}
 
 	command.Flags().Bool(renameRequireCleanFlagName, false, renameRequireCleanDescription)
+	command.Flags().Bool(renameIncludeOwnerFlagName, false, renameIncludeOwnerDescription)
 
 	return command, nil
 }
@@ -65,6 +68,11 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 	requireClean := configuration.RequireCleanWorktree
 	if command != nil && command.Flags().Changed(renameRequireCleanFlagName) {
 		requireClean, _ = command.Flags().GetBool(renameRequireCleanFlagName)
+	}
+
+	includeOwner := configuration.IncludeOwner
+	if command != nil && command.Flags().Changed(renameIncludeOwnerFlagName) {
+		includeOwner, _ = command.Flags().GetBool(renameIncludeOwnerFlagName)
 	}
 
 	roots, rootsError := requireRepositoryRoots(command, arguments, configuration.RepositoryRoots)
@@ -114,20 +122,23 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 		Errors:     command.ErrOrStderr(),
 	}
 
+	directoryPlanner := rename.NewDirectoryPlanner()
 	for _, inspection := range inspections {
-		if len(strings.TrimSpace(inspection.DesiredFolderName)) == 0 {
+		plan := directoryPlanner.Plan(includeOwner, inspection.FinalOwnerRepo, inspection.DesiredFolderName)
+		if plan.IsNoop(inspection.Path, inspection.FolderName) {
 			continue
 		}
-		if inspection.DesiredFolderName == inspection.FolderName {
+		if len(strings.TrimSpace(plan.FolderName)) == 0 {
 			continue
 		}
 
 		renameOptions := rename.Options{
 			RepositoryPath:       inspection.Path,
-			DesiredFolderName:    inspection.DesiredFolderName,
+			DesiredFolderName:    plan.FolderName,
 			DryRun:               dryRun,
 			RequireCleanWorktree: requireClean,
 			AssumeYes:            trackingPrompter.AssumeYes(),
+			IncludeOwner:         plan.IncludeOwner,
 		}
 
 		rename.Execute(command.Context(), renameDependencies, renameOptions)

--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,7 @@ operations:
       dry_run: false
       assume_yes: true
       require_clean: true
+      include_owner: false
       roots:
         - ~/Development
 

--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,7 @@ operations:
     with: &repo_remotes_defaults
       dry_run: false
       assume_yes: true
+      owner: canonical
       roots:
         - ~/Development
 

--- a/docs/cli_design.md
+++ b/docs/cli_design.md
@@ -73,7 +73,7 @@ The table below maps current script switches to Cobra equivalents and documents 
 | Script behavior | Cobra command | Flags & arguments | `gh` usage strategy |
 | --- | --- | --- | --- |
 | CSV audit (read-only) | `git-maintenance audit` | `--root` (repeatable; defaults to `.`), `--debug`, `--format csv` (defaults to CSV; future extensibility), `--output` (optional file). Command is read-only. | Use `exec.CommandContext` to run `gh repo view` and `gh api repos/{owner}/{repo}` exactly once per repo. Results cached per repo to minimize API calls. |
-| Directory rename (`--rename`) | `git-maintenance repo-folders-rename` | `--root`, `--dry-run`, `--require-clean`, `--yes`. | Same metadata resolution as audit. No extra `gh` commands beyond canonical lookup. |
+| Directory rename (`--rename`) | `git-maintenance repo-folders-rename` | `--root`, `--dry-run`, `--require-clean`, `--yes`, `--owner`. | Same metadata resolution as audit. No extra `gh` commands beyond canonical lookup. |
 | Update remote to canonical (`--update-remote`) | `git-maintenance repo-remote-update` | `--root`, `--dry-run`, `--yes`. | Requires canonical owner/repo from `gh api repos/{owner}/{repo}`. |
 | Protocol conversion (`--protocol-from`, `--protocol-to`) | `git-maintenance repo-protocol-convert` | `--root`, `--from {https\|git\|ssh}`, `--to {https\|git\|ssh}`, `--dry-run`, `--yes`. | Canonical resolution via `gh api`; no other `gh` usage. |
 | Delete merged branches | `git-maintenance repo-prs-purge` | `--root`, `--remote origin` (default), `--pr-state closed` (default). No positional args. | Invoke `gh pr list --state <state>` via `exec`. The command will stream JSON once, then process locally. |

--- a/internal/repos/filesystem/os.go
+++ b/internal/repos/filesystem/os.go
@@ -23,3 +23,8 @@ func (OSFileSystem) Rename(oldPath string, newPath string) error {
 func (OSFileSystem) Abs(path string) (string, error) {
 	return filepath.Abs(path)
 }
+
+// MkdirAll ensures a directory hierarchy exists with the provided permissions.
+func (OSFileSystem) MkdirAll(path string, permissions fs.FileMode) error {
+	return os.MkdirAll(path, permissions)
+}

--- a/internal/repos/remotes/executor_test.go
+++ b/internal/repos/remotes/executor_test.go
@@ -61,6 +61,9 @@ const (
 	remotesTestDeclinedMessage         = "UPDATE-REMOTE-SKIP: user declined for %s\n"
 	remotesTestPromptErrorMessage      = "UPDATE-REMOTE-SKIP: %s (error: could not construct target URL)\n"
 	remotesTestSuccessMessage          = "UPDATE-REMOTE-DONE: %s origin now %s\n"
+	remotesTestOwnerConstraintMessage  = "UPDATE-REMOTE-SKIP: %s (owner constraint mismatch: expected %s, actual %s)\n"
+	remotesTestOwnerConstraintValue    = "canonical"
+	remotesTestOwnerMismatchValue      = "different"
 )
 
 func TestExecutorBehaviors(testInstance *testing.T) {
@@ -179,6 +182,35 @@ func TestExecutorBehaviors(testInstance *testing.T) {
 			gitManager:      &stubGitManager{},
 			expectedOutput:  fmt.Sprintf(remotesTestSuccessMessage, remotesTestRepositoryPath, remotesTestCanonicalURL),
 			expectedUpdates: 1,
+		},
+		{
+			name: "owner_constraint_matches",
+			options: remotes.Options{
+				RepositoryPath:           remotesTestRepositoryPath,
+				CurrentOriginURL:         remotesTestCurrentOriginURL,
+				OriginOwnerRepository:    remotesTestOriginOwnerRepository,
+				CanonicalOwnerRepository: remotesTestCanonicalOwnerRepo,
+				RemoteProtocol:           shared.RemoteProtocolHTTPS,
+				AssumeYes:                true,
+				OwnerConstraint:          remotesTestOwnerConstraintValue,
+			},
+			gitManager:      &stubGitManager{},
+			expectedOutput:  fmt.Sprintf(remotesTestSuccessMessage, remotesTestRepositoryPath, remotesTestCanonicalURL),
+			expectedUpdates: 1,
+		},
+		{
+			name: "owner_constraint_mismatch",
+			options: remotes.Options{
+				RepositoryPath:           remotesTestRepositoryPath,
+				CurrentOriginURL:         remotesTestCurrentOriginURL,
+				OriginOwnerRepository:    remotesTestOriginOwnerRepository,
+				CanonicalOwnerRepository: remotesTestCanonicalOwnerRepo,
+				RemoteProtocol:           shared.RemoteProtocolHTTPS,
+				OwnerConstraint:          remotesTestOwnerMismatchValue,
+			},
+			gitManager:      &stubGitManager{},
+			expectedOutput:  fmt.Sprintf(remotesTestOwnerConstraintMessage, remotesTestRepositoryPath, remotesTestOwnerMismatchValue, remotesTestOwnerConstraintValue),
+			expectedUpdates: 0,
 		},
 	}
 

--- a/internal/repos/rename/executor.go
+++ b/internal/repos/rename/executor.go
@@ -35,6 +35,7 @@ type Options struct {
 	DryRun               bool
 	RequireCleanWorktree bool
 	AssumeYes            bool
+	IncludeOwner         bool
 }
 
 // Dependencies supplies collaborators required to evaluate rename operations.

--- a/internal/repos/rename/planner.go
+++ b/internal/repos/rename/planner.go
@@ -1,0 +1,87 @@
+package rename
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ownerRepositorySeparatorConstant = "/"
+)
+
+// DirectoryPlan describes the desired folder arrangement for a repository rename.
+type DirectoryPlan struct {
+	FolderName        string
+	OwnerSegment      string
+	RepositorySegment string
+	IncludeOwner      bool
+}
+
+// DirectoryPlanner computes desired directory plans based on rename preferences.
+type DirectoryPlanner struct{}
+
+// NewDirectoryPlanner constructs a planner instance for deriving rename targets.
+func NewDirectoryPlanner() DirectoryPlanner {
+	return DirectoryPlanner{}
+}
+
+// Plan evaluates the desired directory layout for a repository.
+func (planner DirectoryPlanner) Plan(includeOwner bool, finalOwnerRepository string, defaultFolderName string) DirectoryPlan {
+	trimmedDefaultFolderName := strings.TrimSpace(defaultFolderName)
+	plan := DirectoryPlan{
+		FolderName:        trimmedDefaultFolderName,
+		RepositorySegment: trimmedDefaultFolderName,
+	}
+
+	if !includeOwner {
+		return plan
+	}
+
+	ownerSegment, repositorySegment, parseSucceeded := splitOwnerRepository(finalOwnerRepository)
+	if !parseSucceeded {
+		return plan
+	}
+
+	plan.IncludeOwner = true
+	plan.OwnerSegment = ownerSegment
+	plan.RepositorySegment = repositorySegment
+	plan.FolderName = filepath.Join(ownerSegment, repositorySegment)
+
+	return plan
+}
+
+// IsNoop determines whether the repository already resides at the desired location.
+func (plan DirectoryPlan) IsNoop(repositoryPath string, currentFolderName string) bool {
+	trimmedTarget := strings.TrimSpace(plan.FolderName)
+	if len(trimmedTarget) == 0 {
+		return true
+	}
+
+	if plan.IncludeOwner {
+		cleanedRepositoryPath := filepath.Clean(repositoryPath)
+		expectedSuffix := filepath.Clean(trimmedTarget)
+		return strings.HasSuffix(cleanedRepositoryPath, expectedSuffix)
+	}
+
+	return trimmedTarget == strings.TrimSpace(currentFolderName)
+}
+
+func splitOwnerRepository(ownerRepository string) (string, string, bool) {
+	trimmedOwnerRepository := strings.TrimSpace(ownerRepository)
+	if len(trimmedOwnerRepository) == 0 {
+		return "", "", false
+	}
+
+	segments := strings.Split(trimmedOwnerRepository, ownerRepositorySeparatorConstant)
+	if len(segments) != 2 {
+		return "", "", false
+	}
+
+	ownerSegment := strings.TrimSpace(segments[0])
+	repositorySegment := strings.TrimSpace(segments[1])
+	if len(ownerSegment) == 0 || len(repositorySegment) == 0 {
+		return "", "", false
+	}
+
+	return ownerSegment, repositorySegment, true
+}

--- a/internal/repos/rename/planner_test.go
+++ b/internal/repos/rename/planner_test.go
@@ -1,0 +1,127 @@
+package rename_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/gix/internal/repos/rename"
+)
+
+const (
+	plannerOwnerRepositoryConstant          = "owner/example"
+	plannerAlternateOwnerRepositoryConstant = "alternate/sample"
+	plannerDefaultFolderNameConstant        = "example"
+	plannerRepositoryPathConstant           = "/tmp/example"
+	plannerOwnerRepositoryPathConstant      = "/tmp/owner/example"
+)
+
+func TestDirectoryPlannerPlan(testInstance *testing.T) {
+	testCases := []struct {
+		name              string
+		includeOwner      bool
+		finalOwnerRepo    string
+		defaultFolderName string
+		expectedPlan      rename.DirectoryPlan
+	}{
+		{
+			name:              "without_owner_uses_default",
+			includeOwner:      false,
+			finalOwnerRepo:    plannerOwnerRepositoryConstant,
+			defaultFolderName: plannerDefaultFolderNameConstant,
+			expectedPlan: rename.DirectoryPlan{
+				FolderName:        plannerDefaultFolderNameConstant,
+				RepositorySegment: plannerDefaultFolderNameConstant,
+				IncludeOwner:      false,
+			},
+		},
+		{
+			name:              "with_owner_builds_nested_folder",
+			includeOwner:      true,
+			finalOwnerRepo:    plannerOwnerRepositoryConstant,
+			defaultFolderName: plannerDefaultFolderNameConstant,
+			expectedPlan: rename.DirectoryPlan{
+				FolderName:        filepath.Join("owner", "example"),
+				OwnerSegment:      "owner",
+				RepositorySegment: "example",
+				IncludeOwner:      true,
+			},
+		},
+		{
+			name:              "with_owner_missing_identifier_uses_default",
+			includeOwner:      true,
+			finalOwnerRepo:    "",
+			defaultFolderName: plannerDefaultFolderNameConstant,
+			expectedPlan: rename.DirectoryPlan{
+				FolderName:        plannerDefaultFolderNameConstant,
+				RepositorySegment: plannerDefaultFolderNameConstant,
+				IncludeOwner:      false,
+			},
+		},
+	}
+
+	planner := rename.NewDirectoryPlanner()
+	for _, testCase := range testCases {
+		testCase := testCase
+		testInstance.Run(testCase.name, func(subtest *testing.T) {
+			plan := planner.Plan(testCase.includeOwner, testCase.finalOwnerRepo, testCase.defaultFolderName)
+			require.Equal(subtest, testCase.expectedPlan, plan)
+		})
+	}
+}
+
+func TestDirectoryPlanIsNoop(testInstance *testing.T) {
+	planner := rename.NewDirectoryPlanner()
+	testCases := []struct {
+		name           string
+		plan           rename.DirectoryPlan
+		repositoryPath string
+		currentFolder  string
+		expectedIsNoop bool
+	}{
+		{
+			name:           "empty_target_skips",
+			plan:           rename.DirectoryPlan{FolderName: ""},
+			repositoryPath: plannerRepositoryPathConstant,
+			currentFolder:  plannerDefaultFolderNameConstant,
+			expectedIsNoop: true,
+		},
+		{
+			name:           "matching_folder_without_owner",
+			plan:           planner.Plan(false, plannerOwnerRepositoryConstant, plannerDefaultFolderNameConstant),
+			repositoryPath: plannerRepositoryPathConstant,
+			currentFolder:  plannerDefaultFolderNameConstant,
+			expectedIsNoop: true,
+		},
+		{
+			name:           "mismatched_folder_without_owner",
+			plan:           planner.Plan(false, plannerOwnerRepositoryConstant, plannerDefaultFolderNameConstant),
+			repositoryPath: plannerRepositoryPathConstant,
+			currentFolder:  "legacy",
+			expectedIsNoop: false,
+		},
+		{
+			name:           "matching_owner_repository_suffix",
+			plan:           planner.Plan(true, plannerOwnerRepositoryConstant, plannerDefaultFolderNameConstant),
+			repositoryPath: plannerOwnerRepositoryPathConstant,
+			currentFolder:  plannerDefaultFolderNameConstant,
+			expectedIsNoop: true,
+		},
+		{
+			name:           "different_owner_repository_suffix",
+			plan:           planner.Plan(true, plannerAlternateOwnerRepositoryConstant, plannerDefaultFolderNameConstant),
+			repositoryPath: plannerOwnerRepositoryPathConstant,
+			currentFolder:  plannerDefaultFolderNameConstant,
+			expectedIsNoop: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		testInstance.Run(testCase.name, func(subtest *testing.T) {
+			isNoop := testCase.plan.IsNoop(testCase.repositoryPath, testCase.currentFolder)
+			require.Equal(subtest, testCase.expectedIsNoop, isNoop)
+		})
+	}
+}

--- a/internal/repos/shared/types.go
+++ b/internal/repos/shared/types.go
@@ -49,6 +49,7 @@ type FileSystem interface {
 	Stat(path string) (fs.FileInfo, error)
 	Rename(oldPath string, newPath string) error
 	Abs(path string) (string, error)
+	MkdirAll(path string, permissions fs.FileMode) error
 }
 
 // ConfirmationResult captures the outcome of a user confirmation prompt.

--- a/internal/workflow/configuration_test.go
+++ b/internal/workflow/configuration_test.go
@@ -18,6 +18,8 @@ const (
 	configurationInvalidWorkflowMappingCase = "workflow mapping is rejected"
 	configurationOptionFromKey              = "from"
 	configurationOptionToKey                = "to"
+	configurationOptionRequireClean         = "require_clean"
+	configurationOptionIncludeOwnerKey      = "include_owner"
 	anchoredWorkflowConfigurationTemplate   = `operations:
   - &protocol_conversion_step
     operation: convert-protocol
@@ -75,6 +77,42 @@ func TestBuildOperations(testInstance *testing.T) {
 			assertFunc: func(testingInstance *testing.T, operation workflow.Operation) {
 				_, castSucceeded := operation.(*workflow.CanonicalRemoteOperation)
 				require.True(testingInstance, castSucceeded)
+			},
+		},
+		{
+			name: "builds rename operation with defaults",
+			configuration: workflow.Configuration{
+				Steps: []workflow.StepConfiguration{
+					{Operation: workflow.OperationTypeRenameDirectories},
+				},
+			},
+			expectedOperationType: workflow.OperationTypeRenameDirectories,
+			assertFunc: func(testingInstance *testing.T, operation workflow.Operation) {
+				renameOperation, castSucceeded := operation.(*workflow.RenameOperation)
+				require.True(testingInstance, castSucceeded)
+				require.False(testingInstance, renameOperation.RequireCleanWorktree)
+				require.False(testingInstance, renameOperation.IncludeOwner)
+			},
+		},
+		{
+			name: "builds rename operation with include owner",
+			configuration: workflow.Configuration{
+				Steps: []workflow.StepConfiguration{
+					{
+						Operation: workflow.OperationTypeRenameDirectories,
+						Options: map[string]any{
+							configurationOptionRequireClean:    true,
+							configurationOptionIncludeOwnerKey: true,
+						},
+					},
+				},
+			},
+			expectedOperationType: workflow.OperationTypeRenameDirectories,
+			assertFunc: func(testingInstance *testing.T, operation workflow.Operation) {
+				renameOperation, castSucceeded := operation.(*workflow.RenameOperation)
+				require.True(testingInstance, castSucceeded)
+				require.True(testingInstance, renameOperation.RequireCleanWorktree)
+				require.True(testingInstance, renameOperation.IncludeOwner)
 			},
 		},
 	}

--- a/internal/workflow/configuration_test.go
+++ b/internal/workflow/configuration_test.go
@@ -20,6 +20,8 @@ const (
 	configurationOptionToKey                = "to"
 	configurationOptionRequireClean         = "require_clean"
 	configurationOptionIncludeOwnerKey      = "include_owner"
+	configurationOptionOwnerKey             = "owner"
+	configurationOwnerValueConstant         = "canonical"
 	anchoredWorkflowConfigurationTemplate   = `operations:
   - &protocol_conversion_step
     operation: convert-protocol
@@ -70,13 +72,19 @@ func TestBuildOperations(testInstance *testing.T) {
 			name: "builds canonical remote operation",
 			configuration: workflow.Configuration{
 				Steps: []workflow.StepConfiguration{
-					{Operation: workflow.OperationTypeCanonicalRemote},
+					{
+						Operation: workflow.OperationTypeCanonicalRemote,
+						Options: map[string]any{
+							configurationOptionOwnerKey: configurationOwnerValueConstant,
+						},
+					},
 				},
 			},
 			expectedOperationType: workflow.OperationTypeCanonicalRemote,
 			assertFunc: func(testingInstance *testing.T, operation workflow.Operation) {
-				_, castSucceeded := operation.(*workflow.CanonicalRemoteOperation)
+				canonicalOperation, castSucceeded := operation.(*workflow.CanonicalRemoteOperation)
 				require.True(testingInstance, castSucceeded)
+				require.Equal(testingInstance, configurationOwnerValueConstant, canonicalOperation.OwnerConstraint)
 			},
 		},
 		{

--- a/internal/workflow/operations_builder.go
+++ b/internal/workflow/operations_builder.go
@@ -94,7 +94,15 @@ func buildRenameOperation(options map[string]any) (Operation, error) {
 	if requireCleanError != nil {
 		return nil, requireCleanError
 	}
-	return &RenameOperation{RequireCleanWorktree: requireClean, requireCleanExplicit: requireCleanExplicit}, nil
+	includeOwner, _, includeOwnerError := reader.boolValue(optionIncludeOwnerKeyConstant)
+	if includeOwnerError != nil {
+		return nil, includeOwnerError
+	}
+	return &RenameOperation{
+		RequireCleanWorktree: requireClean,
+		requireCleanExplicit: requireCleanExplicit,
+		IncludeOwner:         includeOwner,
+	}, nil
 }
 
 func buildBranchMigrationOperation(options map[string]any) (Operation, error) {

--- a/internal/workflow/operations_builder.go
+++ b/internal/workflow/operations_builder.go
@@ -41,7 +41,7 @@ func buildOperationFromStep(step StepConfiguration) (Operation, error) {
 	case OperationTypeProtocolConversion:
 		return buildProtocolConversionOperation(normalizedOptions)
 	case OperationTypeCanonicalRemote:
-		return &CanonicalRemoteOperation{}, nil
+		return buildCanonicalRemoteOperation(normalizedOptions)
 	case OperationTypeRenameDirectories:
 		return buildRenameOperation(normalizedOptions)
 	case OperationTypeBranchMigration:
@@ -86,6 +86,16 @@ func buildProtocolConversionOperation(options map[string]any) (Operation, error)
 	}
 
 	return &ProtocolConversionOperation{FromProtocol: fromProtocol, ToProtocol: toProtocol}, nil
+}
+
+func buildCanonicalRemoteOperation(options map[string]any) (Operation, error) {
+	reader := newOptionReader(options)
+	ownerValue, _, ownerError := reader.stringValue(optionOwnerKeyConstant)
+	if ownerError != nil {
+		return nil, ownerError
+	}
+
+	return &CanonicalRemoteOperation{OwnerConstraint: strings.TrimSpace(ownerValue)}, nil
 }
 
 func buildRenameOperation(options map[string]any) (Operation, error) {

--- a/internal/workflow/operations_remote.go
+++ b/internal/workflow/operations_remote.go
@@ -14,7 +14,9 @@ const (
 )
 
 // CanonicalRemoteOperation updates origin URLs to their canonical GitHub equivalents.
-type CanonicalRemoteOperation struct{}
+type CanonicalRemoteOperation struct {
+	OwnerConstraint string
+}
 
 // Name identifies the operation type.
 func (operation *CanonicalRemoteOperation) Name() string {
@@ -54,6 +56,7 @@ func (operation *CanonicalRemoteOperation) Execute(executionContext context.Cont
 			RemoteProtocol:           shared.RemoteProtocol(repository.Inspection.RemoteProtocol),
 			DryRun:                   environment.DryRun,
 			AssumeYes:                assumeYes,
+			OwnerConstraint:          strings.TrimSpace(operation.OwnerConstraint),
 		}
 
 		remotes.Execute(executionContext, dependencies, options)

--- a/internal/workflow/operations_rename.go
+++ b/internal/workflow/operations_rename.go
@@ -61,12 +61,13 @@ func (operation *RenameOperation) Execute(executionContext context.Context, envi
 		originalPath := repository.Path
 
 		options := rename.Options{
-			RepositoryPath:       originalPath,
-			DesiredFolderName:    plan.FolderName,
-			DryRun:               environment.DryRun,
-			RequireCleanWorktree: operation.RequireCleanWorktree,
-			AssumeYes:            assumeYes,
-			IncludeOwner:         plan.IncludeOwner,
+			RepositoryPath:          originalPath,
+			DesiredFolderName:       plan.FolderName,
+			DryRun:                  environment.DryRun,
+			RequireCleanWorktree:    operation.RequireCleanWorktree,
+			AssumeYes:               assumeYes,
+			IncludeOwner:            plan.IncludeOwner,
+			EnsureParentDirectories: plan.IncludeOwner,
 		}
 
 		rename.Execute(executionContext, dependencies, options)

--- a/internal/workflow/options_reader.go
+++ b/internal/workflow/options_reader.go
@@ -10,6 +10,7 @@ const (
 	optionToKeyConstant                 = "to"
 	optionRequireCleanKeyConstant       = "require_clean"
 	optionIncludeOwnerKeyConstant       = "include_owner"
+	optionOwnerKeyConstant              = "owner"
 	optionTargetsKeyConstant            = "targets"
 	optionRemoteNameKeyConstant         = "remote_name"
 	optionSourceBranchKeyConstant       = "source_branch"

--- a/internal/workflow/options_reader.go
+++ b/internal/workflow/options_reader.go
@@ -9,6 +9,7 @@ const (
 	optionFromKeyConstant               = "from"
 	optionToKeyConstant                 = "to"
 	optionRequireCleanKeyConstant       = "require_clean"
+	optionIncludeOwnerKeyConstant       = "include_owner"
 	optionTargetsKeyConstant            = "targets"
 	optionRemoteNameKeyConstant         = "remote_name"
 	optionSourceBranchKeyConstant       = "source_branch"

--- a/tests/repos_integration_test.go
+++ b/tests/repos_integration_test.go
@@ -54,7 +54,7 @@ const (
 	reposIntegrationProtocolMissingFlagsMessage = "specify both --from and --to"
 	reposIntegrationConfigFlagName              = "--config"
 	reposIntegrationConfigFileName              = "config.yaml"
-	reposIntegrationConfigTemplate              = "common:\n  log_level: error\noperations:\n  - operation: repo-remote-update\n    with:\n      roots:\n        - %s\n      assume_yes: true\n  - operation: repo-protocol-convert\n    with:\n      roots:\n        - %s\n      assume_yes: true\n      from: https\n      to: ssh\nworkflow: []\n"
+	reposIntegrationConfigTemplate              = "common:\n  log_level: error\noperations:\n  - operation: repo-remote-update\n    with:\n      roots:\n        - %s\n      assume_yes: true\n      owner: canonical\n  - operation: repo-protocol-convert\n    with:\n      roots:\n        - %s\n      assume_yes: true\n      from: https\n      to: ssh\nworkflow: []\n"
 	reposIntegrationConfigSearchEnvName         = "GIX_CONFIG_SEARCH_PATH"
 	reposIntegrationHomeSymbolConstant          = "~"
 	reposIntegrationHomeRootPatternConstant     = "gix-home-root-*"

--- a/tests/workflow_integration_test.go
+++ b/tests/workflow_integration_test.go
@@ -322,6 +322,7 @@ operations:
         - .
       assume_yes: true
       dry_run: false
+      owner: canonical
   - operation: branch-migrate
     with: &migration_defaults
       roots:


### PR DESCRIPTION
## Summary
- add an include_owner option to repo-folders-rename configuration and expose it via a new --owner flag
- plan rename targets through a shared directory planner so the CLI and workflow can include owner folders when requested
- document the new option and extend unit and integration coverage for owner-aware renames

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68e014023554832787cc3ebbdd051b96