### PR TITLE
fix: preserve branch captures and add proprietary licensing workflow

### DIFF
--- a/configs/proprietary-licensing.yaml
+++ b/configs/proprietary-licensing.yaml
@@ -1,0 +1,119 @@
+workflow:
+  - step:
+      name: folder-rename
+      command: ["folder", "rename"]
+      with:
+        require_clean: false
+        include_owner: false
+
+  - step:
+      name: switch-default-branch
+      after: ["folder-rename"]
+      command: ["tasks", "apply"]
+      with:
+        tasks:
+          - name: "Switch to default branch"
+            ensure_clean: true
+            actions:
+              - type: branch.change
+                options:
+                  remote: origin
+                  create_if_missing: false
+                  capture:
+                    name: initial_branch
+                    value: branch
+
+  - step:
+      name: license-branch
+      after: ["switch-default-branch"]
+      command: ["tasks", "apply"]
+      with:
+        tasks:
+          - name: "Create license branch"
+            ensure_clean: true
+            actions:
+              - type: branch.change
+                options:
+                  branch: 'automation/license-proprietary/{{ .Repository.Name }}-{{ index .Environment "workflow_run_id" }}'
+                  remote: origin
+                  create_if_missing: true
+
+  - step:
+      name: license-apply
+      after: ["license-branch"]
+      command: ["tasks", "apply"]
+      with:
+        tasks:
+          - name: "Apply proprietary license"
+            ensure_clean: true
+            steps:
+              - files.apply
+            files:
+              - path: LICENSE
+                content: |
+                  SPDX-License-Identifier: LicenseRef-MPRL-Proprietary
+
+                  Proprietary License
+
+                  Copyright (c) {{ if .Environment.license_year }}{{ .Environment.license_year }}{{ else }}2026{{ end }} {{ if .Environment.license_company }}{{ .Environment.license_company }}{{ else }}Marco Polo Research Lab{{ end }}
+                  All rights reserved.
+
+                  This software and associated documentation files (the "Software") are the
+                  confidential and proprietary information of {{ if .Environment.license_company }}{{ .Environment.license_company }}{{ else }}Marco Polo Research Lab{{ end }}. Unauthorized copying,
+                  distribution, modification, or use of the Software, in whole or in part, is
+                  strictly prohibited without prior written permission from {{ if .Environment.license_company }}{{ .Environment.license_company }}{{ else }}Marco Polo Research Lab{{ end }}.
+
+                  No license is granted to the public. Use is restricted to customers and
+                  partners under written agreements with {{ if .Environment.license_company }}{{ .Environment.license_company }}{{ else }}Marco Polo Research Lab{{ end }}.
+
+                  The Software is provided "AS IS", without warranty of any kind, express or
+                  implied, including but not limited to the warranties of merchantability,
+                  fitness for a particular purpose, and noninfringement. In no event shall
+                  {{ if .Environment.license_company }}{{ .Environment.license_company }}{{ else }}Marco Polo Research Lab{{ end }} be liable for any claim, damages, or other liability, whether in
+                  an action of contract, tort, or otherwise, arising from, out of, or in
+                  connection with the Software or the use or other dealings in the Software.
+                mode: overwrite
+                permissions: 420
+
+  - step:
+      name: license-stage-commit
+      after: ["license-apply"]
+      command: ["git", "stage-commit"]
+      with:
+        paths:
+          - "LICENSE"
+        commit_message: "chore: update license (proprietary)"
+        safeguards:
+          soft_skip:
+            require_changes: true
+
+  - step:
+      name: license-open-pr
+      after: ["license-stage-commit"]
+      command: ["pull-request", "open"]
+      with:
+        branch: 'automation/license-proprietary/{{ .Repository.Name }}-{{ index .Environment "workflow_run_id" }}'
+        title: "chore({{ .Repository.Name }}): proprietary license"
+        body: |
+          Updates the repository license to an SPDX-tagged proprietary LICENSE file.
+        base: "{{ .Repository.DefaultBranch }}"
+        push_remote: origin
+        draft: true
+        safeguards:
+          soft_skip:
+            require_changes: true
+
+  - step:
+      name: restore-initial-branch
+      after: ["license-open-pr"]
+      command: ["tasks", "apply"]
+      with:
+        tasks:
+          - name: "Restore initial branch"
+            ensure_clean: true
+            actions:
+              - type: branch.change
+                options:
+                  restore:
+                    from: initial_branch
+                    value: branch

--- a/internal/branches/cd/task_action.go
+++ b/internal/branches/cd/task_action.go
@@ -205,6 +205,12 @@ func handleBranchChangeAction(ctx context.Context, environment *workflow.Environ
 		stashPushCount++
 	}
 
+	if captureSpec != nil {
+		if err := captureBranchState(ctx, environment, repository, captureSpec); err != nil {
+			return err
+		}
+	}
+
 	service, serviceError := NewService(ServiceDependencies{
 		GitExecutor: environment.GitExecutor,
 		Logger:      environment.Logger,
@@ -266,12 +272,6 @@ func handleBranchChangeAction(ctx context.Context, environment *workflow.Environ
 			"refresh skipped (dirty worktree)",
 			refreshSkippedDetails,
 		)
-	}
-
-	if captureSpec != nil {
-		if err := captureBranchState(ctx, environment, repository, captureSpec); err != nil {
-			return err
-		}
 	}
 
 	for _, warning := range result.Warnings {

--- a/internal/branches/cd/task_action_test.go
+++ b/internal/branches/cd/task_action_test.go
@@ -73,6 +73,38 @@ func (executor *branchCaptureExecutor) ExecuteGitHubCLI(context.Context, execshe
 	return execshell.ExecutionResult{}, nil
 }
 
+type statefulBranchCaptureExecutor struct {
+	commands      []execshell.CommandDetails
+	currentBranch string
+}
+
+func (executor *statefulBranchCaptureExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	executor.commands = append(executor.commands, details)
+	if len(details.Arguments) == 0 {
+		return execshell.ExecutionResult{}, nil
+	}
+	switch details.Arguments[0] {
+	case "status":
+		return execshell.ExecutionResult{}, nil
+	case "remote":
+		return execshell.ExecutionResult{StandardOutput: "origin\n"}, nil
+	case "rev-parse":
+		if len(details.Arguments) > 2 && details.Arguments[1] == "--abbrev-ref" && details.Arguments[2] == "HEAD" {
+			return execshell.ExecutionResult{StandardOutput: executor.currentBranch + "\n"}, nil
+		}
+	case "switch":
+		if len(details.Arguments) > 1 {
+			executor.currentBranch = details.Arguments[1]
+		}
+		return execshell.ExecutionResult{}, nil
+	}
+	return execshell.ExecutionResult{}, nil
+}
+
+func (executor *statefulBranchCaptureExecutor) ExecuteGitHubCLI(context.Context, execshell.CommandDetails) (execshell.ExecutionResult, error) {
+	return execshell.ExecutionResult{}, nil
+}
+
 func TestHandleBranchChangeActionUsesRepositoryDefault(t *testing.T) {
 	executor := &stubGitExecutor{
 		responses: []stubGitResponse{
@@ -525,6 +557,45 @@ func TestHandleBranchChangeActionCapturesBranch(t *testing.T) {
 	kind, kindExists := environment.CaptureKindForVariable(variableName)
 	require.True(t, kindExists)
 	require.Equal(t, workflow.CaptureKindBranch, kind)
+}
+
+func TestHandleBranchChangeActionCapturesOriginalBranchBeforeSwitch(t *testing.T) {
+	executor := &statefulBranchCaptureExecutor{currentBranch: "feature/local-work"}
+	reporter := &recordingReporter{}
+	variableName, nameErr := workflow.NewVariableName("initial_branch")
+	require.NoError(t, nameErr)
+
+	gitManager, managerErr := gitrepo.NewRepositoryManager(executor)
+	require.NoError(t, managerErr)
+
+	environment := &workflow.Environment{
+		GitExecutor:       executor,
+		RepositoryManager: gitManager,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          reporter,
+		Variables:         workflow.NewVariableStore(),
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			RemoteDefaultBranch: "master",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchRemote: shared.OriginRemoteNameConstant,
+		"capture": map[string]any{
+			"name":  "initial_branch",
+			"value": "branch",
+		},
+	}
+
+	require.NoError(t, handleBranchChangeAction(context.Background(), environment, repository, parameters))
+	value, exists := environment.Variables.Get(variableName)
+	require.True(t, exists)
+	require.Equal(t, "feature/local-work", value)
+	require.Equal(t, "master", executor.currentBranch)
 }
 
 func TestHandleBranchChangeActionCapturesCommit(t *testing.T) {

--- a/internal/licenses/templates/proprietary/LICENSE.md
+++ b/internal/licenses/templates/proprietary/LICENSE.md
@@ -1,5 +1,21 @@
-Copyright (c) {{YEAR}} {{COMPANY}}. All rights reserved.
+SPDX-License-Identifier: LicenseRef-MPRL-Proprietary
 
-This software and associated files are proprietary and confidential. Unauthorized copying, distribution, modification, or use of this software, in whole or in part, is strictly prohibited without express written permission from {{COMPANY}}.
+Proprietary License
 
-No license is granted to the public. Use is restricted to customers and partners under written agreements with {{COMPANY}}.
+Copyright (c) {{YEAR}} {{COMPANY}}
+All rights reserved.
+
+This software and associated documentation files (the "Software") are the
+confidential and proprietary information of {{COMPANY}}. Unauthorized copying,
+distribution, modification, or use of the Software, in whole or in part, is
+strictly prohibited without prior written permission from {{COMPANY}}.
+
+No license is granted to the public. Use is restricted to customers and
+partners under written agreements with {{COMPANY}}.
+
+The Software is provided "AS IS", without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability,
+fitness for a particular purpose, and noninfringement. In no event shall
+{{COMPANY}} be liable for any claim, damages, or other liability, whether in
+an action of contract, tort, or otherwise, arising from, out of, or in
+connection with the Software or the use or other dealings in the Software.

--- a/internal/licenses/templates_test.go
+++ b/internal/licenses/templates_test.go
@@ -23,6 +23,15 @@ func TestLoadTemplateBundleUsesEnvironmentExpressions(testInstance *testing.T) {
 	require.True(testInstance, strings.Contains(templateBundle.PrimaryContent, VariableAuthor))
 }
 
+func TestLoadTemplateBundleUsesSPDXTaggedProprietaryTemplate(testInstance *testing.T) {
+	templateBundle, loadError := LoadTemplateBundle(TemplateNameProprietary)
+	require.NoError(testInstance, loadError)
+	require.Contains(testInstance, templateBundle.PrimaryContent, "SPDX-License-Identifier: LicenseRef-MPRL-Proprietary")
+	require.Contains(testInstance, templateBundle.PrimaryContent, VariableCompany)
+	require.Contains(testInstance, templateBundle.PrimaryContent, `The Software is provided "AS IS"`)
+	require.Contains(testInstance, templateBundle.PrimaryContent, "No license is granted to the public.")
+}
+
 func TestLoadTemplateBundleRejectsUnknownTemplate(testInstance *testing.T) {
 	_, loadError := LoadTemplateBundle("unknown")
 	require.Error(testInstance, loadError)


### PR DESCRIPTION
## Summary
- preserve captured branch state before branch switching so workflow restore returns to the original branch
- upgrade the proprietary license template to the SPDX-tagged house format with the stronger disclaimer text
- add the reusable workflow config at `configs/proprietary-licensing.yaml`

## Validation
- make test
- make lint
- verified dirty repos skip `switch-default-branch`
- verified clean repos receive the proprietary `LICENSE` update on the automation branch