### PR TITLE
GX-12: surface required branch argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes 🐛
+- Updated `branch cd` help to surface the required `<branch>` argument along with usage guidance and examples.
+
+### Testing 🧪
+- Added CLI and command unit tests to enforce the `<branch>` usage template for `branch cd`.
+
 ## [v0.1.0]
 
 ### Features ✨

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -110,7 +110,8 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     exit status 1
     ```
 
-    - [ ] [GX-12] Same required argument with description and examples as in GX-08 shall be in all commands that would require such argument. Analyze all command if there is a similar scenario and the arguments are missing in the help, and fix them.
+    - [x] [GX-12] Same required argument with description and examples as in GX-08 shall be in all commands that would require such argument. Analyze all command if there is a similar scenario and the arguments are missing in the help, and fix them.
+        Resolution: Added help usage templates and examples for `branch cd`, updated long descriptions, and added regression tests to enforce the required branch argument guidance.
 
     - [ ] [GX-10] Got an error message after issuing the command `go run ./... repo release v0.1.0`
     ```shell

--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -139,8 +139,9 @@ const (
 	migrateCommandUseNameConstant                                    = "migrate"
 	refreshCommandUseNameConstant                                    = "refresh"
 	branchChangeCommandUseNameConstant                               = "cd"
+	branchChangeCommandUsageTemplateConstant                         = branchChangeCommandUseNameConstant + " <branch>"
 	branchChangeCommandAliasConstant                                 = "switch"
-	branchChangeLongDescriptionConstant                              = "branch cd fetches updates, switches to the requested branch, creates it when missing, and rebases onto the remote."
+	branchChangeLongDescriptionConstant                              = "branch cd fetches updates, switches to the requested branch, creates it when missing, and rebases onto the remote. Provide the branch name as the first argument before any optional repository roots or flags, or configure a default branch in the application settings."
 	commitNamespaceUseNameConstant                                   = "commit"
 	commitNamespaceAliasConstant                                     = "c"
 	commitNamespaceShortDescriptionConstant                          = "Commit assistance commands"
@@ -653,7 +654,7 @@ func NewApplication() *Application {
 		branchNamespaceCommand.AddCommand(branchMigrateNestedCommand)
 	}
 	if branchChangeCommand, branchChangeError := branchChangeBuilder.Build(); branchChangeError == nil {
-		configureCommandMetadata(branchChangeCommand, branchChangeCommandUseNameConstant, branchChangeCommand.Short, branchChangeLongDescriptionConstant, branchChangeCommandAliasConstant)
+		configureCommandMetadata(branchChangeCommand, branchChangeCommandUsageTemplateConstant, branchChangeCommand.Short, branchChangeLongDescriptionConstant, branchChangeCommandAliasConstant)
 		branchNamespaceCommand.AddCommand(branchChangeCommand)
 	}
 	if branchRefreshNestedCommand, branchRefreshNestedError := branchRefreshBuilder.Build(); branchRefreshNestedError == nil {

--- a/cmd/cli/application_internal_test.go
+++ b/cmd/cli/application_internal_test.go
@@ -271,3 +271,16 @@ func TestReleaseCommandUsageIncludesTagPlaceholder(t *testing.T) {
 	require.Contains(t, releaseCommand.Long, "Provide the tag as the first argument")
 	require.Contains(t, releaseCommand.Example, "gix repo release")
 }
+
+func TestBranchChangeCommandUsageIncludesBranchPlaceholder(t *testing.T) {
+	application := NewApplication()
+	rootCommand := application.rootCommand
+
+	branchChangeCommand, _, branchChangeError := rootCommand.Find([]string{"b", "cd"})
+	require.NoError(t, branchChangeError)
+
+	require.True(t, strings.HasPrefix(strings.TrimSpace(branchChangeCommand.Use), branchChangeCommandUseNameConstant))
+	require.Contains(t, branchChangeCommand.Use, "<branch>")
+	require.Contains(t, branchChangeCommand.Long, "Provide the branch name as the first argument")
+	require.Contains(t, branchChangeCommand.Example, "gix branch cd")
+}

--- a/internal/branches/cd/command.go
+++ b/internal/branches/cd/command.go
@@ -16,9 +16,11 @@ import (
 )
 
 const (
-	commandUseConstant                   = "branch-cd"
+	commandUseNameConstant               = "branch-cd"
+	commandUsageTemplateConstant         = commandUseNameConstant + " <branch>"
+	commandExampleTemplateConstant       = "gix branch cd feature/new-branch --roots ~/Development"
 	commandShortDescriptionConstant      = "Switch repositories to the selected branch"
-	commandLongDescriptionConstant       = "branch-cd fetches updates, switches to the requested branch, creates it if missing, and rebases onto the remote for each repository root."
+	commandLongDescriptionConstant       = "branch-cd fetches updates, switches to the requested branch, creates it if missing, and rebases onto the remote for each repository root. Provide the branch name as the first argument before any optional repository roots or flags, or configure a default branch in the application settings."
 	missingBranchMessageConstant         = "branch name is required; provide it as the first argument or configure a default"
 	changeSuccessMessageTemplateConstant = "SWITCHED: %s -> %s"
 	changeCreatedSuffixConstant          = " (created)"
@@ -38,11 +40,12 @@ type CommandBuilder struct {
 // Build constructs the branch-cd command.
 func (builder *CommandBuilder) Build() (*cobra.Command, error) {
 	command := &cobra.Command{
-		Use:   commandUseConstant,
-		Short: commandShortDescriptionConstant,
-		Long:  commandLongDescriptionConstant,
-		RunE:  builder.run,
-		Args:  cobra.ArbitraryArgs,
+		Use:     commandUsageTemplateConstant,
+		Short:   commandShortDescriptionConstant,
+		Long:    commandLongDescriptionConstant,
+		RunE:    builder.run,
+		Args:    cobra.ArbitraryArgs,
+		Example: commandExampleTemplateConstant,
 	}
 
 	return command, nil

--- a/internal/branches/cd/command_test.go
+++ b/internal/branches/cd/command_test.go
@@ -24,6 +24,13 @@ func TestCommandBuilds(t *testing.T) {
 	require.IsType(t, &cobra.Command{}, command)
 }
 
+func TestCommandUsageIncludesBranchPlaceholder(t *testing.T) {
+	builder := CommandBuilder{}
+	command, err := builder.Build()
+	require.NoError(t, err)
+	require.Contains(t, command.Use, "<branch>")
+}
+
 func TestCommandRequiresBranchArgument(t *testing.T) {
 	builder := CommandBuilder{
 		LoggerProvider: func() *zap.Logger { return zap.NewNop() },


### PR DESCRIPTION
## Summary
- ensure `branch cd` help usage includes the required `<branch>` placeholder and example guidance
- update CLI metadata and command builder to provide the argument instructions consistently
- add regression tests covering the updated help output

## Testing
- go test ./...