### PR TITLE
GX-15: clarify branch fetch logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated `branch cd` help to surface the required `<branch>` argument along with usage guidance and examples.
 - Ensured `repo release` falls back to the embedded `.` repository root when user configuration omits the operation defaults.
 - Updated `workflow` help text to surface the required configuration path and example usage.
+- Disabled default CLI info logging and set the default log level to `error` so commands run silently unless verbosity is explicitly requested.
 
 ### Testing 🧪
 - Added CLI and command unit tests to enforce the `<branch>` usage template for `branch cd`.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -134,7 +134,7 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     - [x] [GX-11] what is --branch CLI flag? `--branch string           Branch name for command context`. I dont think we use it anywhere. Remove it if it's unused, explain here otherwise
         Resolution: Standardized required argument messaging across commands by ensuring `repo release`, `branch cd`, and `workflow` help/usage strings surface their required inputs, backed by tests.
     
-    - [ ] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there.
+    - [ ] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there. The default logging is none.
     ```
     14:16:51 tyemirov@computercat:~/Development/gix [improvement/GX-13-command-alignment] $ go run ./... b cd master
     INFO    configuration initialized | log level=info | log format=console | config file=/home/tyemirov/Development/gix/config.yaml

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -134,7 +134,7 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     - [x] [GX-11] what is --branch CLI flag? `--branch string           Branch name for command context`. I dont think we use it anywhere. Remove it if it's unused, explain here otherwise
         Resolution: Standardized required argument messaging across commands by ensuring `repo release`, `branch cd`, and `workflow` help/usage strings surface their required inputs, backed by tests.
     
-    - [ ] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there. The default logging is none.
+    - [x] [GX-14] See GX-12. Remove all logging unless explicitly called for. The INFO line should have not been there. The default logging is none.
     ```
     14:16:51 tyemirov@computercat:~/Development/gix [improvement/GX-13-command-alignment] $ go run ./... b cd master
     INFO    configuration initialized | log level=info | log format=console | config file=/home/tyemirov/Development/gix/config.yaml
@@ -145,8 +145,9 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     14:17:20        INFO    Running git pull --rebase (in .)
     14:17:21        INFO    Completed git pull --rebase (in .)
     SWITCHED: . -> master
-    14:17:21 tyemirov@computercat:~/Development/gix [master] $ 
+    14:17:21 tyemirov@computercat:~/Development/gix [master] $
     ```
+        Resolution: Default logging now runs at `error`, configuration banners only print in debug mode, and documentation/tests were updated so standard executions stay silent unless increased verbosity is requested.
 
     - [ ] [GX-15] The message is misleading: `Fetching from unknown in .` We always know thwe current brnach and the branch we are switching to, so there can not be "unknown"
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -149,7 +149,8 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     ```
         Resolution: Default logging now runs at `error`, configuration banners only print in debug mode, and documentation/tests were updated so standard executions stay silent unless increased verbosity is requested.
 
-    - [ ] [GX-15] The message is misleading: `Fetching from unknown in .` We always know thwe current brnach and the branch we are switching to, so there can not be "unknown"
+    - [x] [GX-15] The message is misleading: `Fetching from unknown in .` We always know thwe current brnach and the branch we are switching to, so there can not be "unknown"
+        Resolution: Branch fetch now records the remote for logging, message formatter falls back to "all remotes" instead of "unknown," and tests cover the new behavior.
 
 ## Maintenance
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ from the repository name.
 ```yaml
 # config.yaml
 common:
-  log_level: info
+  log_level: error
   log_format: structured
 
 operations:

--- a/cmd/cli/application.go
+++ b/cmd/cli/application.go
@@ -796,7 +796,7 @@ func (application *Application) resolveUserConfigurationDirectoryPaths() []strin
 
 func (application *Application) initializeConfiguration(command *cobra.Command) error {
 	defaultValues := map[string]any{
-		commonLogLevelConfigKeyConstant:     string(utils.LogLevelInfo),
+		commonLogLevelConfigKeyConstant:     string(utils.LogLevelError),
 		commonLogFormatConfigKeyConstant:    string(utils.LogFormatStructured),
 		commonDryRunConfigKeyConstant:       false,
 		commonAssumeYesConfigKeyConstant:    false,
@@ -876,12 +876,21 @@ func (application *Application) InitializeForCommand(commandUse string) error {
 	return application.initializeConfiguration(command)
 }
 
+// ConfigFileUsed returns the configuration file path used during initialization.
+func (application *Application) ConfigFileUsed() string {
+	return application.configurationMetadata.ConfigFileUsed
+}
+
 func (application *Application) humanReadableLoggingEnabled() bool {
 	logFormatValue := strings.TrimSpace(application.configuration.Common.LogFormat)
 	return strings.EqualFold(logFormatValue, string(utils.LogFormatConsole))
 }
 
 func (application *Application) logConfigurationInitialization() {
+	if !strings.EqualFold(strings.TrimSpace(application.configuration.Common.LogLevel), string(utils.LogLevelDebug)) {
+		return
+	}
+
 	if application.humanReadableLoggingEnabled() {
 		bannerMessage := fmt.Sprintf(
 			configurationInitializedConsoleTemplateConstant,

--- a/cmd/cli/default_config.yaml
+++ b/cmd/cli/default_config.yaml
@@ -1,5 +1,5 @@
 common:
-  log_level: info
+  log_level: error
   log_format: console
   dry_run: false
   assume_yes: false

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 # config.yaml
 common:
-  log_level: info
+  log_level: error
   log_format: console
 
 operations:

--- a/internal/branches/cd/service.go
+++ b/internal/branches/cd/service.go
@@ -18,9 +18,8 @@ const (
 	gitSwitchFailureTemplateConstant         = "failed to switch to branch %q: %w"
 	gitCreateBranchFailureTemplateConstant   = "failed to create branch %q from %s: %w"
 	gitPullFailureTemplateConstant           = "failed to pull latest changes: %w"
-	defaultRemoteNameConstant                = "origin"
+	defaultRemoteNameConstant                = shared.OriginRemoteNameConstant
 	gitFetchSubcommandConstant               = "fetch"
-	gitFetchAllFlagConstant                  = "--all"
 	gitFetchPruneFlagConstant                = "--prune"
 	gitSwitchSubcommandConstant              = "switch"
 	gitCreateBranchFlagConstant              = "-c"
@@ -98,7 +97,7 @@ func (service *Service) Change(executionContext context.Context, options Options
 	environment := map[string]string{gitTerminalPromptEnvironmentNameConstant: gitTerminalPromptEnvironmentDisableValue}
 
 	if _, err := service.executor.ExecuteGit(executionContext, execshell.CommandDetails{
-		Arguments:            []string{gitFetchSubcommandConstant, gitFetchAllFlagConstant, gitFetchPruneFlagConstant},
+		Arguments:            []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName},
 		WorkingDirectory:     trimmedRepositoryPath,
 		EnvironmentVariables: environment,
 	}); err != nil {

--- a/internal/branches/cd/service_test.go
+++ b/internal/branches/cd/service_test.go
@@ -42,7 +42,7 @@ func TestChangeExecutesExpectedCommands(t *testing.T) {
 	require.Equal(t, Result{RepositoryPath: "/tmp/repo", BranchName: "feature", BranchCreated: false}, result)
 	require.Len(t, executor.recorded, 3)
 
-	require.Equal(t, []string{"fetch", "--all", "--prune"}, executor.recorded[0].Arguments)
+	require.Equal(t, []string{"fetch", "--prune", "origin"}, executor.recorded[0].Arguments)
 	require.Equal(t, []string{"switch", "feature"}, executor.recorded[1].Arguments)
 	require.Equal(t, []string{"pull", "--rebase"}, executor.recorded[2].Arguments)
 }

--- a/internal/execshell/messages.go
+++ b/internal/execshell/messages.go
@@ -112,6 +112,7 @@ const (
 	gitFetchWithoutRefsFailureTemplateConstant                      = "Failed to fetch from %s in %s (exit code %d%s)"
 	gitFetchExecutionFailureTemplateConstant                        = "Unable to fetch %s from %s in %s: %s"
 	gitFetchWithoutRefsExecutionFailureTemplateConstant             = "Unable to fetch from %s in %s: %s"
+	gitFetchAllRemotesLabelConstant                                 = "all remotes"
 	gitPushStartTemplateConstant                                    = "Pushing %s to %s from %s"
 	gitPushSuccessTemplateConstant                                  = "Pushed %s to %s from %s"
 	gitPushFailureTemplateConstant                                  = "Failed to push %s to %s from %s (exit code %d%s)"
@@ -490,7 +491,10 @@ func (formatter CommandMessageFormatter) describeGitBranchMessage(command ShellC
 func (formatter CommandMessageFormatter) describeGitFetchMessage(command ShellCommand, result ExecutionResult, failure error, stage messageStage) string {
 	workingDirectory := formatter.describeWorkingDirectory(command)
 	remoteName, references := formatter.extractRemoteAndReferences(command.Details.Arguments[1:])
-	trimmedRemote := formatter.ensureValue(remoteName)
+	trimmedRemote := strings.TrimSpace(remoteName)
+	if len(trimmedRemote) == 0 {
+		trimmedRemote = gitFetchAllRemotesLabelConstant
+	}
 	joinedReferences := formatter.joinReferences(references)
 
 	switch stage {
@@ -965,7 +969,7 @@ func (formatter CommandMessageFormatter) extractRemoteAndReferences(arguments []
 		}
 		references = append(references, trimmed)
 	}
-	return formatter.ensureValue(remoteName), references
+	return remoteName, references
 }
 
 func (formatter CommandMessageFormatter) joinReferences(references []string) string {

--- a/internal/execshell/messages_test.go
+++ b/internal/execshell/messages_test.go
@@ -1,0 +1,37 @@
+package execshell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildStartedMessageForFetchIncludesRemoteAndReferences(t *testing.T) {
+	formatter := CommandMessageFormatter{}
+	command := ShellCommand{
+		Name: CommandGit,
+		Details: CommandDetails{
+			Arguments:        []string{"fetch", "--prune", "origin", "feature"},
+			WorkingDirectory: "/workspace/repo",
+		},
+	}
+
+	message := formatter.BuildStartedMessage(command)
+
+	require.Equal(t, "Fetching feature from origin in /workspace/repo", message)
+}
+
+func TestBuildStartedMessageForFetchWithoutRemoteUsesAllRemotesLabel(t *testing.T) {
+	formatter := CommandMessageFormatter{}
+	command := ShellCommand{
+		Name: CommandGit,
+		Details: CommandDetails{
+			Arguments:        []string{"fetch", "--prune"},
+			WorkingDirectory: "/workspace/repo",
+		},
+	}
+
+	message := formatter.BuildStartedMessage(command)
+
+	require.Equal(t, "Fetching from all remotes in /workspace/repo", message)
+}

--- a/tests/cli_integration_test.go
+++ b/tests/cli_integration_test.go
@@ -27,7 +27,6 @@ const (
 	integrationEnvironmentCaseNameConstant             = "environment_error"
 	integrationDebugLevelConstant                      = "debug"
 	integrationErrorLevelConstant                      = "error"
-	integrationInfoLevelConstant                       = "info"
 	integrationCommandTimeout                          = 5 * time.Second
 	integrationConfigFlagTemplateConstant              = "--config=%s"
 	integrationEnvironmentAssignmentTemplateConstant   = "%s=%s"
@@ -52,7 +51,7 @@ func writeIntegrationConfiguration(
 	logLevel string,
 ) string {
 	if len(logLevel) == 0 {
-		logLevel = integrationInfoLevelConstant
+		logLevel = integrationErrorLevelConstant
 	}
 
 	configurationPath := filepath.Join(directory, integrationConfigFileNameConstant)
@@ -82,7 +81,7 @@ func TestCLIIntegrationLogLevels(testInstance *testing.T) {
 			configurationLevel:   "",
 			environmentLevel:     "",
 			extraArguments:       nil,
-			expectedInfoVisible:  true,
+			expectedInfoVisible:  false,
 			expectedDebugVisible: false,
 		},
 		{
@@ -179,7 +178,7 @@ func TestCLIIntegrationDisplaysHelpWhenNoArgumentsProvided(testInstance *testing
 		testInstance.Run(fmt.Sprintf(integrationSubtestNameTemplateConstant, testCaseIndex, testCase.name), func(testInstance *testing.T) {
 			commandArguments := []string{integrationGoRunSubcommandConstant, integrationCurrentDirectoryArgumentConstant}
 			tempDirectory := testInstance.TempDir()
-			configurationPath := writeIntegrationConfiguration(testInstance, tempDirectory, "")
+			configurationPath := writeIntegrationConfiguration(testInstance, tempDirectory, integrationDebugLevelConstant)
 			commandArguments = append(commandArguments, fmt.Sprintf(integrationConfigFlagTemplateConstant, configurationPath))
 			executionContext, cancelFunction := context.WithTimeout(context.Background(), integrationCommandTimeout)
 			defer cancelFunction()
@@ -227,6 +226,7 @@ func TestCLIIntegrationRespectsLogFormatFlag(testInstance *testing.T) {
 			tempDirectory := testInstance.TempDir()
 			configurationPath := writeIntegrationConfiguration(testInstance, tempDirectory, "")
 			commandArguments = append(commandArguments, fmt.Sprintf(integrationConfigFlagTemplateConstant, configurationPath))
+			commandArguments = append(commandArguments, "--log-level=debug")
 			commandArguments = append(commandArguments, testCase.additionalArguments...)
 
 			executionContext, cancelFunction := context.WithTimeout(context.Background(), integrationCommandTimeout)


### PR DESCRIPTION
## Summary
- ensure `branch cd` issues git fetch with a named remote to avoid `unknown` log labels
- teach the execshell fetch formatter to fall back to "all remotes" and add coverage for the new output

## Plan
- GX-15 logging fix
  - Inspect `branch cd` fetch invocation and execshell formatter to locate the `unknown` remote label source.
  - Update fetch argument construction and message formatter fallback so the remote/branch intent flows into logs.
  - Expand branch cd and formatter tests, then run gofmt/go vet/go test to confirm the behavior.

## Testing
- go vet ./...
- go test ./...
