### PR TITLE
GX-14: silence default CLI logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated `branch cd` help to surface the required `<branch>` argument along with usage guidance and examples.
 - Ensured `repo release` falls back to the embedded `.` repository root when user configuration omits the operation defaults.
 - Updated `workflow` help text to surface the required configuration path and example usage.
+- Disabled default CLI info logging and set the default log level to `error` so commands run silently unless verbosity is explicitly requested.
 
 ### Testing 🧪
 - Added CLI and command unit tests to enforce the `<branch>` usage template for `branch cd`.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -134,7 +134,7 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     - [x] [GX-11] what is --branch CLI flag? `--branch string           Branch name for command context`. I dont think we use it anywhere. Remove it if it's unused, explain here otherwise
         Resolution: Standardized required argument messaging across commands by ensuring `repo release`, `branch cd`, and `workflow` help/usage strings surface their required inputs, backed by tests.
     
-    - [ ] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there.
+    - [ ] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there. The default logging is none.
     ```
     14:16:51 tyemirov@computercat:~/Development/gix [improvement/GX-13-command-alignment] $ go run ./... b cd master
     INFO    configuration initialized | log level=info | log format=console | config file=/home/tyemirov/Development/gix/config.yaml

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -134,7 +134,7 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     - [x] [GX-11] what is --branch CLI flag? `--branch string           Branch name for command context`. I dont think we use it anywhere. Remove it if it's unused, explain here otherwise
         Resolution: Standardized required argument messaging across commands by ensuring `repo release`, `branch cd`, and `workflow` help/usage strings surface their required inputs, backed by tests.
     
-    - [ ] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there. The default logging is none.
+    - [x] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there. The default logging is none.
     ```
     14:16:51 tyemirov@computercat:~/Development/gix [improvement/GX-13-command-alignment] $ go run ./... b cd master
     INFO    configuration initialized | log level=info | log format=console | config file=/home/tyemirov/Development/gix/config.yaml
@@ -145,8 +145,9 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     14:17:20        INFO    Running git pull --rebase (in .)
     14:17:21        INFO    Completed git pull --rebase (in .)
     SWITCHED: . -> master
-    14:17:21 tyemirov@computercat:~/Development/gix [master] $ 
+    14:17:21 tyemirov@computercat:~/Development/gix [master] $
     ```
+        Resolution: Default logging now runs at `error`, configuration banners only print in debug mode, and documentation/tests were updated so standard executions stay silent unless increased verbosity is requested.
 
     - [ ] [GX-15] The message is misleading: `Fetching from unknown in .` We always know thwe current brnach and the branch we are switching to, so there can not be "unknown"
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ from the repository name.
 ```yaml
 # config.yaml
 common:
-  log_level: info
+  log_level: error
   log_format: structured
 
 operations:

--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -796,7 +796,7 @@ func (application *Application) resolveUserConfigurationDirectoryPaths() []strin
 
 func (application *Application) initializeConfiguration(command *cobra.Command) error {
 	defaultValues := map[string]any{
-		commonLogLevelConfigKeyConstant:     string(utils.LogLevelInfo),
+		commonLogLevelConfigKeyConstant:     string(utils.LogLevelError),
 		commonLogFormatConfigKeyConstant:    string(utils.LogFormatStructured),
 		commonDryRunConfigKeyConstant:       false,
 		commonAssumeYesConfigKeyConstant:    false,
@@ -876,12 +876,21 @@ func (application *Application) InitializeForCommand(commandUse string) error {
 	return application.initializeConfiguration(command)
 }
 
+// ConfigFileUsed returns the configuration file path used during initialization.
+func (application *Application) ConfigFileUsed() string {
+	return application.configurationMetadata.ConfigFileUsed
+}
+
 func (application *Application) humanReadableLoggingEnabled() bool {
 	logFormatValue := strings.TrimSpace(application.configuration.Common.LogFormat)
 	return strings.EqualFold(logFormatValue, string(utils.LogFormatConsole))
 }
 
 func (application *Application) logConfigurationInitialization() {
+	if !strings.EqualFold(strings.TrimSpace(application.configuration.Common.LogLevel), string(utils.LogLevelDebug)) {
+		return
+	}
+
 	if application.humanReadableLoggingEnabled() {
 		bannerMessage := fmt.Sprintf(
 			configurationInitializedConsoleTemplateConstant,

--- a/cmd/cli/default_config.yaml
+++ b/cmd/cli/default_config.yaml
@@ -1,5 +1,5 @@
 common:
-  log_level: info
+  log_level: error
   log_format: console
   dry_run: false
   assume_yes: false

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 # config.yaml
 common:
-  log_level: info
+  log_level: error
   log_format: console
 
 operations:

--- a/tests/cli_integration_test.go
+++ b/tests/cli_integration_test.go
@@ -27,7 +27,6 @@ const (
 	integrationEnvironmentCaseNameConstant             = "environment_error"
 	integrationDebugLevelConstant                      = "debug"
 	integrationErrorLevelConstant                      = "error"
-	integrationInfoLevelConstant                       = "info"
 	integrationCommandTimeout                          = 5 * time.Second
 	integrationConfigFlagTemplateConstant              = "--config=%s"
 	integrationEnvironmentAssignmentTemplateConstant   = "%s=%s"
@@ -52,7 +51,7 @@ func writeIntegrationConfiguration(
 	logLevel string,
 ) string {
 	if len(logLevel) == 0 {
-		logLevel = integrationInfoLevelConstant
+		logLevel = integrationErrorLevelConstant
 	}
 
 	configurationPath := filepath.Join(directory, integrationConfigFileNameConstant)
@@ -82,7 +81,7 @@ func TestCLIIntegrationLogLevels(testInstance *testing.T) {
 			configurationLevel:   "",
 			environmentLevel:     "",
 			extraArguments:       nil,
-			expectedInfoVisible:  true,
+			expectedInfoVisible:  false,
 			expectedDebugVisible: false,
 		},
 		{
@@ -179,7 +178,7 @@ func TestCLIIntegrationDisplaysHelpWhenNoArgumentsProvided(testInstance *testing
 		testInstance.Run(fmt.Sprintf(integrationSubtestNameTemplateConstant, testCaseIndex, testCase.name), func(testInstance *testing.T) {
 			commandArguments := []string{integrationGoRunSubcommandConstant, integrationCurrentDirectoryArgumentConstant}
 			tempDirectory := testInstance.TempDir()
-			configurationPath := writeIntegrationConfiguration(testInstance, tempDirectory, "")
+			configurationPath := writeIntegrationConfiguration(testInstance, tempDirectory, integrationDebugLevelConstant)
 			commandArguments = append(commandArguments, fmt.Sprintf(integrationConfigFlagTemplateConstant, configurationPath))
 			executionContext, cancelFunction := context.WithTimeout(context.Background(), integrationCommandTimeout)
 			defer cancelFunction()
@@ -227,6 +226,7 @@ func TestCLIIntegrationRespectsLogFormatFlag(testInstance *testing.T) {
 			tempDirectory := testInstance.TempDir()
 			configurationPath := writeIntegrationConfiguration(testInstance, tempDirectory, "")
 			commandArguments = append(commandArguments, fmt.Sprintf(integrationConfigFlagTemplateConstant, configurationPath))
+			commandArguments = append(commandArguments, "--log-level=debug")
 			commandArguments = append(commandArguments, testCase.additionalArguments...)
 
 			executionContext, cancelFunction := context.WithTimeout(context.Background(), integrationCommandTimeout)


### PR DESCRIPTION
## Summary
- lower the default log level to error and suppress configuration banners unless debug logging is enabled
- expose ConfigFileUsed for tests and update CLI/integration suites to expect silent defaults
- refresh README/config examples, changelog, and issue log to document the new logging behavior

## Testing
- go test ./...