### PR TITLE
Support parent directory creation when renaming repositories

### DIFF
--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -133,12 +133,13 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 		}
 
 		renameOptions := rename.Options{
-			RepositoryPath:       inspection.Path,
-			DesiredFolderName:    plan.FolderName,
-			DryRun:               dryRun,
-			RequireCleanWorktree: requireClean,
-			AssumeYes:            trackingPrompter.AssumeYes(),
-			IncludeOwner:         plan.IncludeOwner,
+			RepositoryPath:          inspection.Path,
+			DesiredFolderName:       plan.FolderName,
+			DryRun:                  dryRun,
+			RequireCleanWorktree:    requireClean,
+			AssumeYes:               trackingPrompter.AssumeYes(),
+			IncludeOwner:            plan.IncludeOwner,
+			EnsureParentDirectories: plan.IncludeOwner,
 		}
 
 		rename.Execute(command.Context(), renameDependencies, renameOptions)

--- a/internal/repos/filesystem/os.go
+++ b/internal/repos/filesystem/os.go
@@ -23,3 +23,8 @@ func (OSFileSystem) Rename(oldPath string, newPath string) error {
 func (OSFileSystem) Abs(path string) (string, error) {
 	return filepath.Abs(path)
 }
+
+// MkdirAll ensures a directory hierarchy exists with the provided permissions.
+func (OSFileSystem) MkdirAll(path string, permissions fs.FileMode) error {
+	return os.MkdirAll(path, permissions)
+}

--- a/internal/repos/shared/types.go
+++ b/internal/repos/shared/types.go
@@ -49,6 +49,7 @@ type FileSystem interface {
 	Stat(path string) (fs.FileInfo, error)
 	Rename(oldPath string, newPath string) error
 	Abs(path string) (string, error)
+	MkdirAll(path string, permissions fs.FileMode) error
 }
 
 // ConfirmationResult captures the outcome of a user confirmation prompt.

--- a/internal/workflow/operations_rename.go
+++ b/internal/workflow/operations_rename.go
@@ -61,12 +61,13 @@ func (operation *RenameOperation) Execute(executionContext context.Context, envi
 		originalPath := repository.Path
 
 		options := rename.Options{
-			RepositoryPath:       originalPath,
-			DesiredFolderName:    plan.FolderName,
-			DryRun:               environment.DryRun,
-			RequireCleanWorktree: operation.RequireCleanWorktree,
-			AssumeYes:            assumeYes,
-			IncludeOwner:         plan.IncludeOwner,
+			RepositoryPath:          originalPath,
+			DesiredFolderName:       plan.FolderName,
+			DryRun:                  environment.DryRun,
+			RequireCleanWorktree:    operation.RequireCleanWorktree,
+			AssumeYes:               assumeYes,
+			IncludeOwner:            plan.IncludeOwner,
+			EnsureParentDirectories: plan.IncludeOwner,
 		}
 
 		rename.Execute(executionContext, dependencies, options)


### PR DESCRIPTION
## Summary
- extend the shared FileSystem with MkdirAll and support it in the OS-backed implementation
- allow the rename executor to create missing parent directories when requested and wire the option through CLI and workflow code
- update rename executor and CLI tests to cover parent-directory creation scenarios

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68e01c7009148327956a7dca2e99a916