### PR TITLE
maintenance/GX 405 shared helper cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements ⚙️
 - Introduced validated domain types for repository paths, owner/repo tuples, remotes, and branch names, refactoring repository executors and workflow options to consume the new constructors.
 - Added contextual error catalog and refactored repository executors/workflow bridges to emit and surface stable sentinel codes instead of printing ad-hoc failure strings.
+- Consolidated repository helper utilities (optional owner parsing, confirmation policies, shared reporter) and removed duplicated string normalization across protocol, remotes, and rename workflows.
 
 ### Bug Fixes 🐛
 - Prevented `branch cd` from aborting when repositories lack remotes by skipping fetch/pull operations and creating untracked branches when necessary.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -37,10 +37,8 @@ If a repository doesnt have a remote, there is nothing to fetch, but we can stil
   - Resolution: Added smart constructors in `internal/repos/shared` for repository paths, owners, repositories, remotes, branches, and protocols, refactored repos/workflow options to require these types, updated CLI/workflow edges to construct them once, and expanded tests to cover the new constructors.
 - [x] [GX-404] Establish contextual error strategy for repository executors
   - Resolution: Added `internal/repos/errors` sentinel catalog, refactored remotes/protocol/rename/history executors to wrap failures with operation-specific codes, taught workflow operations to log the contextual errors, and extended unit/integration tests to assert on the new propagation semantics.
-- [ ] [GX-405] Consolidate shared helpers and eliminate duplicated validation
-  - Extract owner/repository parsing into a single reusable helper and share prompt/output formatting via a reporter interface.
-  - Remove repeated `strings.TrimSpace` and similar defensive code paths, trusting normalized domain types introduced in GX-403.
-  - Review boolean flags such as `AssumeYes` and `RequireCleanWorktree`; convert to clearer enums or document retained semantics when multiple behaviors are conflated.
+- [x] [GX-405] Consolidate shared helpers and eliminate duplicated validation
+  - Resolution: Added shared reporter/policy helpers for repository executors, refactored protocol/remotes/rename workflows to reuse optional owner parsing and structured confirmation policies, and updated tests/CLI bridges to exercise the new abstractions without redundant trimming or boolean flags.
 - [ ] [GX-406] Expand regression coverage for policy compliance
   - Add table-driven tests for the new domain constructors and protocol conversion edge cases (current vs. target protocol mismatches, missing owner slugs, unknown protocols).
   - Test dependency resolvers in `internal/repos/dependencies` to ensure logger wiring and error propagation.

--- a/internal/repos/protocol/executor_test.go
+++ b/internal/repos/protocol/executor_test.go
@@ -188,7 +188,7 @@ func TestExecutorBehaviors(t *testing.T) {
 				CanonicalOwnerRepository: cloneOwnerRepository(canonicalOwnerRepository),
 				CurrentProtocol:          shared.RemoteProtocolHTTPS,
 				TargetProtocol:           shared.RemoteProtocolSSH,
-				AssumeYes:                true,
+				ConfirmationPolicy:       shared.ConfirmationAssumeYes,
 			},
 			gitManager:      &stubGitManager{currentURL: protocolTestOriginURL},
 			expectedOutput:  fmt.Sprintf(protocolTestSuccessMessage, protocolTestRepositoryPath, protocolTestTargetURL),
@@ -203,7 +203,7 @@ func TestExecutorBehaviors(t *testing.T) {
 			executor := protocol.NewExecutor(protocol.Dependencies{
 				GitManager: testCase.gitManager,
 				Prompter:   testCase.prompter,
-				Output:     outputBuffer,
+				Reporter:   shared.NewWriterReporter(outputBuffer),
 			})
 
 			executionError := executor.Execute(context.Background(), testCase.options)
@@ -244,7 +244,7 @@ func TestExecutorPromptsAdvertiseApplyAll(t *testing.T) {
 	dependencies := protocol.Dependencies{
 		GitManager: gitManager,
 		Prompter:   commandPrompter,
-		Output:     outputBuffer,
+		Reporter:   shared.NewWriterReporter(outputBuffer),
 	}
 	repositoryPath, repositoryPathError := shared.NewRepositoryPath(protocolTestRepositoryPath)
 	require.NoError(t, repositoryPathError)

--- a/internal/repos/shared/policies.go
+++ b/internal/repos/shared/policies.go
@@ -1,0 +1,93 @@
+package shared
+
+import "strings"
+
+// ConfirmationPolicy specifies how executors should handle user confirmations.
+type ConfirmationPolicy int
+
+const (
+	// ConfirmationPrompt indicates the executor should prompt the user.
+	ConfirmationPrompt ConfirmationPolicy = iota
+	// ConfirmationAssumeYes indicates the executor should continue without prompting.
+	ConfirmationAssumeYes
+)
+
+// ConfirmationPolicyFromBool converts legacy boolean flags into a policy.
+func ConfirmationPolicyFromBool(assumeYes bool) ConfirmationPolicy {
+	if assumeYes {
+		return ConfirmationAssumeYes
+	}
+	return ConfirmationPrompt
+}
+
+// ShouldPrompt reports whether the executor must prompt the user.
+func (policy ConfirmationPolicy) ShouldPrompt() bool {
+	return policy != ConfirmationAssumeYes
+}
+
+// ShouldAssumeYes reports whether prompting can be skipped.
+func (policy ConfirmationPolicy) ShouldAssumeYes() bool {
+	return policy == ConfirmationAssumeYes
+}
+
+// CleanWorktreePolicy describes expectations for repository cleanliness.
+type CleanWorktreePolicy int
+
+const (
+	// CleanWorktreeRequired enforces clean worktrees prior to executing an operation.
+	CleanWorktreeRequired CleanWorktreePolicy = iota
+	// CleanWorktreeOptional allows dirty worktrees.
+	CleanWorktreeOptional
+)
+
+// CleanWorktreePolicyFromBool converts legacy boolean flags into a policy value.
+func CleanWorktreePolicyFromBool(requireClean bool) CleanWorktreePolicy {
+	if requireClean {
+		return CleanWorktreeRequired
+	}
+	return CleanWorktreeOptional
+}
+
+// RequireClean reports whether a clean worktree is mandatory.
+func (policy CleanWorktreePolicy) RequireClean() bool {
+	return policy == CleanWorktreeRequired
+}
+
+// ParseOwnerRepositoryOptional normalizes and validates owner/repo tuples, returning nil when empty.
+func ParseOwnerRepositoryOptional(raw string) (*OwnerRepository, error) {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	ownerRepository, ownerRepositoryError := NewOwnerRepository(trimmed)
+	if ownerRepositoryError != nil {
+		return nil, ownerRepositoryError
+	}
+	return &ownerRepository, nil
+}
+
+// ParseOwnerSlugOptional normalizes owner slugs, returning nil when empty.
+func ParseOwnerSlugOptional(raw string) (*OwnerSlug, error) {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	slug, slugError := NewOwnerSlug(trimmed)
+	if slugError != nil {
+		return nil, slugError
+	}
+	return &slug, nil
+}
+
+// ParseRemoteURLOptional normalizes remote URLs, returning nil when empty.
+func ParseRemoteURLOptional(raw string) (*RemoteURL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	remoteURL, remoteURLError := NewRemoteURL(trimmed)
+	if remoteURLError != nil {
+		return nil, remoteURLError
+	}
+	return &remoteURL, nil
+}

--- a/internal/repos/shared/reporting.go
+++ b/internal/repos/shared/reporting.go
@@ -1,0 +1,27 @@
+package shared
+
+import (
+	"fmt"
+	"io"
+)
+
+// Reporter emits formatted executor events to an underlying sink.
+type Reporter interface {
+	Printf(format string, args ...any)
+}
+
+type writerReporter struct {
+	writer io.Writer
+}
+
+// NewWriterReporter constructs a Reporter that writes to the provided io.Writer.
+func NewWriterReporter(writer io.Writer) Reporter {
+	return writerReporter{writer: writer}
+}
+
+func (reporter writerReporter) Printf(format string, args ...any) {
+	if reporter.writer == nil {
+		return
+	}
+	fmt.Fprintf(reporter.writer, format, args...)
+}

--- a/internal/workflow/operations_rename.go
+++ b/internal/workflow/operations_rename.go
@@ -39,7 +39,7 @@ func (operation *RenameOperation) Execute(executionContext context.Context, envi
 		GitManager: environment.RepositoryManager,
 		Prompter:   environment.Prompter,
 		Clock:      shared.SystemClock{},
-		Output:     environment.Output,
+		Reporter:   shared.NewWriterReporter(environment.Output),
 	}
 
 	for repositoryIndex := range state.Repositories {
@@ -69,8 +69,8 @@ func (operation *RenameOperation) Execute(executionContext context.Context, envi
 			RepositoryPath:          repositoryPath,
 			DesiredFolderName:       trimmedFolderName,
 			DryRun:                  environment.DryRun,
-			RequireCleanWorktree:    operation.RequireCleanWorktree,
-			AssumeYes:               assumeYes,
+			CleanPolicy:             shared.CleanWorktreePolicyFromBool(operation.RequireCleanWorktree),
+			ConfirmationPolicy:      shared.ConfirmationPolicyFromBool(assumeYes),
 			IncludeOwner:            plan.IncludeOwner,
 			EnsureParentDirectories: plan.IncludeOwner,
 		}


### PR DESCRIPTION
- **fix(branch): skip network operations without remotes**
- **maint(GX-404): add contextual repo error handling**
- **maint(GX-405): unify repo option helpers and reporter**
