### PR TITLE
fix(branch): skip network operations without remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Improvements ⚙️
 - Introduced validated domain types for repository paths, owner/repo tuples, remotes, and branch names, refactoring repository executors and workflow options to consume the new constructors.
 
+### Bug Fixes 🐛
+- Prevented `branch cd` from aborting when repositories lack remotes by skipping fetch/pull operations and creating untracked branches when necessary.
+
 ### Docs 📚
 - Re-centered the README on user workflows and added `ARCHITECTURE.md` to document command wiring, package layout, and configuration internals.
 - Expanded `ARCHITECTURE.md` with current package responsibilities, dependency resolution, and workflow step registration details.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -23,6 +23,8 @@ If a repository doesnt have a remote, there is nothing to fetch, but we can stil
 
 ## BugFixes (300–399)
 
+- [x] [GX-300] `gix b default` aborts for repositories without remotes; it treats the `git fetch` failure as fatal instead of warning and skipping the fetch, so the branch switch never executes.
+  - Resolution: The branch change service now enumerates remotes once, skips fetch/pull when none exist, and creates branches without tracking nonexistent remotes. Added regression coverage for the zero-remote case.
 
 ## Maintenance (400–499)
 


### PR DESCRIPTION
- enumerate remotes once and skip fetch/pull when no upstream exists
- allow branch creation without tracking nonexistent remotes
- add regression covering repositories lacking remotes for branch cd
- CI: go test ./internal/... ./cmd/... ./pkg/... && go vet ./... passing
