### PR TITLE
GX-22: replace branch migrate with default

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -288,10 +288,11 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
     echo "Purged from history: ${purge_paths[*]}"
     ```
     - [ ] [GX-21] Implement a task to perform replacements in files. The input is a glob to be used to identify the files (*.go, *.sum etc), a string to find, a string to replace, a command to run after the successfull replacement, a safeguard before the execution(the conditioons can be clean tree, master branch, a presence of some file or folder). Look at tols ns-rewrite for an example of a specialized case where we replace a package name.
-    - [ ] [GX-22] Replace the branch migrate semantics
+    - [x] [GX-22] Replace the branch migrate semantics
         1. Rename the `migrate` subcommand to `default`, e.g. `gix branch default`
         2. We only need destination and we dont need source, as the source can be determined dynamically.
         3. Perform all the changes and document: `gix b default master`
+        Resolution: Renamed the branch command to `branch default`, removed the `--from` flag/config plumbing, auto-detect the current default branch via GitHub metadata across CLI/workflow paths, refreshed tests, configs, and README to document `gix b default <target>`.
 
 ## BugFixes
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ You can run the CLI in two complementary ways depending on how much orchestratio
 - **Directory reconciliation** – rename working directories to match the canonical repository name returned by GitHub.
 - **Remote normalization** – update `origin` to the canonical GitHub remote or convert between HTTPS, SSH, and `git`
   protocols.
-- **Branch maintenance** – delete remote/local branches once their pull requests are closed and migrate defaults from
-  `main` to
-  `master` with safety gates.
+- **Branch maintenance** – delete remote/local branches once their pull requests are closed and promote defaults to
+  `master` with safety gates, automatically detecting the current default branch.
 - **GitHub Packages upkeep** – remove untagged GHCR container versions via the official API.
 - **Workflow bundling** – describe ordered operations in YAML or JSON and execute them in one pass with shared
   discovery,
@@ -121,7 +120,7 @@ with the registered command names and flags.
 | `repo prs delete`                  | `r prs delete`              | Remove remote and local branches for closed pull requests     | `go run . r prs delete --remote origin --limit 100 --roots ~/Development`                               |
 | `repo packages delete`             | `r packages delete`         | Delete untagged GHCR versions                                 | `go run . r packages delete --dry-run --roots ~/Development`                                            |
 | `repo release`                     | `r release`                 | Annotate and push a release tag across repositories           | `go run . r release v1.2.3 --roots ~/Development`                                                      |
-| `branch migrate`                   | `b migrate`                 | Migrate repository defaults from main to master               | `go run . b migrate --from main --to master --roots ~/Development/project-repo`                         |
+| `branch default`                   | `b default`                 | Promote a branch to the repository default with safety gates  | `go run . b default master --roots ~/Development/project-repo`                                          |
 | `branch refresh`                   | `b refresh`                 | Fetch, checkout, and pull a branch with recovery options      | `go run . b refresh --branch main --roots ~/Development/project-repo --stash`                           |
 | `branch cd`                        | `b cd`                      | Switch repositories to a branch, creating it when missing     | `go run . b cd feature/rebrand --roots ~/Development/project-repo`                                      |
 | `branch commit message`            | `b commit message`          | Draft a Conventional Commit message from staged or worktree changes | `go run . b commit message --roots . --dry-run`                                                     |
@@ -202,8 +201,8 @@ operations:
       dry_run: false
       assume_yes: false
 
-  - operation: branch-migrate
-    with: &branch_migrate_defaults
+  - operation: branch-default
+    with: &branch_default_defaults
       debug: false
       roots:
         - ~/Development
@@ -229,12 +228,11 @@ workflow:
 
   - step:
       order: 4
-      operation: migrate-branch
+      operation: default-branch
       with:
-        <<: *branch_migrate_defaults
+        <<: *branch_default_defaults
         targets:
           - remote_name: origin
-            source_branch: main
             target_branch: master
             push_to_remote: true
             delete_source_branch: false
@@ -446,7 +444,7 @@ export GITHUB_PACKAGES_TOKEN=ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 - Provide explicit repository roots (or configure defaults) to operate on multiple directories; commands return an error when no roots are supplied.
 - Use `--dry-run` to preview changes. Combine with `--yes` once you are comfortable executing the plan without prompts.
-- Workflow configurations let you mix and match operations (for example, convert protocols, migrate branches, and audit)
+- Workflow configurations let you mix and match operations (for example, convert protocols, promote default branches, and audit)
   while
   sharing discovery costs.
 

--- a/cmd/cli/application_internal_test.go
+++ b/cmd/cli/application_internal_test.go
@@ -237,11 +237,11 @@ func TestApplicationCommandHierarchyAndAliases(t *testing.T) {
 	require.NotNil(t, releaseCommand.Parent())
 	require.Equal(t, "repo", releaseCommand.Parent().Name())
 
-	branchMigrateCommand, _, branchMigrateError := rootCommand.Find([]string{"b", "migrate"})
-	require.NoError(t, branchMigrateError)
-	require.Equal(t, "migrate", branchMigrateCommand.Name())
-	require.NotNil(t, branchMigrateCommand.Parent())
-	require.Equal(t, "branch", branchMigrateCommand.Parent().Name())
+	branchDefaultCommand, _, branchDefaultError := rootCommand.Find([]string{"b", "default"})
+	require.NoError(t, branchDefaultError)
+	require.Equal(t, "default", branchDefaultCommand.Name())
+	require.NotNil(t, branchDefaultCommand.Parent())
+	require.Equal(t, "branch", branchDefaultCommand.Parent().Name())
 
 	branchChangeCommand, _, branchChangeError := rootCommand.Find([]string{"b", "cd"})
 	require.NoError(t, branchChangeError)
@@ -310,9 +310,9 @@ func TestApplicationHierarchicalCommandsLoadExpectedOperations(t *testing.T) {
 	require.NoError(t, packagesError)
 	require.Equal(t, []string{packagesPurgeOperationNameConstant}, application.operationsRequiredForCommand(repoPackagesCommand))
 
-	branchMigrateCommand, _, branchMigrateError := rootCommand.Find([]string{"b", "migrate"})
-	require.NoError(t, branchMigrateError)
-	require.Equal(t, []string{branchMigrateOperationNameConstant}, application.operationsRequiredForCommand(branchMigrateCommand))
+	branchDefaultCommand, _, branchDefaultError := rootCommand.Find([]string{"b", "default"})
+	require.NoError(t, branchDefaultError)
+	require.Equal(t, []string{branchDefaultOperationNameConstant}, application.operationsRequiredForCommand(branchDefaultCommand))
 
 	commitMessageCommand, _, commitMessageError := rootCommand.Find([]string{"b", "commit", "message"})
 	require.NoError(t, commitMessageError)

--- a/cmd/cli/application_test.go
+++ b/cmd/cli/application_test.go
@@ -36,7 +36,7 @@ const (
 	testOperationRootDirectoryConstant                       = "/tmp/config-root"
 	testConfigurationSearchPathEnvironmentName               = "GIX_CONFIG_SEARCH_PATH"
 	testPackagesCommandNameConstant                          = "repo-packages-purge"
-	testBranchMigrateCommandNameConstant                     = "branch-migrate"
+	testBranchDefaultCommandNameConstant                     = "branch-default"
 	testBranchRefreshCommandNameConstant                     = "branch-refresh"
 	testBranchCleanupCommandNameConstant                     = "repo-prs-purge"
 	testReposRemotesCommandNameConstant                      = "repo-remote-update"
@@ -51,7 +51,7 @@ const (
 	embeddedDefaultsReposRenameTestNameConstant              = "ReposRenameDefaults"
 	embeddedDefaultsWorkflowTestNameConstant                 = "WorkflowDefaults"
 	embeddedDefaultsBranchRefreshTestNameConstant            = "BranchRefreshDefaults"
-	embeddedDefaultsBranchMigrateTestNameConstant            = "BranchMigrateDefaults"
+	embeddedDefaultsBranchDefaultTestNameConstant            = "BranchDefaultDefaults"
 	embeddedDefaultsAuditTestNameConstant                    = "AuditDefaults"
 	embeddedDefaultRootPathConstant                          = "."
 	embeddedDefaultRemoteNameConstant                        = "origin"
@@ -93,7 +93,7 @@ var requiredOperationNames = []string{
 	"repo-release",
 	"workflow",
 	"branch-refresh",
-	"branch-migrate",
+	"branch-default",
 	"branch-cd",
 	"commit-message",
 	"changelog-message",
@@ -134,7 +134,7 @@ func TestApplicationInitializeConfiguration(t *testing.T) {
 				"workflow",
 				"branch-refresh",
 			},
-			commandUse: testBranchMigrateCommandNameConstant,
+			commandUse: testBranchDefaultCommandNameConstant,
 		},
 	}
 
@@ -715,9 +715,9 @@ func TestApplicationEmbeddedDefaultsProvideCommandConfigurations(testInstance *t
 			},
 		},
 		{
-			name:          embeddedDefaultsBranchMigrateTestNameConstant,
-			commandUse:    testBranchMigrateCommandNameConstant,
-			operationName: testBranchMigrateCommandNameConstant,
+			name:          embeddedDefaultsBranchDefaultTestNameConstant,
+			commandUse:    testBranchDefaultCommandNameConstant,
+			operationName: testBranchDefaultCommandNameConstant,
 			assertion: func(assertionTarget testing.TB, options map[string]any) {
 				assertionTarget.Helper()
 
@@ -727,6 +727,7 @@ func TestApplicationEmbeddedDefaultsProvideCommandConfigurations(testInstance *t
 
 				assertions := require.New(assertionTarget)
 				assertions.Equal([]string{embeddedDefaultRootPathConstant}, sanitized.RepositoryRoots)
+				assertions.Equal(migrate.BranchMaster, migrate.BranchName(sanitized.TargetBranch))
 			},
 		},
 		{

--- a/cmd/cli/default_config.yaml
+++ b/cmd/cli/default_config.yaml
@@ -47,7 +47,7 @@ operations:
     with:
       roots:
         - .
-  - operation: branch-migrate
+  - operation: branch-default
     with:
       roots:
         - .

--- a/config.yaml
+++ b/config.yaml
@@ -62,8 +62,8 @@ operations:
       roots:
         - ~/Development
 
-  - operation: branch-migrate
-    with: &branch_migrate_defaults
+  - operation: branch-default
+    with: &branch_default_defaults
       debug: false
       roots:
         - ~/Development
@@ -89,12 +89,11 @@ workflow:
 
   - step:
       order: 4
-      operation: migrate-branch
+      operation: default-branch
       with:
-        <<: *branch_migrate_defaults
+        <<: *branch_default_defaults
         targets:
           - remote_name: origin
-            source_branch: main
             target_branch: master
             push_to_remote: true
             delete_source_branch: false

--- a/docs/cli_design.md
+++ b/docs/cli_design.md
@@ -64,7 +64,7 @@ The new CLI (working name **`git-maintenance`**) will use Cobra for command/flag
 - `git-maintenance repo-remote-update`
 - `git-maintenance repo-protocol-convert`
 - `git-maintenance repo-prs-purge`
-- `git-maintenance branch-migrate`
+- `git-maintenance branch-default`
 - `git-maintenance repo-packages-purge`
 
 ### 3.1 Flag and Behavior Mapping

--- a/docs/readme_config_test.go
+++ b/docs/readme_config_test.go
@@ -37,7 +37,7 @@ var expectedCommandOperations = map[string]struct{}{
 	"repo-protocol-convert": {},
 	"repo-folders-rename":   {},
 	"workflow":              {},
-	"branch-migrate":        {},
+	"branch-default":        {},
 }
 
 type readmeApplicationConfiguration struct {

--- a/internal/migrate/configuration.go
+++ b/internal/migrate/configuration.go
@@ -8,20 +8,18 @@ import (
 
 var migrateConfigurationRepositoryPathSanitizer = pathutils.NewRepositoryPathSanitizerWithConfiguration(nil, pathutils.RepositoryPathSanitizerConfiguration{PruneNestedPaths: true})
 
-// CommandConfiguration captures persisted configuration for branch migration.
+// CommandConfiguration captures persisted configuration for promoting a default branch.
 type CommandConfiguration struct {
 	EnableDebugLogging bool     `mapstructure:"debug"`
 	RepositoryRoots    []string `mapstructure:"roots"`
-	SourceBranch       string   `mapstructure:"from"`
 	TargetBranch       string   `mapstructure:"to"`
 }
 
-// DefaultCommandConfiguration returns baseline configuration values for branch migration.
+// DefaultCommandConfiguration returns baseline configuration values for default branch promotion.
 func DefaultCommandConfiguration() CommandConfiguration {
 	return CommandConfiguration{
 		EnableDebugLogging: false,
 		RepositoryRoots:    nil,
-		SourceBranch:       string(BranchMain),
 		TargetBranch:       string(BranchMaster),
 	}
 }
@@ -30,10 +28,6 @@ func DefaultCommandConfiguration() CommandConfiguration {
 func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized := configuration
 	sanitized.RepositoryRoots = migrateConfigurationRepositoryPathSanitizer.Sanitize(configuration.RepositoryRoots)
-	sanitized.SourceBranch = strings.TrimSpace(configuration.SourceBranch)
-	if len(sanitized.SourceBranch) == 0 {
-		sanitized.SourceBranch = string(BranchMain)
-	}
 	sanitized.TargetBranch = strings.TrimSpace(configuration.TargetBranch)
 	if len(sanitized.TargetBranch) == 0 {
 		sanitized.TargetBranch = string(BranchMaster)

--- a/internal/migrate/pages_test.go
+++ b/internal/migrate/pages_test.go
@@ -28,6 +28,10 @@ type stubGitHubOperations struct {
 	updatePagesFunc func(context.Context, string, githubcli.PagesConfiguration) error
 }
 
+func (stub *stubGitHubOperations) ResolveRepoMetadata(context.Context, string) (githubcli.RepositoryMetadata, error) {
+	return githubcli.RepositoryMetadata{}, nil
+}
+
 func (stub *stubGitHubOperations) GetPagesConfig(ctx context.Context, repository string) (githubcli.PagesStatus, error) {
 	if stub.getPagesFunc != nil {
 		return stub.getPagesFunc(ctx, repository)

--- a/internal/migrate/types.go
+++ b/internal/migrate/types.go
@@ -24,6 +24,7 @@ type MigrationExecutor interface {
 
 // GitHubOperations exposes the GitHub workflows required for migration.
 type GitHubOperations interface {
+	ResolveRepoMetadata(executionContext context.Context, repository string) (githubcli.RepositoryMetadata, error)
 	GetPagesConfig(executionContext context.Context, repository string) (githubcli.PagesStatus, error)
 	UpdatePagesConfig(executionContext context.Context, repository string, configuration githubcli.PagesConfiguration) error
 	ListPullRequests(executionContext context.Context, repository string, options githubcli.PullRequestListOptions) ([]githubcli.PullRequest, error)

--- a/internal/workflow/configuration.go
+++ b/internal/workflow/configuration.go
@@ -26,7 +26,7 @@ const (
 	OperationTypeProtocolConversion OperationType = OperationType("convert-protocol")
 	OperationTypeCanonicalRemote    OperationType = OperationType("update-canonical-remote")
 	OperationTypeRenameDirectories  OperationType = OperationType("rename-directories")
-	OperationTypeBranchMigration    OperationType = OperationType("migrate-branch")
+	OperationTypeBranchDefault      OperationType = OperationType("default-branch")
 	OperationTypeAuditReport        OperationType = OperationType("audit-report")
 	OperationTypeApplyTasks         OperationType = OperationType("apply-tasks")
 )

--- a/internal/workflow/operations_builder.go
+++ b/internal/workflow/operations_builder.go
@@ -12,7 +12,7 @@ const (
 	protocolConversionInvalidFromMessageConstant  = "convert-protocol step requires a valid 'from' protocol"
 	protocolConversionInvalidToMessageConstant    = "convert-protocol step requires a valid 'to' protocol"
 	protocolConversionSameProtocolMessageConstant = "convert-protocol step requires distinct source and target protocols"
-	branchMigrationTargetsRequiredMessageConstant = "migrate-branch step requires at least one target"
+	branchMigrationTargetsRequiredMessageConstant = "default-branch step requires at least one target"
 )
 
 // BuildOperations converts the declarative configuration into executable operations.
@@ -44,7 +44,7 @@ func buildOperationFromStep(step StepConfiguration) (Operation, error) {
 		return buildCanonicalRemoteOperation(normalizedOptions)
 	case OperationTypeRenameDirectories:
 		return buildRenameOperation(normalizedOptions)
-	case OperationTypeBranchMigration:
+	case OperationTypeBranchDefault:
 		return buildBranchMigrationOperation(normalizedOptions)
 	case OperationTypeAuditReport:
 		return buildAuditReportOperation(normalizedOptions)
@@ -203,7 +203,7 @@ func defaultSourceBranch(explicit bool, value string) string {
 			return trimmed
 		}
 	}
-	return defaultMigrationSourceBranchConstant
+	return ""
 }
 
 func defaultTargetBranch(explicit bool, value string) string {

--- a/tests/migrate_integration_test.go
+++ b/tests/migrate_integration_test.go
@@ -48,6 +48,7 @@ type recordingGitHubOperations struct {
 	retargetedPullRequests  []int
 	branchProtectionEnabled bool
 	remoteGitDirectoryPath  string
+	currentDefaultBranch    string
 }
 
 func (operations *recordingGitHubOperations) GetPagesConfig(_ context.Context, repository string) (githubcli.PagesStatus, error) {
@@ -77,6 +78,7 @@ func (operations *recordingGitHubOperations) UpdatePullRequestBase(_ context.Con
 func (operations *recordingGitHubOperations) SetDefaultBranch(_ context.Context, repository string, branchName string) error {
 	_ = repository
 	operations.defaultBranchTarget = branchName
+	operations.currentDefaultBranch = branchName
 	if len(operations.remoteGitDirectoryPath) == 0 {
 		return fmt.Errorf(symbolicRefMissingRemotePathErrorConstant)
 	}
@@ -100,6 +102,15 @@ func (operations *recordingGitHubOperations) SetDefaultBranch(_ context.Context,
 		return fmt.Errorf(symbolicRefFailureErrorTemplateConstant, symbolicRefError)
 	}
 	return nil
+}
+
+func (operations *recordingGitHubOperations) ResolveRepoMetadata(_ context.Context, repository string) (githubcli.RepositoryMetadata, error) {
+	_ = repository
+	defaultBranch := strings.TrimSpace(operations.currentDefaultBranch)
+	if len(defaultBranch) == 0 {
+		defaultBranch = "main"
+	}
+	return githubcli.RepositoryMetadata{NameWithOwner: repository, DefaultBranch: defaultBranch}, nil
 }
 
 func (operations *recordingGitHubOperations) CheckBranchProtection(_ context.Context, repository string, branchName string) (bool, error) {

--- a/tests/workflow_integration_test.go
+++ b/tests/workflow_integration_test.go
@@ -51,11 +51,11 @@ const (
 	workflowIntegrationBranchCommitMessage     = "CI: switch workflow branch filters to master"
 	workflowIntegrationRepoViewJSONTemplate    = "{\"nameWithOwner\":\"canonical/example\",\"defaultBranchRef\":{\"name\":\"%s\"},\"description\":\"\"}\n"
 	workflowIntegrationConvertExpectedTemplate = "CONVERT-DONE: %s origin now ssh://git@github.com/canonical/example.git\n"
-	workflowIntegrationMigrateExpectedTemplate = "WORKFLOW-MIGRATE: %s (main → master) safe_to_delete=true\n"
+	workflowIntegrationDefaultExpectedTemplate = "WORKFLOW-DEFAULT: %s (main → master) safe_to_delete=true\n"
 	workflowIntegrationAuditExpectedTemplate   = "WORKFLOW-AUDIT: wrote report to %s\n"
 	workflowIntegrationCSVHeader               = "folder_name,final_github_repo,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical\n"
 	workflowIntegrationSubtestNameTemplate     = "%d_%s"
-	workflowIntegrationDefaultCaseName         = "protocol_migrate_audit"
+	workflowIntegrationDefaultCaseName         = "protocol_default_audit"
 	workflowIntegrationConfigFlagCaseName      = "config_flag_without_positional"
 	workflowIntegrationRepositoryConfigCase    = "repository_root_configuration"
 	workflowIntegrationHelpCaseName            = "workflow_help_missing_configuration"
@@ -190,7 +190,7 @@ func TestWorkflowRunIntegration(testInstance *testing.T) {
 			filteredOutput := filterStructuredOutput(rawOutput)
 
 			expectedConversion := fmt.Sprintf(workflowIntegrationConvertExpectedTemplate, repositoryPath)
-			expectedMigration := fmt.Sprintf(workflowIntegrationMigrateExpectedTemplate, repositoryPath)
+			expectedMigration := fmt.Sprintf(workflowIntegrationDefaultExpectedTemplate, repositoryPath)
 			expectedAudit := fmt.Sprintf(workflowIntegrationAuditExpectedTemplate, auditPath)
 
 			require.Contains(subtest, filteredOutput, expectedConversion)
@@ -323,14 +323,13 @@ operations:
       assume_yes: true
       dry_run: false
       owner: canonical
-  - operation: branch-migrate
+  - operation: branch-default
     with: &migration_defaults
       roots:
         - .
       debug: false
       targets:
         - remote_name: origin
-          source_branch: main
           target_branch: master
           push_to_remote: false
           delete_source_branch: false
@@ -344,7 +343,7 @@ workflow:
       with:
         <<: *remote_defaults
   - step:
-      operation: migrate-branch
+      operation: default-branch
       with:
         <<: *migration_defaults
   - step:


### PR DESCRIPTION
## Plan
- Map every CLI/config reference to the new branch default command
- Drop the --from flag and rely on automatic source detection per repository
- Extend services/tests so default branch metadata drives CLI and workflow behavior

## Summary
- rename the branch CLI command to b default and update docs/configs accordingly
- remove manual source flag handling and resolve the current default branch via GitHub metadata
- align workflows and integration tests with the new default-branch semantics and skip no-op repos gracefully

## Testing
- go test ./...]}