### PR TITLE
fix(migrate): raise actionable default-branch errors

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -28,7 +28,8 @@ If a repository doesnt have a remote, there is nothing to fetch, but we can stil
 
 - [x] [GX-300] `gix b default` aborts for repositories without remotes; it treats the `git fetch` failure as fatal instead of warning and skipping the fetch, so the branch switch never executes.
   - Resolution: The branch change service now enumerates remotes once, skips fetch/pull when none exist, and creates branches without tracking nonexistent remotes. Added regression coverage for the zero-remote case.
-- [ ] [GX-301] The message is repetitive, it's enough to say -- unable to update default branch. But it's absolutely unclear why or where it has happened. The error message shall be actionable, not informative. We must specify what folder/branch/etc we were at, and what command has failed, and why. That is an error/warning criteria for all commands.
+- [x] [GX-301] The message is repetitive, it's enough to say -- unable to update default branch. But it's absolutely unclear why or where it has happened. The error message shall be actionable, not informative. We must specify what folder/branch/etc we were at, and what command has failed, and why. That is an error/warning criteria for all commands.
+  - Resolution: Default branch update failures now raise `DefaultBranchUpdateError`, which includes repository path, identifier, source/target branches, and the GitHub CLI failure summary; the workflow operation forwards this error without extra wrapping, and new tests assert the actionable messaging.
 ```
 01:06:39 tyemirov@computercat:~/Development/Poodle $ gix --roots . b default master
 WORKFLOW-DEFAULT-SKIP: /home/tyemirov/Development/Poodle/ProductScanner already defaults to master

--- a/internal/workflow/operations_migrate.go
+++ b/internal/workflow/operations_migrate.go
@@ -133,6 +133,10 @@ func (operation *BranchMigrationOperation) Execute(executionContext context.Cont
 
 		result, executionError := migrationService.Execute(executionContext, options)
 		if executionError != nil {
+			var updateError migrate.DefaultBranchUpdateError
+			if errors.As(executionError, &updateError) {
+				return executionError
+			}
 			return fmt.Errorf(migrationExecutionErrorTemplateConstant, executionError)
 		}
 

--- a/internal/workflow/operations_migrate_test.go
+++ b/internal/workflow/operations_migrate_test.go
@@ -2,13 +2,16 @@ package workflow
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/temirov/gix/internal/audit"
 	"github.com/temirov/gix/internal/execshell"
 	"github.com/temirov/gix/internal/githubcli"
 	"github.com/temirov/gix/internal/gitrepo"
+	migrate "github.com/temirov/gix/internal/migrate"
 )
 
 type fakeGitExecutor struct{}
@@ -19,6 +22,37 @@ func (fakeGitExecutor) ExecuteGit(context.Context, execshell.CommandDetails) (ex
 
 func (fakeGitExecutor) ExecuteGitHubCLI(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
 	return execshell.ExecutionResult{}, nil
+}
+
+type defaultBranchFailureExecutor struct {
+	failure execshell.CommandFailedError
+}
+
+func newDefaultBranchFailureExecutor(message string) defaultBranchFailureExecutor {
+	return defaultBranchFailureExecutor{
+		failure: execshell.CommandFailedError{
+			Command: execshell.ShellCommand{Name: execshell.CommandGitHub},
+			Result: execshell.ExecutionResult{
+				ExitCode:      1,
+				StandardError: message,
+			},
+		},
+	}
+}
+
+func (executor defaultBranchFailureExecutor) ExecuteGit(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{}, nil
+}
+
+func (executor defaultBranchFailureExecutor) ExecuteGitHubCLI(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	if len(details.Arguments) >= 2 && details.Arguments[0] == "api" {
+		for _, argument := range details.Arguments {
+			if strings.Contains(argument, "default_branch=") {
+				return execshell.ExecutionResult{}, executor.failure
+			}
+		}
+	}
+	return execshell.ExecutionResult{StandardOutput: ""}, nil
 }
 
 func TestBranchMigrationOperationRequiresSingleTarget(testInstance *testing.T) {
@@ -41,4 +75,52 @@ func TestBranchMigrationOperationRequiresSingleTarget(testInstance *testing.T) {
 
 	require.Error(testInstance, executionError)
 	require.EqualError(testInstance, executionError, migrationMultipleTargetsUnsupportedMessageConstant)
+}
+
+func TestBranchMigrationOperationReturnsActionableDefaultBranchError(testInstance *testing.T) {
+	executor := newDefaultBranchFailureExecutor("GraphQL: branch not found")
+
+	repositoryManager, managerError := gitrepo.NewRepositoryManager(executor)
+	require.NoError(testInstance, managerError)
+
+	githubClient, clientError := githubcli.NewClient(executor)
+	require.NoError(testInstance, clientError)
+
+	operation := &BranchMigrationOperation{Targets: []BranchMigrationTarget{
+		{RemoteName: "origin", SourceBranch: "main", TargetBranch: "master"},
+	}}
+
+	repositoryPath := testInstance.TempDir()
+
+	state := &State{
+		Repositories: []*RepositoryState{
+			{
+				Path: repositoryPath,
+				Inspection: audit.RepositoryInspection{
+					CanonicalOwnerRepo: "owner/example",
+				},
+			},
+		},
+	}
+
+	environment := &Environment{
+		RepositoryManager: repositoryManager,
+		GitExecutor:       executor,
+		GitHubClient:      githubClient,
+	}
+
+	executionError := operation.Execute(context.Background(), environment, state)
+
+	require.Error(testInstance, executionError)
+
+	var updateError migrate.DefaultBranchUpdateError
+	require.ErrorAs(testInstance, executionError, &updateError)
+
+	errorMessage := executionError.Error()
+	require.Contains(testInstance, errorMessage, repositoryPath)
+	require.Contains(testInstance, errorMessage, "owner/example")
+	require.Contains(testInstance, errorMessage, "source=main")
+	require.Contains(testInstance, errorMessage, "target=master")
+	require.Contains(testInstance, errorMessage, "GraphQL: branch not found")
+	require.NotContains(testInstance, errorMessage, "default branch update failed")
 }


### PR DESCRIPTION
- add DefaultBranchUpdateError carrying repository metadata and CLI failure summary
- surface the structured error from workflow branch migration without redundant wrapping
- expand migrate and workflow tests for default-branch failure messaging
- CI: go test ./internal/migrate ./internal/workflow