### PR TITLE
Handle audit report nested output directories

### DIFF
--- a/internal/workflow/operations_audit_test.go
+++ b/internal/workflow/operations_audit_test.go
@@ -1,0 +1,70 @@
+package workflow_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/gix/internal/workflow"
+)
+
+const (
+	auditReportTestFileNameConstant       = "audit_report.csv"
+	auditReportWhitespacePaddingConstant  = " "
+	auditReportExpectedHeaderLineConstant = "final_github_repo,folder_name,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical"
+)
+
+func TestAuditReportOperationCreatesNestedOutput(testInstance *testing.T) {
+	testCases := []struct {
+		name                     string
+		outputPathComponents     []string
+		shouldTrimConfiguredPath bool
+		expectedFileRelativePath string
+	}{{
+		name:                     "creates nested directories and writes header",
+		outputPathComponents:     []string{"nested", "reports"},
+		shouldTrimConfiguredPath: true,
+		expectedFileRelativePath: auditReportTestFileNameConstant,
+	}}
+
+	for testCaseIndex := range testCases {
+		currentTestCase := testCases[testCaseIndex]
+
+		testInstance.Run(currentTestCase.name, func(testingInstance *testing.T) {
+			testingInstance.Parallel()
+
+			temporaryDirectory := testingInstance.TempDir()
+			filePathComponents := append([]string{temporaryDirectory}, currentTestCase.outputPathComponents...)
+			filePathComponents = append(filePathComponents, currentTestCase.expectedFileRelativePath)
+			configuredOutputPath := filepath.Join(filePathComponents...)
+			if currentTestCase.shouldTrimConfiguredPath {
+				configuredOutputPath = auditReportWhitespacePaddingConstant + configuredOutputPath + auditReportWhitespacePaddingConstant
+			}
+
+			operation := &workflow.AuditReportOperation{OutputPath: configuredOutputPath, WriteToFile: true}
+			operationEnvironment := &workflow.Environment{Output: &bytes.Buffer{}}
+			operationState := &workflow.State{}
+
+			executionError := operation.Execute(context.Background(), operationEnvironment, operationState)
+			require.NoError(testingInstance, executionError)
+
+			sanitizedOutputPath := strings.TrimSpace(configuredOutputPath)
+			require.FileExists(testingInstance, sanitizedOutputPath)
+
+			fileParentDirectory := filepath.Dir(sanitizedOutputPath)
+			require.DirExists(testingInstance, fileParentDirectory)
+
+			fileContents, fileReadError := os.ReadFile(sanitizedOutputPath)
+			require.NoError(testingInstance, fileReadError)
+
+			fileLines := strings.Split(strings.TrimSpace(string(fileContents)), "\n")
+			require.NotEmpty(testingInstance, fileLines)
+			require.Equal(testingInstance, auditReportExpectedHeaderLineConstant, fileLines[0])
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- trim configured audit report output paths before writing and ensure parent directories exist
- add a regression test that writes an audit report into a nested directory and verifies the CSV header

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e03f0cfab0832793305bf458050888