### PR TITLE
Implement branch refresh command

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -14,7 +14,17 @@ Leave Features, BugFixes, Improvements, Maintenance sections empty when all fixe
 
 ## Improvements
 
+- [ ] [GX-04] Add --version flag and use the technique similar to the ctx.
+Add a helper function (e.g., GetApplicationVersion) that returns a version string by first checking debug.ReadBuildInfo(). If that yields a
+    non-empty, non-(devel) version, return it. Otherwise, look for the repository root, then try git describe --tags --exact-match, and finally
+    git describe --tags --long --dirty; trim whitespace and fall back to a constant like "unknown" if every call fails.
+  - In the Cobra root command constructor, bind a --version flag to a boolean. Use a PersistentPreRun hook to detect when the flag is set,
+    print fmt.Printf("app version: %s\n", GetApplicationVersion()), and exit immediately with os.Exit(0) so no subcommands execute.
+  - Ensure the flag is documented in usage text, and keep the version template in a constant to avoid repeated string literals.
+  - Maintain clean GoDoc for exported APIs, run go fmt ./..., go vet ./..., and go test ./... before finishing.
+
 ## BugFixes
 
-## Maintenance
+- [ ] [GX-05] when running Repo PRS purge command it didnt ask for the confirmation. ensure that the dialog about any distructive operations is codined in one place and is present for all of the operations that perform actual changes, plan first
 
+## Maintenance

--- a/NOTES.md
+++ b/NOTES.md
@@ -14,15 +14,6 @@ Leave Features, BugFixes, Improvements, Maintenance sections empty when all fixe
 
 ## Improvements
 
-- [ ] [GX-04] Add --version flag and use the technique similar to the ctx.
-Add a helper function (e.g., GetApplicationVersion) that returns a version string by first checking debug.ReadBuildInfo(). If that yields a
-    non-empty, non-(devel) version, return it. Otherwise, look for the repository root, then try git describe --tags --exact-match, and finally
-    git describe --tags --long --dirty; trim whitespace and fall back to a constant like "unknown" if every call fails.
-  - In the Cobra root command constructor, bind a --version flag to a boolean. Use a PersistentPreRun hook to detect when the flag is set,
-    print fmt.Printf("app version: %s\n", GetApplicationVersion()), and exit immediately with os.Exit(0) so no subcommands execute.
-  - Ensure the flag is documented in usage text, and keep the version template in a constant to avoid repeated string literals.
-  - Maintain clean GoDoc for exported APIs, run go fmt ./..., go vet ./..., and go test ./... before finishing.
-
 ## BugFixes
 
 - [ ] [GX-05] when running Repo PRS purge command it didnt ask for the confirmation. ensure that the dialog about any distructive operations is codined in one place and is present for all of the operations that perform actual changes, plan first

--- a/NOTES.md
+++ b/NOTES.md
@@ -16,6 +16,4 @@ Leave Features, BugFixes, Improvements, Maintenance sections empty when all fixe
 
 ## BugFixes
 
-- [ ] [GX-05] when running Repo PRS purge command it didnt ask for the confirmation. ensure that the dialog about any distructive operations is codined in one place and is present for all of the operations that perform actual changes, plan first
-
 ## Maintenance

--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -98,7 +98,7 @@ const (
 	branchMigrateOperationNameConstant                               = "branch-migrate"
 	versionFlagNameConstant                                          = "version"
 	versionFlagUsageConstant                                         = "Print the application version and exit"
-	versionOutputTemplateConstant                                    = "app version: %s\n"
+	versionOutputTemplateConstant                                    = "gix version: %s\n"
 	operationDecodeErrorMessageConstant                              = "unable to decode operation defaults"
 	operationNameLogFieldConstant                                    = "operation"
 	operationErrorLogFieldConstant                                   = "error"

--- a/cmd/cli/application_test.go
+++ b/cmd/cli/application_test.go
@@ -19,6 +19,7 @@ import (
 	workflowcmd "github.com/temirov/gix/cmd/cli/workflow"
 	"github.com/temirov/gix/internal/audit"
 	"github.com/temirov/gix/internal/branches"
+	branchrefresh "github.com/temirov/gix/internal/branches/refresh"
 	"github.com/temirov/gix/internal/migrate"
 	"github.com/temirov/gix/internal/packages"
 	"github.com/temirov/gix/internal/utils"
@@ -34,6 +35,7 @@ const (
 	testConfigurationSearchPathEnvironmentName               = "GIX_CONFIG_SEARCH_PATH"
 	testPackagesCommandNameConstant                          = "repo-packages-purge"
 	testBranchMigrateCommandNameConstant                     = "branch-migrate"
+	testBranchRefreshCommandNameConstant                     = "branch-refresh"
 	testBranchCleanupCommandNameConstant                     = "repo-prs-purge"
 	testReposRemotesCommandNameConstant                      = "repo-remote-update"
 	testReposProtocolCommandNameConstant                     = "repo-protocol-convert"
@@ -46,6 +48,7 @@ const (
 	embeddedDefaultsReposProtocolTestNameConstant            = "ReposProtocolDefaults"
 	embeddedDefaultsReposRenameTestNameConstant              = "ReposRenameDefaults"
 	embeddedDefaultsWorkflowTestNameConstant                 = "WorkflowDefaults"
+	embeddedDefaultsBranchRefreshTestNameConstant            = "BranchRefreshDefaults"
 	embeddedDefaultsBranchMigrateTestNameConstant            = "BranchMigrateDefaults"
 	embeddedDefaultsAuditTestNameConstant                    = "AuditDefaults"
 	embeddedDefaultRootPathConstant                          = "."
@@ -86,6 +89,7 @@ var requiredOperationNames = []string{
 	"repo-remote-update",
 	"repo-protocol-convert",
 	"workflow",
+	"branch-refresh",
 	"branch-migrate",
 }
 
@@ -122,6 +126,7 @@ func TestApplicationInitializeConfiguration(t *testing.T) {
 				"repo-remote-update",
 				"repo-protocol-convert",
 				"workflow",
+				"branch-refresh",
 			},
 			commandUse: testBranchMigrateCommandNameConstant,
 		},
@@ -579,6 +584,22 @@ func TestApplicationEmbeddedDefaultsProvideCommandConfigurations(testInstance *t
 
 				assertions := require.New(assertionTarget)
 				assertions.Equal([]string{embeddedDefaultRootPathConstant}, sanitized.Roots)
+			},
+		},
+		{
+			name:          embeddedDefaultsBranchRefreshTestNameConstant,
+			commandUse:    testBranchRefreshCommandNameConstant,
+			operationName: testBranchRefreshCommandNameConstant,
+			assertion: func(assertionTarget testing.TB, options map[string]any) {
+				assertionTarget.Helper()
+
+				var configuration branchrefresh.CommandConfiguration
+				decodeOperationOptions(assertionTarget, options, &configuration)
+				sanitized := configuration.Sanitize()
+
+				assertions := require.New(assertionTarget)
+				assertions.Equal([]string{embeddedDefaultRootPathConstant}, sanitized.RepositoryRoots)
+				assertions.Empty(strings.TrimSpace(sanitized.BranchName))
 			},
 		},
 		{

--- a/cmd/cli/application_version_test.go
+++ b/cmd/cli/application_version_test.go
@@ -78,6 +78,6 @@ func TestApplicationVersionFlagPrintsVersionAndExits(t *testing.T) {
 	})
 
 	output := capture.Stop(t)
-	require.Equal(t, "app version: v2.0.0\n", output)
+	require.Equal(t, "gix version: v2.0.0\n", output)
 	require.Equal(t, 0, exitCode)
 }

--- a/cmd/cli/application_version_test.go
+++ b/cmd/cli/application_version_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stdoutCapture struct {
+	original *os.File
+	reader   *os.File
+	writer   *os.File
+}
+
+func startStdoutCapture(t *testing.T) stdoutCapture {
+	t.Helper()
+
+	reader, writer, pipeError := os.Pipe()
+	require.NoError(t, pipeError)
+
+	capture := stdoutCapture{
+		original: os.Stdout,
+		reader:   reader,
+		writer:   writer,
+	}
+
+	os.Stdout = writer
+	return capture
+}
+
+func (capture *stdoutCapture) Stop(t *testing.T) string {
+	t.Helper()
+
+	os.Stdout = capture.original
+	require.NoError(t, capture.writer.Close())
+
+	capturedBytes, readError := io.ReadAll(capture.reader)
+	require.NoError(t, readError)
+	require.NoError(t, capture.reader.Close())
+
+	output := string(capturedBytes)
+	capture.reader = nil
+	capture.writer = nil
+	return output
+}
+
+func TestApplicationVersionFlagPrintsVersionAndExits(t *testing.T) {
+	application := NewApplication()
+	application.versionResolver = func(context.Context) string {
+		return "v2.0.0"
+	}
+
+	exitCode := -1
+	sentinel := "version-exit"
+	application.exitFunction = func(code int) {
+		exitCode = code
+		panic(sentinel)
+	}
+
+	capture := startStdoutCapture(t)
+	defer func() {
+		if capture.reader != nil {
+			_ = capture.Stop(t)
+		}
+	}()
+
+	originalArgs := os.Args
+	defer func() {
+		os.Args = originalArgs
+	}()
+	os.Args = []string{"gix", "--version"}
+
+	require.PanicsWithValue(t, sentinel, func() {
+		_ = application.Execute()
+	})
+
+	output := capture.Stop(t)
+	require.Equal(t, "app version: v2.0.0\n", output)
+	require.Equal(t, 0, exitCode)
+}

--- a/cmd/cli/default_config.yaml
+++ b/cmd/cli/default_config.yaml
@@ -38,6 +38,10 @@ operations:
     with:
       roots:
         - .
+  - operation: branch-refresh
+    with:
+      roots:
+        - .
   - operation: branch-migrate
     with:
       roots:

--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,11 @@ operations:
       dry_run: false
       assume_yes: false
 
+  - operation: branch-refresh
+    with: &branch_refresh_defaults
+      roots:
+        - ~/Development
+
   - operation: branch-migrate
     with: &branch_migrate_defaults
       debug: false

--- a/internal/branches/configuration.go
+++ b/internal/branches/configuration.go
@@ -13,6 +13,7 @@ type CommandConfiguration struct {
 	RemoteName       string   `mapstructure:"remote"`
 	PullRequestLimit int      `mapstructure:"limit"`
 	DryRun           bool     `mapstructure:"dry_run"`
+	AssumeYes        bool     `mapstructure:"assume_yes"`
 	RepositoryRoots  []string `mapstructure:"roots"`
 }
 
@@ -22,6 +23,7 @@ func DefaultCommandConfiguration() CommandConfiguration {
 		RemoteName:       "",
 		PullRequestLimit: 0,
 		DryRun:           false,
+		AssumeYes:        false,
 		RepositoryRoots:  nil,
 	}
 }

--- a/internal/branches/refresh/command.go
+++ b/internal/branches/refresh/command.go
@@ -1,0 +1,145 @@
+package refresh
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/temirov/gix/internal/repos/dependencies"
+	"github.com/temirov/gix/internal/repos/shared"
+	"github.com/temirov/gix/internal/utils"
+	rootutils "github.com/temirov/gix/internal/utils/roots"
+)
+
+const (
+	commandUseConstant                      = "branch-refresh"
+	commandShortDescriptionConstant         = "Fetch, checkout, and pull a branch"
+	commandLongDescriptionConstant          = "branch-refresh synchronizes a repository branch by fetching updates, checking out the branch, and pulling the latest changes."
+	stashFlagNameConstant                   = "stash"
+	stashFlagDescriptionConstant            = "Stash local changes before refreshing the branch"
+	commitFlagNameConstant                  = "commit"
+	commitFlagDescriptionConstant           = "Commit local changes before refreshing the branch"
+	missingBranchNameMessageConstant        = "branch name is required; supply --branch"
+	conflictingRecoveryFlagsMessageConstant = "use at most one of --stash or --commit"
+	refreshSuccessMessageTemplateConstant   = "REFRESHED: %s (%s)\n"
+)
+
+// LoggerProvider yields a zap logger for command execution.
+type LoggerProvider func() *zap.Logger
+
+// CommandBuilder assembles the branch-refresh command.
+type CommandBuilder struct {
+	LoggerProvider               LoggerProvider
+	GitExecutor                  shared.GitExecutor
+	GitRepositoryManager         shared.GitRepositoryManager
+	HumanReadableLoggingProvider func() bool
+	ConfigurationProvider        func() CommandConfiguration
+}
+
+// Build constructs the branch-refresh command.
+func (builder *CommandBuilder) Build() (*cobra.Command, error) {
+	command := &cobra.Command{
+		Use:   commandUseConstant,
+		Short: commandShortDescriptionConstant,
+		Long:  commandLongDescriptionConstant,
+		Args:  cobra.NoArgs,
+		RunE:  builder.run,
+	}
+
+	command.Flags().Bool(stashFlagNameConstant, false, stashFlagDescriptionConstant)
+	command.Flags().Bool(commitFlagNameConstant, false, commitFlagDescriptionConstant)
+
+	return command, nil
+}
+
+func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) error {
+	configuration := builder.resolveConfiguration()
+
+	branchName := strings.TrimSpace(configuration.BranchName)
+	contextAccessor := utils.NewCommandContextAccessor()
+	if branchContext, exists := contextAccessor.BranchContext(command.Context()); exists {
+		if len(strings.TrimSpace(branchContext.Name)) > 0 {
+			branchName = branchContext.Name
+		}
+	}
+	if len(branchName) == 0 {
+		if command != nil {
+			_ = command.Help()
+		}
+		return errors.New(missingBranchNameMessageConstant)
+	}
+
+	stashRequested, stashFlagError := command.Flags().GetBool(stashFlagNameConstant)
+	if stashFlagError != nil {
+		return stashFlagError
+	}
+	commitRequested, commitFlagError := command.Flags().GetBool(commitFlagNameConstant)
+	if commitFlagError != nil {
+		return commitFlagError
+	}
+	if stashRequested && commitRequested {
+		return errors.New(conflictingRecoveryFlagsMessageConstant)
+	}
+
+	repositoryRoots, rootsError := rootutils.Resolve(command, arguments, configuration.RepositoryRoots)
+	if rootsError != nil {
+		return rootsError
+	}
+
+	logger := builder.resolveLogger()
+	humanReadableLogging := false
+	if builder.HumanReadableLoggingProvider != nil {
+		humanReadableLogging = builder.HumanReadableLoggingProvider()
+	}
+	gitExecutor, executorError := dependencies.ResolveGitExecutor(builder.GitExecutor, logger, humanReadableLogging)
+	if executorError != nil {
+		return executorError
+	}
+
+	repositoryManager, managerError := dependencies.ResolveGitRepositoryManager(builder.GitRepositoryManager, gitExecutor)
+	if managerError != nil {
+		return managerError
+	}
+
+	service, serviceCreationError := NewService(Dependencies{GitExecutor: gitExecutor, RepositoryManager: repositoryManager})
+	if serviceCreationError != nil {
+		return serviceCreationError
+	}
+
+	for _, repositoryPath := range repositoryRoots {
+		_, refreshError := service.Refresh(command.Context(), Options{
+			RepositoryPath: repositoryPath,
+			BranchName:     branchName,
+			RequireClean:   true,
+			StashChanges:   stashRequested,
+			CommitChanges:  commitRequested,
+		})
+		if refreshError != nil {
+			return refreshError
+		}
+		fmt.Fprintf(command.OutOrStdout(), refreshSuccessMessageTemplateConstant, repositoryPath, branchName)
+	}
+
+	return nil
+}
+
+func (builder *CommandBuilder) resolveConfiguration() CommandConfiguration {
+	if builder.ConfigurationProvider == nil {
+		return DefaultCommandConfiguration()
+	}
+	return builder.ConfigurationProvider().Sanitize()
+}
+
+func (builder *CommandBuilder) resolveLogger() *zap.Logger {
+	if builder.LoggerProvider == nil {
+		return zap.NewNop()
+	}
+	logger := builder.LoggerProvider()
+	if logger == nil {
+		return zap.NewNop()
+	}
+	return logger
+}

--- a/internal/branches/refresh/command_test.go
+++ b/internal/branches/refresh/command_test.go
@@ -1,0 +1,160 @@
+package refresh_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/temirov/gix/internal/branches/refresh"
+	"github.com/temirov/gix/internal/execshell"
+	"github.com/temirov/gix/internal/utils"
+	flagutils "github.com/temirov/gix/internal/utils/flags"
+)
+
+type recordingGitExecutor struct {
+	invocationErrors []error
+	recordedCommands []execshell.CommandDetails
+}
+
+func (executor *recordingGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	executor.recordedCommands = append(executor.recordedCommands, details)
+	if len(executor.invocationErrors) == 0 {
+		return execshell.ExecutionResult{}, nil
+	}
+	err := executor.invocationErrors[0]
+	executor.invocationErrors = executor.invocationErrors[1:]
+	if err != nil {
+		return execshell.ExecutionResult{}, err
+	}
+	return execshell.ExecutionResult{}, nil
+}
+
+func (executor *recordingGitExecutor) ExecuteGitHubCLI(_ context.Context, _ execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{}, nil
+}
+
+type constantCleanRepositoryManager struct{}
+
+type erroringRepositoryManager struct{}
+
+func (constantCleanRepositoryManager) CheckCleanWorktree(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func (constantCleanRepositoryManager) GetCurrentBranch(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (constantCleanRepositoryManager) GetRemoteURL(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func (constantCleanRepositoryManager) SetRemoteURL(context.Context, string, string, string) error {
+	return nil
+}
+
+func (erroringRepositoryManager) CheckCleanWorktree(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (erroringRepositoryManager) GetCurrentBranch(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (erroringRepositoryManager) GetRemoteURL(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func (erroringRepositoryManager) SetRemoteURL(context.Context, string, string, string) error {
+	return nil
+}
+
+func TestBuildReturnsCommand(t *testing.T) {
+	builder := refresh.CommandBuilder{}
+	command, buildError := builder.Build()
+	require.NoError(t, buildError)
+	require.IsType(t, &cobra.Command{}, command)
+}
+
+func TestCommandRequiresBranchName(t *testing.T) {
+	builder := refresh.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() refresh.CommandConfiguration {
+			return refresh.CommandConfiguration{}
+		},
+		GitExecutor:          &recordingGitExecutor{},
+		GitRepositoryManager: constantCleanRepositoryManager{},
+	}
+	command, buildError := builder.Build()
+	require.NoError(t, buildError)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+	require.Error(t, command.RunE(command, []string{}))
+}
+
+func TestCommandRunsSuccessfully(t *testing.T) {
+	temporaryRepository := t.TempDir()
+	executor := &recordingGitExecutor{}
+	builder := refresh.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() refresh.CommandConfiguration {
+			return refresh.CommandConfiguration{RepositoryRoots: []string{temporaryRepository}}
+		},
+		GitExecutor:          executor,
+		GitRepositoryManager: constantCleanRepositoryManager{},
+	}
+	command, buildError := builder.Build()
+	require.NoError(t, buildError)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+
+	contextAccessor := utils.NewCommandContextAccessor()
+	command.SetContext(contextAccessor.WithBranchContext(context.Background(), utils.BranchContext{Name: "main", RequireClean: true}))
+
+	outputBuffer := &bytes.Buffer{}
+	command.SetOut(outputBuffer)
+
+	require.NoError(t, command.RunE(command, []string{}))
+	require.Contains(t, outputBuffer.String(), temporaryRepository)
+	require.Contains(t, outputBuffer.String(), "main")
+	require.Len(t, executor.recordedCommands, 3)
+}
+
+func TestCommandReportsDirtyWorktree(t *testing.T) {
+	temporaryRepository := t.TempDir()
+	builder := refresh.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() refresh.CommandConfiguration {
+			return refresh.CommandConfiguration{RepositoryRoots: []string{temporaryRepository}, BranchName: "main"}
+		},
+		GitExecutor:          &recordingGitExecutor{},
+		GitRepositoryManager: erroringRepositoryManager{},
+	}
+	command, buildError := builder.Build()
+	require.NoError(t, buildError)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+
+	require.Error(t, command.RunE(command, []string{}))
+}
+
+func TestCommandRejectsConflictingFlags(t *testing.T) {
+	temporaryRepository := t.TempDir()
+	builder := refresh.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() refresh.CommandConfiguration {
+			return refresh.CommandConfiguration{RepositoryRoots: []string{temporaryRepository}, BranchName: "main"}
+		},
+		GitExecutor:          &recordingGitExecutor{},
+		GitRepositoryManager: constantCleanRepositoryManager{},
+	}
+	command, buildError := builder.Build()
+	require.NoError(t, buildError)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+
+	require.NoError(t, command.Flags().Set("stash", "true"))
+	require.NoError(t, command.Flags().Set("commit", "true"))
+
+	require.Error(t, command.RunE(command, []string{}))
+}

--- a/internal/branches/refresh/configuration.go
+++ b/internal/branches/refresh/configuration.go
@@ -1,0 +1,28 @@
+package refresh
+
+import (
+	"strings"
+
+	pathutils "github.com/temirov/gix/internal/utils/path"
+)
+
+var refreshConfigurationRepositoryPathSanitizer = pathutils.NewRepositoryPathSanitizerWithConfiguration(nil, pathutils.RepositoryPathSanitizerConfiguration{PruneNestedPaths: true})
+
+// CommandConfiguration captures configuration values for the branch refresh command.
+type CommandConfiguration struct {
+	RepositoryRoots []string `mapstructure:"roots"`
+	BranchName      string   `mapstructure:"branch"`
+}
+
+// DefaultCommandConfiguration returns empty defaults for the branch refresh command.
+func DefaultCommandConfiguration() CommandConfiguration {
+	return CommandConfiguration{}
+}
+
+// Sanitize trims textual configuration values and normalizes repository roots.
+func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
+	sanitized := configuration
+	sanitized.BranchName = strings.TrimSpace(configuration.BranchName)
+	sanitized.RepositoryRoots = refreshConfigurationRepositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
+	return sanitized
+}

--- a/internal/branches/refresh/doc.go
+++ b/internal/branches/refresh/doc.go
@@ -1,0 +1,2 @@
+// Package refresh provides a CLI command that synchronizes local branches with their remotes.
+package refresh

--- a/internal/branches/refresh/service.go
+++ b/internal/branches/refresh/service.go
@@ -1,0 +1,139 @@
+package refresh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/temirov/gix/internal/execshell"
+	"github.com/temirov/gix/internal/repos/shared"
+)
+
+const (
+	repositoryPathRequiredMessageConstant       = "repository path must be provided"
+	branchNameRequiredMessageConstant           = "branch name must be provided"
+	gitExecutorMissingMessageConstant           = "git executor not configured"
+	repositoryManagerMissingMessageConstant     = "repository manager not configured"
+	cleanVerificationErrorTemplateConstant      = "failed to verify clean worktree: %w"
+	worktreeNotCleanMessageConstant             = "repository worktree is not clean"
+	gitFetchFailureTemplateConstant             = "failed to fetch updates: %w"
+	gitCheckoutFailureTemplateConstant          = "failed to checkout branch %q: %w"
+	gitPullFailureTemplateConstant              = "failed to pull latest changes: %w"
+	gitFetchSubcommandConstant                  = "fetch"
+	gitFetchPruneFlagConstant                   = "--prune"
+	gitCheckoutSubcommandConstant               = "checkout"
+	gitPullSubcommandConstant                   = "pull"
+	gitPullFastForwardFlagConstant              = "--ff-only"
+	gitTerminalPromptEnvironmentNameConstant    = "GIT_TERMINAL_PROMPT"
+	gitTerminalPromptEnvironmentDisableConstant = "0"
+)
+
+// ErrRepositoryPathRequired indicates the repository path option was empty.
+var ErrRepositoryPathRequired = errors.New(repositoryPathRequiredMessageConstant)
+
+// ErrBranchNameRequired indicates the branch name option was empty.
+var ErrBranchNameRequired = errors.New(branchNameRequiredMessageConstant)
+
+// ErrGitExecutorNotConfigured indicates the git executor dependency was missing.
+var ErrGitExecutorNotConfigured = errors.New(gitExecutorMissingMessageConstant)
+
+// ErrRepositoryManagerNotConfigured indicates the repository manager dependency was missing.
+var ErrRepositoryManagerNotConfigured = errors.New(repositoryManagerMissingMessageConstant)
+
+// ErrWorktreeNotClean indicates the repository contains uncommitted changes.
+var ErrWorktreeNotClean = errors.New(worktreeNotCleanMessageConstant)
+
+// Dependencies enumerates external collaborators required for refresh operations.
+type Dependencies struct {
+	GitExecutor       shared.GitExecutor
+	RepositoryManager shared.GitRepositoryManager
+}
+
+// Options configures a branch refresh operation.
+type Options struct {
+	RepositoryPath string
+	BranchName     string
+	RequireClean   bool
+	StashChanges   bool
+	CommitChanges  bool
+}
+
+// Result captures the observable outcomes of a refresh.
+type Result struct {
+	RepositoryPath string
+	BranchName     string
+}
+
+// Service coordinates branch refresh operations through git.
+type Service struct {
+	executor          shared.GitExecutor
+	repositoryManager shared.GitRepositoryManager
+}
+
+// NewService constructs a Service from the provided dependencies.
+func NewService(dependencies Dependencies) (*Service, error) {
+	if dependencies.GitExecutor == nil {
+		return nil, ErrGitExecutorNotConfigured
+	}
+	if dependencies.RepositoryManager == nil {
+		return nil, ErrRepositoryManagerNotConfigured
+	}
+	return &Service{executor: dependencies.GitExecutor, repositoryManager: dependencies.RepositoryManager}, nil
+}
+
+// Refresh synchronizes the specified branch with its remote counterpart.
+func (service *Service) Refresh(executionContext context.Context, options Options) (Result, error) {
+	trimmedRepositoryPath := strings.TrimSpace(options.RepositoryPath)
+	if len(trimmedRepositoryPath) == 0 {
+		return Result{}, ErrRepositoryPathRequired
+	}
+
+	trimmedBranchName := strings.TrimSpace(options.BranchName)
+	if len(trimmedBranchName) == 0 {
+		return Result{}, ErrBranchNameRequired
+	}
+
+	requireClean := options.RequireClean
+	if requireClean {
+		clean, cleanError := service.repositoryManager.CheckCleanWorktree(executionContext, trimmedRepositoryPath)
+		if cleanError != nil {
+			return Result{}, fmt.Errorf(cleanVerificationErrorTemplateConstant, cleanError)
+		}
+		if !clean {
+			return Result{}, ErrWorktreeNotClean
+		}
+	}
+
+	if fetchError := service.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant},
+		WorkingDirectory: trimmedRepositoryPath,
+	}); fetchError != nil {
+		return Result{}, fmt.Errorf(gitFetchFailureTemplateConstant, fetchError)
+	}
+
+	if checkoutError := service.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitCheckoutSubcommandConstant, trimmedBranchName},
+		WorkingDirectory: trimmedRepositoryPath,
+	}); checkoutError != nil {
+		return Result{}, fmt.Errorf(gitCheckoutFailureTemplateConstant, trimmedBranchName, checkoutError)
+	}
+
+	if pullError := service.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitPullSubcommandConstant, gitPullFastForwardFlagConstant},
+		WorkingDirectory: trimmedRepositoryPath,
+	}); pullError != nil {
+		return Result{}, fmt.Errorf(gitPullFailureTemplateConstant, pullError)
+	}
+
+	return Result{RepositoryPath: trimmedRepositoryPath, BranchName: trimmedBranchName}, nil
+}
+
+func (service *Service) executeGit(executionContext context.Context, details execshell.CommandDetails) error {
+	if details.EnvironmentVariables == nil {
+		details.EnvironmentVariables = map[string]string{}
+	}
+	details.EnvironmentVariables[gitTerminalPromptEnvironmentNameConstant] = gitTerminalPromptEnvironmentDisableConstant
+	_, executionError := service.executor.ExecuteGit(executionContext, details)
+	return executionError
+}

--- a/internal/branches/refresh/service.go
+++ b/internal/branches/refresh/service.go
@@ -17,6 +17,10 @@ const (
 	repositoryManagerMissingMessageConstant     = "repository manager not configured"
 	cleanVerificationErrorTemplateConstant      = "failed to verify clean worktree: %w"
 	worktreeNotCleanMessageConstant             = "repository worktree is not clean"
+	stashFailureTemplateConstant                = "failed to stash local changes: %w"
+	stageFailureTemplateConstant                = "failed to stage local changes: %w"
+	commitFailureTemplateConstant               = "failed to commit local changes: %w"
+	commitMessageTemplateConstant               = "chore: checkpoint before refreshing %s"
 	gitFetchFailureTemplateConstant             = "failed to fetch updates: %w"
 	gitCheckoutFailureTemplateConstant          = "failed to checkout branch %q: %w"
 	gitPullFailureTemplateConstant              = "failed to pull latest changes: %w"
@@ -25,6 +29,13 @@ const (
 	gitCheckoutSubcommandConstant               = "checkout"
 	gitPullSubcommandConstant                   = "pull"
 	gitPullFastForwardFlagConstant              = "--ff-only"
+	gitAddSubcommandConstant                    = "add"
+	gitAddAllFlagConstant                       = "--all"
+	gitCommitSubcommandConstant                 = "commit"
+	gitCommitMessageFlagConstant                = "-m"
+	gitStashSubcommandConstant                  = "stash"
+	gitStashPushSubcommandConstant              = "push"
+	gitStashIncludeUntrackedFlagConstant        = "--include-untracked"
 	gitTerminalPromptEnvironmentNameConstant    = "GIT_TERMINAL_PROMPT"
 	gitTerminalPromptEnvironmentDisableConstant = "0"
 )
@@ -101,7 +112,25 @@ func (service *Service) Refresh(executionContext context.Context, options Option
 			return Result{}, fmt.Errorf(cleanVerificationErrorTemplateConstant, cleanError)
 		}
 		if !clean {
-			return Result{}, ErrWorktreeNotClean
+			if options.StashChanges {
+				if stashError := service.stashLocalChanges(executionContext, trimmedRepositoryPath); stashError != nil {
+					return Result{}, stashError
+				}
+			} else if options.CommitChanges {
+				if commitError := service.commitLocalChanges(executionContext, trimmedRepositoryPath, trimmedBranchName); commitError != nil {
+					return Result{}, commitError
+				}
+			} else {
+				return Result{}, ErrWorktreeNotClean
+			}
+
+			clean, cleanError = service.repositoryManager.CheckCleanWorktree(executionContext, trimmedRepositoryPath)
+			if cleanError != nil {
+				return Result{}, fmt.Errorf(cleanVerificationErrorTemplateConstant, cleanError)
+			}
+			if !clean {
+				return Result{}, ErrWorktreeNotClean
+			}
 		}
 	}
 
@@ -136,4 +165,33 @@ func (service *Service) executeGit(executionContext context.Context, details exe
 	details.EnvironmentVariables[gitTerminalPromptEnvironmentNameConstant] = gitTerminalPromptEnvironmentDisableConstant
 	_, executionError := service.executor.ExecuteGit(executionContext, details)
 	return executionError
+}
+
+func (service *Service) stashLocalChanges(executionContext context.Context, repositoryPath string) error {
+	if stashError := service.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitStashSubcommandConstant, gitStashPushSubcommandConstant, gitStashIncludeUntrackedFlagConstant},
+		WorkingDirectory: repositoryPath,
+	}); stashError != nil {
+		return fmt.Errorf(stashFailureTemplateConstant, stashError)
+	}
+	return nil
+}
+
+func (service *Service) commitLocalChanges(executionContext context.Context, repositoryPath string, branchName string) error {
+	if stageError := service.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitAddSubcommandConstant, gitAddAllFlagConstant},
+		WorkingDirectory: repositoryPath,
+	}); stageError != nil {
+		return fmt.Errorf(stageFailureTemplateConstant, stageError)
+	}
+
+	commitMessage := fmt.Sprintf(commitMessageTemplateConstant, branchName)
+	if commitError := service.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitCommitSubcommandConstant, gitCommitMessageFlagConstant, commitMessage},
+		WorkingDirectory: repositoryPath,
+	}); commitError != nil {
+		return fmt.Errorf(commitFailureTemplateConstant, commitError)
+	}
+
+	return nil
 }

--- a/internal/branches/refresh/service_test.go
+++ b/internal/branches/refresh/service_test.go
@@ -214,4 +214,5 @@ func TestRefreshCommitsDirtyWorktreeWhenRequested(t *testing.T) {
 	require.Len(t, executor.recordedCommands, 5)
 	require.Equal(t, []string{gitAddSubcommandConstant, gitAddAllFlagConstant}, executor.recordedCommands[0].Arguments)
 	require.Equal(t, []string{gitCommitSubcommandConstant, gitCommitMessageFlagConstant, fmt.Sprintf(commitMessageTemplateConstant, branchName)}, executor.recordedCommands[1].Arguments)
+	require.Equal(t, []string{gitPullSubcommandConstant, gitPullRebaseFlagConstant}, executor.recordedCommands[4].Arguments)
 }

--- a/internal/branches/refresh/service_test.go
+++ b/internal/branches/refresh/service_test.go
@@ -1,0 +1,176 @@
+package refresh
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/gix/internal/execshell"
+)
+
+type stubGitExecutor struct {
+	invocationErrors []error
+	recordedCommands []execshell.CommandDetails
+}
+
+func (executor *stubGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	executor.recordedCommands = append(executor.recordedCommands, details)
+	if len(executor.invocationErrors) == 0 {
+		return execshell.ExecutionResult{}, nil
+	}
+	err := executor.invocationErrors[0]
+	executor.invocationErrors = executor.invocationErrors[1:]
+	if err != nil {
+		return execshell.ExecutionResult{}, err
+	}
+	return execshell.ExecutionResult{}, nil
+}
+
+func (executor *stubGitExecutor) ExecuteGitHubCLI(_ context.Context, _ execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{}, nil
+}
+
+type stubRepositoryManager struct {
+	cleanState     bool
+	executionError error
+}
+
+func (manager stubRepositoryManager) CheckCleanWorktree(context.Context, string) (bool, error) {
+	return manager.cleanState, manager.executionError
+}
+
+func (stubRepositoryManager) GetCurrentBranch(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (stubRepositoryManager) GetRemoteURL(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func (stubRepositoryManager) SetRemoteURL(context.Context, string, string, string) error {
+	return nil
+}
+
+func TestNewServiceValidatesDependencies(t *testing.T) {
+	testCases := []struct {
+		name         string
+		dependencies Dependencies
+		expectedErr  error
+	}{
+		{
+			name:         "MissingGitExecutor",
+			dependencies: Dependencies{RepositoryManager: stubRepositoryManager{cleanState: true}},
+			expectedErr:  ErrGitExecutorNotConfigured,
+		},
+		{
+			name:         "MissingRepositoryManager",
+			dependencies: Dependencies{GitExecutor: &stubGitExecutor{}},
+			expectedErr:  ErrRepositoryManagerNotConfigured,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			service, creationError := NewService(testCase.dependencies)
+			require.ErrorIs(t, creationError, testCase.expectedErr)
+			require.Nil(t, service)
+		})
+	}
+
+	service, creationError := NewService(Dependencies{GitExecutor: &stubGitExecutor{}, RepositoryManager: stubRepositoryManager{cleanState: true}})
+	require.NoError(t, creationError)
+	require.NotNil(t, service)
+}
+
+func TestRefreshValidatesInputs(t *testing.T) {
+	executor := &stubGitExecutor{}
+	service, creationError := NewService(Dependencies{GitExecutor: executor, RepositoryManager: stubRepositoryManager{cleanState: true}})
+	require.NoError(t, creationError)
+
+	_, err := service.Refresh(context.Background(), Options{BranchName: "main", RequireClean: true})
+	require.ErrorIs(t, err, ErrRepositoryPathRequired)
+
+	_, err = service.Refresh(context.Background(), Options{RepositoryPath: "/tmp/repo", RequireClean: true})
+	require.ErrorIs(t, err, ErrBranchNameRequired)
+}
+
+func TestRefreshPropagatesCleanCheckError(t *testing.T) {
+	executor := &stubGitExecutor{}
+	repositoryManager := stubRepositoryManager{cleanState: false, executionError: errors.New("status failed")}
+	service, creationError := NewService(Dependencies{GitExecutor: executor, RepositoryManager: repositoryManager})
+	require.NoError(t, creationError)
+
+	_, err := service.Refresh(context.Background(), Options{RepositoryPath: "/tmp/repo", BranchName: "main", RequireClean: true})
+	require.ErrorContains(t, err, "failed to verify clean worktree")
+}
+
+func TestRefreshFailsWhenWorktreeDirty(t *testing.T) {
+	executor := &stubGitExecutor{}
+	repositoryManager := stubRepositoryManager{cleanState: false}
+	service, creationError := NewService(Dependencies{GitExecutor: executor, RepositoryManager: repositoryManager})
+	require.NoError(t, creationError)
+
+	_, err := service.Refresh(context.Background(), Options{RepositoryPath: "/tmp/repo", BranchName: "main", RequireClean: true})
+	require.ErrorIs(t, err, ErrWorktreeNotClean)
+}
+
+func TestRefreshExecutesGitCommandsInOrder(t *testing.T) {
+	executor := &stubGitExecutor{}
+	repositoryManager := stubRepositoryManager{cleanState: true}
+	service, creationError := NewService(Dependencies{GitExecutor: executor, RepositoryManager: repositoryManager})
+	require.NoError(t, creationError)
+
+	result, err := service.Refresh(context.Background(), Options{RepositoryPath: "/tmp/repo", BranchName: "main", RequireClean: true})
+	require.NoError(t, err)
+	require.Equal(t, Result{RepositoryPath: "/tmp/repo", BranchName: "main"}, result)
+	require.Len(t, executor.recordedCommands, 3)
+	require.Equal(t, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant}, executor.recordedCommands[0].Arguments)
+	require.Equal(t, []string{gitCheckoutSubcommandConstant, "main"}, executor.recordedCommands[1].Arguments)
+	require.Equal(t, []string{gitPullSubcommandConstant, gitPullFastForwardFlagConstant}, executor.recordedCommands[2].Arguments)
+
+	for _, commandDetails := range executor.recordedCommands {
+		require.Equal(t, gitTerminalPromptEnvironmentDisableConstant, commandDetails.EnvironmentVariables[gitTerminalPromptEnvironmentNameConstant])
+	}
+}
+
+func TestRefreshSurfacesGitFailures(t *testing.T) {
+	testError := errors.New("execution failed")
+	testCases := []struct {
+		name             string
+		errors           []error
+		expectedFragment string
+	}{
+		{
+			name:             "FetchFailure",
+			errors:           []error{testError},
+			expectedFragment: "failed to fetch updates",
+		},
+		{
+			name:             "CheckoutFailure",
+			errors:           []error{nil, testError},
+			expectedFragment: "failed to checkout branch",
+		},
+		{
+			name:             "PullFailure",
+			errors:           []error{nil, nil, testError},
+			expectedFragment: "failed to pull latest changes",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			executor := &stubGitExecutor{invocationErrors: append([]error{}, testCase.errors...)}
+			repositoryManager := stubRepositoryManager{cleanState: true}
+			service, creationError := NewService(Dependencies{GitExecutor: executor, RepositoryManager: repositoryManager})
+			require.NoError(t, creationError)
+
+			_, err := service.Refresh(context.Background(), Options{RepositoryPath: "/tmp/repo", BranchName: "main", RequireClean: true})
+			require.ErrorContains(t, err, testCase.expectedFragment)
+			require.Contains(t, err.Error(), testError.Error())
+		})
+	}
+}

--- a/internal/version/detector.go
+++ b/internal/version/detector.go
@@ -1,0 +1,195 @@
+package version
+
+import (
+	"context"
+	"errors"
+	"os"
+	"runtime/debug"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/temirov/gix/internal/execshell"
+	"github.com/temirov/gix/internal/repos/shared"
+)
+
+const (
+	unknownVersionFallbackConstant            = "unknown"
+	buildInfoDevelVersionValue                = "devel"
+	gitRevParseSubcommandConstant             = "rev-parse"
+	gitShowTopLevelFlagConstant               = "--show-toplevel"
+	gitDescribeSubcommandConstant             = "describe"
+	gitTagsFlagConstant                       = "--tags"
+	gitExactMatchFlagConstant                 = "--exact-match"
+	gitLongFlagConstant                       = "--long"
+	gitDirtyFlagConstant                      = "--dirty"
+	gitTerminalPromptEnvironmentNameConstant  = "GIT_TERMINAL_PROMPT"
+	gitTerminalPromptEnvironmentValueConstant = "0"
+	gitExecutorMissingMessageConstant         = "git executor not configured"
+)
+
+// BuildInfoProvider exposes runtime build metadata.
+type BuildInfoProvider interface {
+	Read() (*debug.BuildInfo, bool)
+}
+
+// Detector resolves application version strings.
+type Detector struct {
+	buildInfoProvider BuildInfoProvider
+	gitExecutor       shared.GitExecutor
+	workingDirectory  string
+}
+
+// Dependencies describes the collaborators required for version detection.
+type Dependencies struct {
+	BuildInfoProvider BuildInfoProvider
+	GitExecutor       shared.GitExecutor
+	WorkingDirectory  string
+}
+
+// NewDetector constructs a Detector with the supplied dependencies or sensible defaults.
+func NewDetector(dependencies Dependencies) (*Detector, error) {
+	provider := dependencies.BuildInfoProvider
+	if provider == nil {
+		provider = runtimeBuildInfoProvider{}
+	}
+
+	executor := dependencies.GitExecutor
+	if executor == nil {
+		shellExecutor, creationError := defaultGitExecutor()
+		if creationError != nil {
+			return nil, creationError
+		}
+		executor = shellExecutor
+	}
+
+	workingDirectory := strings.TrimSpace(dependencies.WorkingDirectory)
+	if len(workingDirectory) == 0 {
+		currentDirectory, workingDirectoryError := os.Getwd()
+		if workingDirectoryError == nil {
+			workingDirectory = currentDirectory
+		}
+	}
+
+	return &Detector{
+		buildInfoProvider: provider,
+		gitExecutor:       executor,
+		workingDirectory:  workingDirectory,
+	}, nil
+}
+
+// Detect resolves the application version using the supplied dependencies.
+func Detect(executionContext context.Context, dependencies Dependencies) string {
+	detector, detectorError := NewDetector(dependencies)
+	if detectorError != nil {
+		return unknownVersionFallbackConstant
+	}
+	return detector.Version(executionContext)
+}
+
+// Version returns the detected application version string.
+func (detector *Detector) Version(executionContext context.Context) string {
+	if detector == nil {
+		return unknownVersionFallbackConstant
+	}
+
+	if buildVersion := detector.versionFromBuildInfo(); len(buildVersion) > 0 {
+		return buildVersion
+	}
+
+	repositoryRoot := detector.resolveRepositoryRoot(executionContext)
+
+	if exactVersion := detector.describeVersion(executionContext, repositoryRoot, []string{gitDescribeSubcommandConstant, gitTagsFlagConstant, gitExactMatchFlagConstant}); len(exactVersion) > 0 {
+		return exactVersion
+	}
+
+	if longVersion := detector.describeVersion(executionContext, repositoryRoot, []string{gitDescribeSubcommandConstant, gitTagsFlagConstant, gitLongFlagConstant, gitDirtyFlagConstant}); len(longVersion) > 0 {
+		return longVersion
+	}
+
+	return unknownVersionFallbackConstant
+}
+
+func (detector *Detector) versionFromBuildInfo() string {
+	if detector.buildInfoProvider == nil {
+		return ""
+	}
+
+	buildInfo, available := detector.buildInfoProvider.Read()
+	if !available || buildInfo == nil {
+		return ""
+	}
+
+	trimmedVersion := strings.TrimSpace(buildInfo.Main.Version)
+	if len(trimmedVersion) == 0 {
+		return ""
+	}
+
+	if strings.EqualFold(trimmedVersion, buildInfoDevelVersionValue) {
+		return ""
+	}
+
+	return trimmedVersion
+}
+
+func (detector *Detector) resolveRepositoryRoot(executionContext context.Context) string {
+	if len(detector.workingDirectory) == 0 {
+		return ""
+	}
+
+	executionResult, executionError := detector.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{gitRevParseSubcommandConstant, gitShowTopLevelFlagConstant},
+		WorkingDirectory: detector.workingDirectory,
+	})
+	if executionError != nil {
+		return detector.workingDirectory
+	}
+
+	trimmedPath := strings.TrimSpace(executionResult.StandardOutput)
+	if len(trimmedPath) == 0 {
+		return detector.workingDirectory
+	}
+
+	return trimmedPath
+}
+
+func (detector *Detector) describeVersion(executionContext context.Context, repositoryRoot string, arguments []string) string {
+	executionResult, executionError := detector.executeGit(executionContext, execshell.CommandDetails{
+		Arguments:        arguments,
+		WorkingDirectory: repositoryRoot,
+	})
+	if executionError != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(executionResult.StandardOutput)
+}
+
+func (detector *Detector) executeGit(executionContext context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	if detector.gitExecutor == nil {
+		return execshell.ExecutionResult{}, errors.New(gitExecutorMissingMessageConstant)
+	}
+
+	environment := details.EnvironmentVariables
+	if environment == nil {
+		environment = map[string]string{}
+	}
+	environment[gitTerminalPromptEnvironmentNameConstant] = gitTerminalPromptEnvironmentValueConstant
+	details.EnvironmentVariables = environment
+
+	return detector.gitExecutor.ExecuteGit(executionContext, details)
+}
+
+type runtimeBuildInfoProvider struct{}
+
+func (runtimeBuildInfoProvider) Read() (*debug.BuildInfo, bool) {
+	return debug.ReadBuildInfo()
+}
+
+func defaultGitExecutor() (shared.GitExecutor, error) {
+	shellExecutor, creationError := execshell.NewShellExecutor(zap.NewNop(), execshell.NewOSCommandRunner(), false)
+	if creationError != nil {
+		return nil, creationError
+	}
+	return shellExecutor, nil
+}

--- a/internal/version/detector_test.go
+++ b/internal/version/detector_test.go
@@ -1,0 +1,123 @@
+package version_test
+
+import (
+	"context"
+	"errors"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temirov/gix/internal/execshell"
+	"github.com/temirov/gix/internal/repos/shared"
+	"github.com/temirov/gix/internal/version"
+)
+
+type stubBuildInfoProvider struct {
+	info      *debug.BuildInfo
+	available bool
+}
+
+func (provider stubBuildInfoProvider) Read() (*debug.BuildInfo, bool) {
+	if !provider.available {
+		return nil, false
+	}
+	return provider.info, true
+}
+
+type stubGitExecutor struct {
+	testInstance *testing.T
+	commands     []stubGitCommand
+}
+
+type stubGitCommand struct {
+	expectedArguments []string
+	output            string
+	executionError    error
+}
+
+func (executor *stubGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	executor.testInstance.Helper()
+	require.Greater(executor.testInstance, len(executor.commands), 0)
+
+	executedArguments := append([]string{}, details.Arguments...)
+	command := executor.commands[0]
+	executor.commands = executor.commands[1:]
+
+	require.Equal(executor.testInstance, command.expectedArguments, executedArguments)
+	return execshell.ExecutionResult{StandardOutput: command.output}, command.executionError
+}
+
+func (executor *stubGitExecutor) ExecuteGitHubCLI(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	executor.testInstance.Helper()
+	require.Fail(executor.testInstance, "ExecuteGitHubCLI should not be invoked")
+	return execshell.ExecutionResult{}, errors.New("unexpected invocation")
+}
+
+func TestVersionUsesBuildInfoWhenAvailable(t *testing.T) {
+	provider := stubBuildInfoProvider{info: &debug.BuildInfo{Main: debug.Module{Version: "v1.2.3"}}, available: true}
+	detector, creationError := version.NewDetector(version.Dependencies{BuildInfoProvider: provider})
+	require.NoError(t, creationError)
+
+	versionString := detector.Version(context.Background())
+	require.Equal(t, "v1.2.3", versionString)
+}
+
+func TestVersionFallsBackToExactDescribe(t *testing.T) {
+	executor := &stubGitExecutor{
+		testInstance: t,
+		commands: []stubGitCommand{
+			{expectedArguments: []string{"rev-parse", "--show-toplevel"}, output: "/workspace"},
+			{expectedArguments: []string{"describe", "--tags", "--exact-match"}, output: "v0.9.0"},
+		},
+	}
+	detector, creationError := version.NewDetector(version.Dependencies{
+		BuildInfoProvider: stubBuildInfoProvider{info: &debug.BuildInfo{Main: debug.Module{Version: "devel"}}, available: true},
+		GitExecutor:       executor,
+	})
+	require.NoError(t, creationError)
+
+	versionString := detector.Version(context.Background())
+	require.Equal(t, "v0.9.0", versionString)
+	require.Len(t, executor.commands, 0)
+}
+
+func TestVersionUsesLongDescribeWhenExactMissing(t *testing.T) {
+	executor := &stubGitExecutor{
+		testInstance: t,
+		commands: []stubGitCommand{
+			{expectedArguments: []string{"rev-parse", "--show-toplevel"}, output: "/workspace"},
+			{expectedArguments: []string{"describe", "--tags", "--exact-match"}, executionError: errors.New("not tagged")},
+			{expectedArguments: []string{"describe", "--tags", "--long", "--dirty"}, output: "v0.9.0-1-gabcdef"},
+		},
+	}
+	detector, creationError := version.NewDetector(version.Dependencies{
+		BuildInfoProvider: stubBuildInfoProvider{info: &debug.BuildInfo{Main: debug.Module{Version: "devel"}}, available: true},
+		GitExecutor:       executor,
+	})
+	require.NoError(t, creationError)
+
+	versionString := detector.Version(context.Background())
+	require.Equal(t, "v0.9.0-1-gabcdef", versionString)
+}
+
+func TestVersionReturnsUnknownWhenAllSourcesFail(t *testing.T) {
+	executor := &stubGitExecutor{
+		testInstance: t,
+		commands: []stubGitCommand{
+			{expectedArguments: []string{"rev-parse", "--show-toplevel"}, executionError: errors.New("failure")},
+			{expectedArguments: []string{"describe", "--tags", "--exact-match"}, executionError: errors.New("failure")},
+			{expectedArguments: []string{"describe", "--tags", "--long", "--dirty"}, executionError: errors.New("failure")},
+		},
+	}
+	detector, creationError := version.NewDetector(version.Dependencies{
+		BuildInfoProvider: stubBuildInfoProvider{info: &debug.BuildInfo{Main: debug.Module{Version: "devel"}}, available: true},
+		GitExecutor:       executor,
+	})
+	require.NoError(t, creationError)
+
+	versionString := detector.Version(context.Background())
+	require.Equal(t, "unknown", versionString)
+}
+
+var _ shared.GitExecutor = (*stubGitExecutor)(nil)

--- a/internal/version/doc.go
+++ b/internal/version/doc.go
@@ -1,0 +1,2 @@
+// Package version determines the application version string.
+package version

--- a/tests/pr_cleanup_integration_test.go
+++ b/tests/pr_cleanup_integration_test.go
@@ -11,11 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/temirov/gix/internal/branches"
 	"github.com/temirov/gix/internal/execshell"
+	"github.com/temirov/gix/internal/repos/shared"
 	flagutils "github.com/temirov/gix/internal/utils/flags"
 )
 
@@ -48,6 +50,12 @@ const (
 	integrationExpectationMessageTemplateConstant = "expected branch state: %s"
 	prCleanupSubtestNameTemplateConstant          = "%d_%s"
 )
+
+type automaticConfirmationPrompter struct{}
+
+func (automaticConfirmationPrompter) Confirm(string) (shared.ConfirmationResult, error) {
+	return shared.ConfirmationResult{Confirmed: true}, nil
+}
 
 func TestPullRequestCleanupIntegration(testInstance *testing.T) {
 	temporaryRoot := testInstance.TempDir()
@@ -102,6 +110,9 @@ func TestPullRequestCleanupIntegration(testInstance *testing.T) {
 			return zap.NewNop()
 		},
 		Executor: shellExecutor,
+		PrompterFactory: func(*cobra.Command) shared.ConfirmationPrompter {
+			return automaticConfirmationPrompter{}
+		},
 	}
 
 	cleanupCommand, buildError := cleanupCommandBuilder.Build()


### PR DESCRIPTION
Introduce a branch-refresh CLI that fetches, checks out, and pulls the configured branch while enforcing a clean worktree. Wire the command into application defaults, embed configuration, and cover behavior with unit tests. Update NOTES to mark GX-03 complete.