### PR TITLE
feat(web): queue audit remediations before apply

### DIFF
--- a/cmd/cli/application_web.go
+++ b/cmd/cli/application_web.go
@@ -62,12 +62,14 @@ const (
 	webDraftTemplateFilesRemoveConstant         = "files_remove"
 	webAuditQueuedChangesRequiredConstant       = "at least one queued audit change is required"
 	webAuditChangePathRequiredConstant          = "audit change path is required"
+	webAuditChangePathAbsoluteRequiredConstant  = "audit change path must be absolute"
 	webAuditChangeDeleteRejectedConstant        = "delete_folder requires confirm_delete"
 	webAuditChangeDeleteRootRejectedConstant    = "delete_folder does not allow deleting filesystem roots"
 	webAuditChangeProtocolMissingConstant       = "convert_protocol requires source_protocol and target_protocol"
 	webAuditChangeSyncStrategyTemplateConstant  = "unsupported sync strategy %q"
 	webAuditChangeKindTemplateConstant          = "unsupported audit change kind %q"
 	webAuditChangeStatusSucceededConstant       = "succeeded"
+	webAuditChangeStatusSkippedConstant         = "skipped"
 	webAuditChangeStatusFailedConstant          = "failed"
 )
 
@@ -313,6 +315,7 @@ func (application *Application) applyWebAuditChange(executionContext context.Con
 	errorBuffer := &bytes.Buffer{}
 
 	applyError := error(nil)
+	executionOutcome := workflow.ExecutionOutcome{}
 	message := ""
 
 	switch change.Kind {
@@ -330,7 +333,6 @@ func (application *Application) applyWebAuditChange(executionContext context.Con
 			break
 		}
 		_, _ = fmt.Fprintf(outputBuffer, "DELETED: %s\n", normalizedPath)
-		message = "Folder deleted"
 	default:
 		dependencies, dependencyError := application.webTaskRunnerDependencies(outputBuffer, errorBuffer)
 		if dependencyError != nil {
@@ -338,22 +340,27 @@ func (application *Application) applyWebAuditChange(executionContext context.Con
 			break
 		}
 
-		applyError = executeWebAuditWorkflowChange(executionContext, dependencies.Workflow, normalizedPath, change)
-		message = webAuditChangeMessage(change.Kind)
+		executionOutcome, applyError = executeWebAuditWorkflowChange(executionContext, dependencies.Workflow, normalizedPath, change)
 	}
 
 	result.Stdout = outputBuffer.String()
 	result.Stderr = errorBuffer.String()
-	if len(message) > 0 {
-		result.Message = message
-	}
-	if applyError != nil {
+	result.Status = webAuditChangeResultStatus(executionOutcome, applyError)
+	if result.Status == webAuditChangeStatusFailedConstant {
 		result.Status = webAuditChangeStatusFailedConstant
 		result.Error = applyError.Error()
 		return result
 	}
 
-	result.Status = webAuditChangeStatusSucceededConstant
+	if result.Status == webAuditChangeStatusSkippedConstant {
+		message = webAuditChangeSkippedMessage(change.Kind)
+	} else {
+		message = webAuditChangeMessage(change.Kind)
+	}
+	if len(message) > 0 {
+		result.Message = message
+	}
+
 	return result
 }
 
@@ -473,7 +480,7 @@ func executeWebAuditWorkflowChange(
 	dependencies workflow.Dependencies,
 	repositoryPath string,
 	change web.AuditQueuedChange,
-) error {
+) (workflow.ExecutionOutcome, error) {
 	switch change.Kind {
 	case web.AuditChangeKindRenameFolder:
 		return executeWebAuditOperation(
@@ -495,11 +502,11 @@ func executeWebAuditWorkflowChange(
 	case web.AuditChangeKindConvertProtocol:
 		sourceProtocol, sourceError := shared.ParseRemoteProtocol(change.SourceProtocol)
 		if sourceError != nil {
-			return errors.New(webAuditChangeProtocolMissingConstant)
+			return workflow.ExecutionOutcome{}, errors.New(webAuditChangeProtocolMissingConstant)
 		}
 		targetProtocol, targetError := shared.ParseRemoteProtocol(change.TargetProtocol)
 		if targetError != nil {
-			return errors.New(webAuditChangeProtocolMissingConstant)
+			return workflow.ExecutionOutcome{}, errors.New(webAuditChangeProtocolMissingConstant)
 		}
 		return executeWebAuditOperation(
 			executionContext,
@@ -513,7 +520,7 @@ func executeWebAuditWorkflowChange(
 	case web.AuditChangeKindSyncWithRemote:
 		taskDefinition, taskDefinitionError := webAuditSyncTaskDefinition(change.SyncStrategy)
 		if taskDefinitionError != nil {
-			return taskDefinitionError
+			return workflow.ExecutionOutcome{}, taskDefinitionError
 		}
 		return executeWebAuditTasks(
 			executionContext,
@@ -522,7 +529,7 @@ func executeWebAuditWorkflowChange(
 			[]workflow.TaskDefinition{taskDefinition},
 		)
 	default:
-		return fmt.Errorf(webAuditChangeKindTemplateConstant, change.Kind)
+		return workflow.ExecutionOutcome{}, fmt.Errorf(webAuditChangeKindTemplateConstant, change.Kind)
 	}
 }
 
@@ -531,9 +538,9 @@ func executeWebAuditOperation(
 	dependencies workflow.Dependencies,
 	repositoryPath string,
 	operation workflow.Operation,
-) error {
+) (workflow.ExecutionOutcome, error) {
 	executor := workflow.NewExecutor([]workflow.Operation{operation}, dependencies)
-	_, executionError := executor.Execute(
+	return executor.Execute(
 		executionContext,
 		[]string{repositoryPath},
 		workflow.RuntimeOptions{
@@ -541,7 +548,6 @@ func executeWebAuditOperation(
 			WorkflowParallelism: 1,
 		},
 	)
-	return executionError
 }
 
 func executeWebAuditTasks(
@@ -549,9 +555,9 @@ func executeWebAuditTasks(
 	dependencies workflow.Dependencies,
 	repositoryPath string,
 	definitions []workflow.TaskDefinition,
-) error {
+) (workflow.ExecutionOutcome, error) {
 	runner := workflow.NewTaskRunner(dependencies)
-	_, executionError := runner.Run(
+	return runner.Run(
 		executionContext,
 		[]string{repositoryPath},
 		definitions,
@@ -560,7 +566,6 @@ func executeWebAuditTasks(
 			WorkflowParallelism: 1,
 		},
 	)
-	return executionError
 }
 
 func webAuditSyncTaskDefinition(syncStrategy string) (workflow.TaskDefinition, error) {
@@ -608,6 +613,47 @@ func webAuditChangeMessage(kind web.AuditChangeKind) string {
 	}
 }
 
+func webAuditChangeSkippedMessage(kind web.AuditChangeKind) string {
+	switch kind {
+	case web.AuditChangeKindRenameFolder:
+		return "Rename folder skipped"
+	case web.AuditChangeKindUpdateCanonical:
+		return "Canonical remote update skipped"
+	case web.AuditChangeKindConvertProtocol:
+		return "Remote protocol update skipped"
+	case web.AuditChangeKindSyncWithRemote:
+		return "Repository synchronization skipped"
+	case web.AuditChangeKindDeleteFolder:
+		return "Folder deletion skipped"
+	default:
+		return ""
+	}
+}
+
+func webAuditChangeResultStatus(executionOutcome workflow.ExecutionOutcome, executionError error) string {
+	if executionError != nil {
+		return webAuditChangeStatusFailedConstant
+	}
+	if webAuditExecutionOutcomeContainsStepOutcome(executionOutcome, webAuditChangeStatusSkippedConstant) {
+		return webAuditChangeStatusSkippedConstant
+	}
+	return webAuditChangeStatusSucceededConstant
+}
+
+func webAuditExecutionOutcomeContainsStepOutcome(executionOutcome workflow.ExecutionOutcome, outcomeLabel string) bool {
+	if len(outcomeLabel) == 0 {
+		return false
+	}
+
+	for _, stepOutcomeCounts := range executionOutcome.ReporterSummaryData.StepOutcomeCounts {
+		if stepOutcomeCounts[outcomeLabel] > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 func cmpWebAuditChangePriority(left web.AuditChangeKind, right web.AuditChangeKind) int {
 	return webAuditChangePriority(left) - webAuditChangePriority(right)
 }
@@ -634,7 +680,11 @@ func normalizeWebAuditChangePath(rawPath string) (string, error) {
 	if len(trimmedPath) == 0 {
 		return "", errors.New(webAuditChangePathRequiredConstant)
 	}
-	return filepath.Clean(trimmedPath), nil
+	cleanPath := filepath.Clean(trimmedPath)
+	if !filepath.IsAbs(cleanPath) {
+		return "", errors.New(webAuditChangePathAbsoluteRequiredConstant)
+	}
+	return cleanPath, nil
 }
 
 func auditInspectionReportRow(inspection audit.RepositoryInspection) audit.AuditReportRow {

--- a/cmd/cli/application_web.go
+++ b/cmd/cli/application_web.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -260,9 +261,14 @@ func (application *Application) newWebAuditChangeExecutor() web.AuditChangeExecu
 			return web.AuditChangeApplyResponse{Error: webAuditQueuedChangesRequiredConstant}
 		}
 
-		results := make([]web.AuditChangeApplyResult, 0, len(request.Changes))
-		for changeIndex := range request.Changes {
-			results = append(results, application.applyWebAuditChange(executionContext, request.Changes[changeIndex]))
+		changes := append([]web.AuditQueuedChange(nil), request.Changes...)
+		slices.SortStableFunc(changes, func(left web.AuditQueuedChange, right web.AuditQueuedChange) int {
+			return cmpWebAuditChangePriority(left.Kind, right.Kind)
+		})
+
+		results := make([]web.AuditChangeApplyResult, 0, len(changes))
+		for changeIndex := range changes {
+			results = append(results, application.applyWebAuditChange(executionContext, changes[changeIndex]))
 		}
 
 		return web.AuditChangeApplyResponse{Results: results}
@@ -599,6 +605,27 @@ func webAuditChangeMessage(kind web.AuditChangeKind) string {
 		return "Folder deleted"
 	default:
 		return ""
+	}
+}
+
+func cmpWebAuditChangePriority(left web.AuditChangeKind, right web.AuditChangeKind) int {
+	return webAuditChangePriority(left) - webAuditChangePriority(right)
+}
+
+func webAuditChangePriority(kind web.AuditChangeKind) int {
+	switch kind {
+	case web.AuditChangeKindUpdateCanonical:
+		return 10
+	case web.AuditChangeKindConvertProtocol:
+		return 20
+	case web.AuditChangeKindSyncWithRemote:
+		return 30
+	case web.AuditChangeKindRenameFolder:
+		return 40
+	case web.AuditChangeKindDeleteFolder:
+		return 50
+	default:
+		return 100
 	}
 }
 

--- a/cmd/cli/application_web.go
+++ b/cmd/cli/application_web.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,12 +14,16 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.uber.org/zap"
 
+	"github.com/tyemirov/gix/internal/audit"
 	"github.com/tyemirov/gix/internal/execshell"
 	reposdeps "github.com/tyemirov/gix/internal/repos/dependencies"
 	"github.com/tyemirov/gix/internal/repos/shared"
 	flagutils "github.com/tyemirov/gix/internal/utils/flags"
 	"github.com/tyemirov/gix/internal/web"
+	"github.com/tyemirov/gix/internal/workflow"
+	"github.com/tyemirov/gix/pkg/taskrunner"
 )
 
 const (
@@ -54,6 +59,15 @@ const (
 	webDraftTemplateFilesAddConstant            = "files_add"
 	webDraftTemplateFilesReplaceConstant        = "files_replace"
 	webDraftTemplateFilesRemoveConstant         = "files_remove"
+	webAuditQueuedChangesRequiredConstant       = "at least one queued audit change is required"
+	webAuditChangePathRequiredConstant          = "audit change path is required"
+	webAuditChangeDeleteRejectedConstant        = "delete_folder requires confirm_delete"
+	webAuditChangeDeleteRootRejectedConstant    = "delete_folder does not allow deleting filesystem roots"
+	webAuditChangeProtocolMissingConstant       = "convert_protocol requires source_protocol and target_protocol"
+	webAuditChangeSyncStrategyTemplateConstant  = "unsupported sync strategy %q"
+	webAuditChangeKindTemplateConstant          = "unsupported audit change kind %q"
+	webAuditChangeStatusSucceededConstant       = "succeeded"
+	webAuditChangeStatusFailedConstant          = "failed"
 )
 
 var nonActionableCommandPaths = map[string]struct{}{
@@ -85,6 +99,7 @@ type webRunner func(context.Context, web.ServerOptions) error
 
 type execshellGitExecutor = shared.GitExecutor
 type webGitRepositoryManager = shared.GitRepositoryManager
+type webGitHubMetadataResolver = shared.GitHubMetadataResolver
 
 type webLaunchConfiguration struct {
 	port int
@@ -142,11 +157,13 @@ func (application *Application) handleWebLaunch(command *cobra.Command) (bool, e
 	repositoryCatalog := application.repositoryCatalog(executionContext)
 
 	return true, application.webRunner(executionContext, web.ServerOptions{
-		Address:      launchConfiguration.listenAddress(),
-		Repositories: repositoryCatalog,
-		Catalog:      application.commandCatalog(),
-		LoadBranches: application.loadRepositoryBranches,
-		Execute:      application.newWebCommandExecutor(),
+		Address:           launchConfiguration.listenAddress(),
+		Repositories:      repositoryCatalog,
+		Catalog:           application.commandCatalog(),
+		LoadBranches:      application.loadRepositoryBranches,
+		Execute:           application.newWebCommandExecutor(),
+		InspectAudit:      application.newWebAuditInspector(),
+		ApplyAuditChanges: application.newWebAuditChangeExecutor(),
 	})
 }
 
@@ -198,6 +215,60 @@ func (application *Application) newWebCommandExecutor() web.CommandExecutor {
 	}
 }
 
+func (application *Application) newWebAuditInspector() web.AuditInspector {
+	return func(executionContext context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+		discoverer, gitExecutor, repositoryManager, githubResolver, dependencyError := application.webAuditDependencies()
+		if dependencyError != nil {
+			return web.AuditInspectionResponse{Error: dependencyError.Error()}
+		}
+
+		auditService := audit.NewService(
+			discoverer,
+			repositoryManager,
+			gitExecutor,
+			githubResolver,
+			io.Discard,
+			io.Discard,
+		)
+
+		inspections, inspectionError := auditService.DiscoverInspections(
+			executionContext,
+			append([]string(nil), request.Roots...),
+			request.IncludeAll,
+			false,
+			audit.InspectionDepthFull,
+		)
+		if inspectionError != nil {
+			return web.AuditInspectionResponse{Roots: append([]string(nil), request.Roots...), Error: inspectionError.Error()}
+		}
+
+		rows := make([]web.AuditInspectionRow, 0, len(inspections))
+		for inspectionIndex := range inspections {
+			rows = append(rows, mapAuditInspectionRow(inspections[inspectionIndex]))
+		}
+
+		return web.AuditInspectionResponse{
+			Roots: append([]string(nil), request.Roots...),
+			Rows:  rows,
+		}
+	}
+}
+
+func (application *Application) newWebAuditChangeExecutor() web.AuditChangeExecutor {
+	return func(executionContext context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+		if len(request.Changes) == 0 {
+			return web.AuditChangeApplyResponse{Error: webAuditQueuedChangesRequiredConstant}
+		}
+
+		results := make([]web.AuditChangeApplyResult, 0, len(request.Changes))
+		for changeIndex := range request.Changes {
+			results = append(results, application.applyWebAuditChange(executionContext, request.Changes[changeIndex]))
+		}
+
+		return web.AuditChangeApplyResponse{Results: results}
+	}
+}
+
 func (application *Application) webInheritedArguments(arguments []string) []string {
 	inheritedArguments := make([]string, 0, len(arguments)+6)
 
@@ -217,6 +288,67 @@ func (application *Application) webInheritedArguments(arguments []string) []stri
 	}
 
 	return append(inheritedArguments, arguments...)
+}
+
+func (application *Application) applyWebAuditChange(executionContext context.Context, change web.AuditQueuedChange) web.AuditChangeApplyResult {
+	normalizedPath, pathError := normalizeWebAuditChangePath(change.Path)
+	result := web.AuditChangeApplyResult{
+		ID:   change.ID,
+		Kind: change.Kind,
+		Path: normalizedPath,
+	}
+	if pathError != nil {
+		result.Status = webAuditChangeStatusFailedConstant
+		result.Error = pathError.Error()
+		return result
+	}
+
+	outputBuffer := &bytes.Buffer{}
+	errorBuffer := &bytes.Buffer{}
+
+	applyError := error(nil)
+	message := ""
+
+	switch change.Kind {
+	case web.AuditChangeKindDeleteFolder:
+		if !change.ConfirmDelete {
+			applyError = errors.New(webAuditChangeDeleteRejectedConstant)
+			break
+		}
+		if filepath.Dir(normalizedPath) == normalizedPath {
+			applyError = errors.New(webAuditChangeDeleteRootRejectedConstant)
+			break
+		}
+		if deleteError := os.RemoveAll(normalizedPath); deleteError != nil {
+			applyError = deleteError
+			break
+		}
+		_, _ = fmt.Fprintf(outputBuffer, "DELETED: %s\n", normalizedPath)
+		message = "Folder deleted"
+	default:
+		dependencies, dependencyError := application.webTaskRunnerDependencies(outputBuffer, errorBuffer)
+		if dependencyError != nil {
+			applyError = dependencyError
+			break
+		}
+
+		applyError = executeWebAuditWorkflowChange(executionContext, dependencies.Workflow, normalizedPath, change)
+		message = webAuditChangeMessage(change.Kind)
+	}
+
+	result.Stdout = outputBuffer.String()
+	result.Stderr = errorBuffer.String()
+	if len(message) > 0 {
+		result.Message = message
+	}
+	if applyError != nil {
+		result.Status = webAuditChangeStatusFailedConstant
+		result.Error = applyError.Error()
+		return result
+	}
+
+	result.Status = webAuditChangeStatusSucceededConstant
+	return result
 }
 
 func commandArgumentsContainFlag(arguments []string, flagName string) bool {
@@ -311,6 +443,232 @@ func (application *Application) loadRepositoryBranches(executionContext context.
 	return loadRepositoryBranches(executionContext, repository, gitExecutor)
 }
 
+func mapAuditInspectionRow(inspection audit.RepositoryInspection) web.AuditInspectionRow {
+	row := auditInspectionReportRow(inspection)
+	return web.AuditInspectionRow{
+		Path:                   inspection.Path,
+		FolderName:             row.FolderName,
+		IsGitRepository:        inspection.IsGitRepository,
+		FinalGitHubRepository:  row.FinalRepository,
+		OriginRemoteStatus:     string(row.OriginRemoteStatus),
+		NameMatches:            string(row.NameMatches),
+		RemoteDefaultBranch:    row.RemoteDefaultBranch,
+		LocalBranch:            row.LocalBranch,
+		InSync:                 string(row.InSync),
+		RemoteProtocol:         string(row.RemoteProtocol),
+		OriginMatchesCanonical: string(row.OriginMatchesCanonical),
+		WorktreeDirty:          string(row.WorktreeDirty),
+		DirtyFiles:             row.DirtyFiles,
+	}
+}
+
+func executeWebAuditWorkflowChange(
+	executionContext context.Context,
+	dependencies workflow.Dependencies,
+	repositoryPath string,
+	change web.AuditQueuedChange,
+) error {
+	switch change.Kind {
+	case web.AuditChangeKindRenameFolder:
+		return executeWebAuditOperation(
+			executionContext,
+			dependencies,
+			repositoryPath,
+			&workflow.RenameOperation{
+				RequireCleanWorktree: change.RequireClean,
+				IncludeOwner:         change.IncludeOwner,
+			},
+		)
+	case web.AuditChangeKindUpdateCanonical:
+		return executeWebAuditOperation(
+			executionContext,
+			dependencies,
+			repositoryPath,
+			&workflow.CanonicalRemoteOperation{},
+		)
+	case web.AuditChangeKindConvertProtocol:
+		sourceProtocol, sourceError := shared.ParseRemoteProtocol(change.SourceProtocol)
+		if sourceError != nil {
+			return errors.New(webAuditChangeProtocolMissingConstant)
+		}
+		targetProtocol, targetError := shared.ParseRemoteProtocol(change.TargetProtocol)
+		if targetError != nil {
+			return errors.New(webAuditChangeProtocolMissingConstant)
+		}
+		return executeWebAuditOperation(
+			executionContext,
+			dependencies,
+			repositoryPath,
+			&workflow.ProtocolConversionOperation{
+				FromProtocol: sourceProtocol,
+				ToProtocol:   targetProtocol,
+			},
+		)
+	case web.AuditChangeKindSyncWithRemote:
+		taskDefinition, taskDefinitionError := webAuditSyncTaskDefinition(change.SyncStrategy)
+		if taskDefinitionError != nil {
+			return taskDefinitionError
+		}
+		return executeWebAuditTasks(
+			executionContext,
+			dependencies,
+			repositoryPath,
+			[]workflow.TaskDefinition{taskDefinition},
+		)
+	default:
+		return fmt.Errorf(webAuditChangeKindTemplateConstant, change.Kind)
+	}
+}
+
+func executeWebAuditOperation(
+	executionContext context.Context,
+	dependencies workflow.Dependencies,
+	repositoryPath string,
+	operation workflow.Operation,
+) error {
+	executor := workflow.NewExecutor([]workflow.Operation{operation}, dependencies)
+	_, executionError := executor.Execute(
+		executionContext,
+		[]string{repositoryPath},
+		workflow.RuntimeOptions{
+			AssumeYes:           true,
+			WorkflowParallelism: 1,
+		},
+	)
+	return executionError
+}
+
+func executeWebAuditTasks(
+	executionContext context.Context,
+	dependencies workflow.Dependencies,
+	repositoryPath string,
+	definitions []workflow.TaskDefinition,
+) error {
+	runner := workflow.NewTaskRunner(dependencies)
+	_, executionError := runner.Run(
+		executionContext,
+		[]string{repositoryPath},
+		definitions,
+		workflow.RuntimeOptions{
+			AssumeYes:           true,
+			WorkflowParallelism: 1,
+		},
+	)
+	return executionError
+}
+
+func webAuditSyncTaskDefinition(syncStrategy string) (workflow.TaskDefinition, error) {
+	options := map[string]any{
+		"refresh": true,
+	}
+
+	switch strings.TrimSpace(syncStrategy) {
+	case "", web.AuditChangeSyncStrategyRequireClean:
+		options["require_clean"] = true
+	case web.AuditChangeSyncStrategyStashChanges:
+		options["stash"] = true
+	case web.AuditChangeSyncStrategyCommitChanges:
+		options["commit"] = true
+	default:
+		return workflow.TaskDefinition{}, fmt.Errorf(webAuditChangeSyncStrategyTemplateConstant, syncStrategy)
+	}
+
+	return workflow.TaskDefinition{
+		Name:  "audit-sync",
+		Steps: []workflow.TaskExecutionStep{workflow.TaskExecutionStepCustomActions},
+		Actions: []workflow.TaskActionDefinition{
+			{
+				Type:    "branch.change",
+				Options: options,
+			},
+		},
+	}, nil
+}
+
+func webAuditChangeMessage(kind web.AuditChangeKind) string {
+	switch kind {
+	case web.AuditChangeKindRenameFolder:
+		return "Rename folder applied"
+	case web.AuditChangeKindUpdateCanonical:
+		return "Canonical remote updated"
+	case web.AuditChangeKindConvertProtocol:
+		return "Remote protocol updated"
+	case web.AuditChangeKindSyncWithRemote:
+		return "Repository synchronized with remote"
+	case web.AuditChangeKindDeleteFolder:
+		return "Folder deleted"
+	default:
+		return ""
+	}
+}
+
+func normalizeWebAuditChangePath(rawPath string) (string, error) {
+	trimmedPath := strings.TrimSpace(rawPath)
+	if len(trimmedPath) == 0 {
+		return "", errors.New(webAuditChangePathRequiredConstant)
+	}
+	return filepath.Clean(trimmedPath), nil
+}
+
+func auditInspectionReportRow(inspection audit.RepositoryInspection) audit.AuditReportRow {
+	finalRepository := strings.TrimSpace(inspection.CanonicalOwnerRepo)
+	if len(finalRepository) == 0 {
+		finalRepository = inspection.OriginOwnerRepo
+	}
+
+	nameMatches := audit.TernaryValueNotApplicable
+	if inspection.IsGitRepository {
+		nameMatches = audit.TernaryValueNo
+		folderBaseName := filepath.Base(inspection.FolderName)
+		if len(inspection.DesiredFolderName) > 0 && inspection.DesiredFolderName == folderBaseName {
+			nameMatches = audit.TernaryValueYes
+		}
+	}
+
+	remoteDefaultBranch := inspection.RemoteDefaultBranch
+	localBranch := inspection.LocalBranch
+	inSync := inspection.InSyncStatus
+	originRemoteStatus := inspection.OriginRemoteStatus
+	remoteProtocol := inspection.RemoteProtocol
+	originMatches := inspection.OriginMatchesCanonical
+	worktreeDirty := audit.TernaryValueNo
+	dirtyFiles := ""
+
+	if !inspection.IsGitRepository {
+		finalRepository = string(audit.TernaryValueNotApplicable)
+		originRemoteStatus = audit.OriginRemoteStatusNotApplicable
+		remoteDefaultBranch = string(audit.TernaryValueNotApplicable)
+		localBranch = string(audit.TernaryValueNotApplicable)
+		inSync = audit.TernaryValueNotApplicable
+		remoteProtocol = audit.RemoteProtocolType(string(audit.TernaryValueNotApplicable))
+		originMatches = audit.TernaryValueNotApplicable
+		worktreeDirty = audit.TernaryValueNotApplicable
+	} else {
+		if originRemoteStatus == audit.OriginRemoteStatusMissing {
+			finalRepository = string(audit.TernaryValueNotApplicable)
+			remoteProtocol = audit.RemoteProtocolType(string(audit.TernaryValueNotApplicable))
+		}
+		if len(inspection.WorktreeDirtyFiles) > 0 {
+			worktreeDirty = audit.TernaryValueYes
+			dirtyFiles = strings.Join(inspection.WorktreeDirtyFiles, "; ")
+		}
+	}
+
+	return audit.AuditReportRow{
+		FolderName:             inspection.FolderName,
+		FinalRepository:        finalRepository,
+		OriginRemoteStatus:     originRemoteStatus,
+		NameMatches:            nameMatches,
+		RemoteDefaultBranch:    remoteDefaultBranch,
+		LocalBranch:            localBranch,
+		InSync:                 inSync,
+		RemoteProtocol:         remoteProtocol,
+		OriginMatchesCanonical: originMatches,
+		WorktreeDirty:          worktreeDirty,
+		DirtyFiles:             dirtyFiles,
+	}
+}
+
 func loadRepositoryBranches(executionContext context.Context, repository web.RepositoryDescriptor, gitExecutor execshellGitExecutor) web.BranchCatalog {
 	trimmedRepositoryPath := strings.TrimSpace(repository.Path)
 	if len(trimmedRepositoryPath) == 0 {
@@ -351,6 +709,37 @@ func (application *Application) webGitDependencies() (execshellGitExecutor, webG
 	}
 
 	return gitExecutor, repositoryManager, nil
+}
+
+func (application *Application) webTaskRunnerDependencies(outputWriter io.Writer, errorWriter io.Writer) (taskrunner.DependenciesResult, error) {
+	return taskrunner.BuildDependencies(
+		taskrunner.DependenciesConfig{
+			LoggerProvider: func() *zap.Logger {
+				return application.logger
+			},
+			HumanReadableLoggingProvider: application.humanReadableLoggingEnabled,
+		},
+		taskrunner.DependenciesOptions{
+			Output:          outputWriter,
+			Errors:          errorWriter,
+			DisablePrompter: true,
+		},
+	)
+}
+
+func (application *Application) webAuditDependencies() (shared.RepositoryDiscoverer, execshellGitExecutor, webGitRepositoryManager, webGitHubMetadataResolver, error) {
+	discoverer := reposdeps.ResolveRepositoryDiscoverer(nil)
+	gitExecutor, repositoryManager, dependencyError := application.webGitDependencies()
+	if dependencyError != nil {
+		return nil, nil, nil, nil, dependencyError
+	}
+
+	githubResolver, resolverError := reposdeps.ResolveGitHubResolver(nil, gitExecutor)
+	if resolverError != nil {
+		return nil, nil, nil, nil, resolverError
+	}
+
+	return discoverer, gitExecutor, repositoryManager, githubResolver, nil
 }
 
 func (application *Application) currentRepositoryRoot(executionContext context.Context, gitExecutor execshellGitExecutor, workingDirectory string) (string, bool) {

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -27,11 +26,17 @@ const (
 	browserReadyPollIntervalConstant       = 100 * time.Millisecond
 	repositoryTitleLoadingConstant         = "Loading..."
 
+	auditRootsInputSelectorConstant       = "#audit-roots-input"
+	auditIncludeAllSelectorConstant       = "#audit-include-all"
 	auditRunButtonSelectorConstant        = "#task-inspect-load"
 	auditResultsPanelSelectorConstant     = "#audit-results-panel"
 	auditResultsSummarySelectorConstant   = "#audit-results-summary"
 	auditResultsBodySelectorConstant      = "#audit-results-body"
-	runStatusSelectorConstant             = "#run-status"
+	auditQueuePanelSelectorConstant       = "#audit-queue-panel"
+	auditQueueSummarySelectorConstant     = "#audit-queue-summary"
+	auditQueueListSelectorConstant        = "#audit-queue-list"
+	auditQueueApplySelectorConstant       = "#audit-queue-apply"
+	auditQueueRenameSelectorConstant      = "[data-audit-action='rename_folder']"
 	branchTaskButtonSelectorConstant      = "#task-branch"
 	filesTaskButtonSelectorConstant       = "#task-files"
 	remotesTaskButtonSelectorConstant     = "#task-remotes"
@@ -76,7 +81,7 @@ const (
 	workflowVariableAssignmentConstant    = "license_year=2026"
 	workflowVariableFileConstant          = "./vars.yaml"
 	workflowWorkersValueConstant          = "3"
-	auditBrowserOutputConstant            = "folder_name,final_github_repo,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\nexample,canonical/example,no,main,feature/demo,n/a,https,no,no,\n"
+	auditCustomRootValueConstant          = "/tmp/browser-audit-root"
 )
 
 var browserExecutableCandidates = []string{
@@ -150,15 +155,30 @@ func TestWebInterfaceBrowserPrefillsBranchAndFileTasks(t *testing.T) {
 	})
 }
 
-func TestWebInterfaceBrowserRunsAuditAndDisplaysTable(t *testing.T) {
+func TestWebInterfaceBrowserInspectsAuditRootsAndDisplaysTable(t *testing.T) {
 	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
 
-	httpServer, repositoryCatalog := newBrowserTestServerWithExecutor(t, repositoryPath, func(_ context.Context, arguments []string, _ io.Reader, standardOutput io.Writer, _ io.Writer) error {
-		if len(arguments) == 0 || arguments[0] != "audit" {
-			return nil
+	httpServer, repositoryCatalog := newBrowserTestServerWithInspector(t, repositoryPath, func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+		return web.AuditInspectionResponse{
+			Roots: request.Roots,
+			Rows: []web.AuditInspectionRow{
+				{
+					Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+					FolderName:             "example",
+					IsGitRepository:        true,
+					FinalGitHubRepository:  "canonical/example",
+					OriginRemoteStatus:     "missing",
+					NameMatches:            "no",
+					RemoteDefaultBranch:    "",
+					LocalBranch:            "",
+					InSync:                 "n/a",
+					RemoteProtocol:         "n/a",
+					OriginMatchesCanonical: "n/a",
+					WorktreeDirty:          "no",
+					DirtyFiles:             "",
+				},
+			},
 		}
-		_, writeError := io.WriteString(standardOutput, auditBrowserOutputConstant)
-		return writeError
 	})
 	defer httpServer.Close()
 
@@ -172,24 +192,11 @@ func TestWebInterfaceBrowserRunsAuditAndDisplaysTable(t *testing.T) {
 	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
 
 	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		setCheckboxValue(auditIncludeAllSelectorConstant, true),
 		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
 		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
 	))
-
-	assertSelectedCommand(t, browserContext, auditCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"audit",
-		"--roots",
-		expectedRepository.Path,
-	})
-
-	require.Eventually(t, func() bool {
-		runStatus, runStatusError := readTextContent(browserContext, runStatusSelectorConstant)
-		if runStatusError != nil {
-			return false
-		}
-		return runStatus == "succeeded"
-	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 
 	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
 	require.NoError(t, auditSummaryError)
@@ -199,7 +206,103 @@ func TestWebInterfaceBrowserRunsAuditAndDisplaysTable(t *testing.T) {
 	require.NoError(t, auditResultsError)
 	require.Contains(t, auditResultsText, "example")
 	require.Contains(t, auditResultsText, "canonical/example")
-	require.Contains(t, auditResultsText, "feature/demo")
+	require.Contains(t, auditResultsText, "missing")
+	require.Contains(t, auditResultsText, auditCustomRootValueConstant)
+}
+
+func TestWebInterfaceBrowserQueuesRenameChangeAndAppliesIt(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	renameQueued := false
+	httpServer, repositoryCatalog := newBrowserTestServerWithAuditHandlers(
+		t,
+		repositoryPath,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			nameMatchStatus := "no"
+			if renameQueued {
+				nameMatchStatus = "yes"
+			}
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            nameMatchStatus,
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "main",
+						InSync:                 "yes",
+						RemoteProtocol:         "https",
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			if len(request.Changes) == 1 && request.Changes[0].Kind == "rename_folder" {
+				renameQueued = true
+			}
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "rename applied",
+					},
+				},
+			}
+		},
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueRenameSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditQueuePanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	queueSummary, queueSummaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+	require.NoError(t, queueSummaryError)
+	require.Equal(t, "1 pending change", queueSummary)
+
+	queueText, queueTextError := readTextContent(browserContext, auditQueueListSelectorConstant)
+	require.NoError(t, queueTextError)
+	require.Contains(t, queueText, "Rename folder")
+	require.Contains(t, queueText, "canonical/example")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		summaryText, summaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+		if summaryError != nil {
+			return false
+		}
+		return summaryText == "0 pending changes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, "yes")
 }
 
 func TestWebInterfaceBrowserPrefillsRemoteAndWorkflowTasksAcrossRepositoryScope(t *testing.T) {
@@ -310,10 +413,29 @@ func TestWebInterfaceBrowserAdvancedHidesTaskOwnedCommands(t *testing.T) {
 }
 
 func newBrowserTestServer(testingInstance *testing.T, workingDirectory string) (*httptest.Server, web.RepositoryCatalog) {
-	return newBrowserTestServerWithExecutor(testingInstance, workingDirectory, nil)
+	return newBrowserTestServerWithOptions(testingInstance, workingDirectory, nil, nil, nil)
 }
 
-func newBrowserTestServerWithExecutor(testingInstance *testing.T, workingDirectory string, execute web.CommandExecutor) (*httptest.Server, web.RepositoryCatalog) {
+func newBrowserTestServerWithInspector(testingInstance *testing.T, workingDirectory string, inspectAudit web.AuditInspector) (*httptest.Server, web.RepositoryCatalog) {
+	return newBrowserTestServerWithOptions(testingInstance, workingDirectory, nil, inspectAudit, nil)
+}
+
+func newBrowserTestServerWithAuditHandlers(
+	testingInstance *testing.T,
+	workingDirectory string,
+	inspectAudit web.AuditInspector,
+	applyAuditChanges web.AuditChangeExecutor,
+) (*httptest.Server, web.RepositoryCatalog) {
+	return newBrowserTestServerWithOptions(testingInstance, workingDirectory, nil, inspectAudit, applyAuditChanges)
+}
+
+func newBrowserTestServerWithOptions(
+	testingInstance *testing.T,
+	workingDirectory string,
+	execute web.CommandExecutor,
+	inspectAudit web.AuditInspector,
+	applyAuditChanges web.AuditChangeExecutor,
+) (*httptest.Server, web.RepositoryCatalog) {
 	testingInstance.Helper()
 
 	var httpServer *httptest.Server
@@ -326,13 +448,23 @@ func newBrowserTestServerWithExecutor(testingInstance *testing.T, workingDirecto
 		if commandExecutor == nil {
 			commandExecutor = application.newWebCommandExecutor()
 		}
+		auditInspector := inspectAudit
+		if auditInspector == nil {
+			auditInspector = application.newWebAuditInspector()
+		}
+		auditChangeExecutor := applyAuditChanges
+		if auditChangeExecutor == nil {
+			auditChangeExecutor = application.newWebAuditChangeExecutor()
+		}
 
 		server, serverError := web.NewServer(web.ServerOptions{
-			Address:      testServerAddressConstant,
-			Repositories: repositoryCatalog,
-			Catalog:      application.commandCatalog(),
-			LoadBranches: application.loadRepositoryBranches,
-			Execute:      commandExecutor,
+			Address:           testServerAddressConstant,
+			Repositories:      repositoryCatalog,
+			Catalog:           application.commandCatalog(),
+			LoadBranches:      application.loadRepositoryBranches,
+			Execute:           commandExecutor,
+			InspectAudit:      auditInspector,
+			ApplyAuditChanges: auditChangeExecutor,
 		})
 		require.NoError(testingInstance, serverError)
 

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -38,7 +38,11 @@ const (
 	auditQueueApplySelectorConstant       = "#audit-queue-apply"
 	auditQueueDeleteSelectorConstant      = "[data-audit-action='delete_folder']"
 	auditQueueDeleteConfirmSelector       = "[data-queue-confirm-delete]"
+	auditQueueProtocolSelectorConstant    = "[data-audit-action='convert_protocol']"
 	auditQueueRenameSelectorConstant      = "[data-audit-action='rename_folder']"
+	auditQueueSyncSelectorConstant        = "[data-audit-action='sync_with_remote']"
+	auditQueueTargetProtocolSelector      = "[data-queue-target-protocol]"
+	auditQueueSyncStrategySelector        = "[data-queue-sync-strategy]"
 	branchTaskButtonSelectorConstant      = "#task-branch"
 	filesTaskButtonSelectorConstant       = "#task-files"
 	remotesTaskButtonSelectorConstant     = "#task-remotes"
@@ -417,6 +421,133 @@ func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing
 	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
 	require.NoError(t, auditSummaryError)
 	require.Equal(t, "0 rows", auditSummary)
+}
+
+func TestWebInterfaceBrowserQueuesProtocolAndSyncChangesWithEditableOptions(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	protocolUpdated := false
+	syncUpdated := false
+	httpServer, repositoryCatalog := newBrowserTestServerWithAuditHandlers(
+		t,
+		repositoryPath,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			remoteProtocol := "https"
+			inSyncStatus := "no"
+			if protocolUpdated {
+				remoteProtocol = "ssh"
+			}
+			if syncUpdated {
+				inSyncStatus = "yes"
+			}
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            "yes",
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "feature/demo",
+						InSync:                 inSyncStatus,
+						RemoteProtocol:         remoteProtocol,
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			require.Len(t, request.Changes, 2)
+
+			for _, change := range request.Changes {
+				switch change.Kind {
+				case web.AuditChangeKindConvertProtocol:
+					require.Equal(t, "https", change.SourceProtocol)
+					require.Equal(t, "ssh", change.TargetProtocol)
+					protocolUpdated = true
+				case web.AuditChangeKindSyncWithRemote:
+					require.Equal(t, web.AuditChangeSyncStrategyStashChanges, change.SyncStrategy)
+					syncUpdated = true
+				default:
+					t.Fatalf("unexpected change kind %s", change.Kind)
+				}
+			}
+
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "change applied",
+					},
+					{
+						ID:      request.Changes[1].ID,
+						Kind:    request.Changes[1].Kind,
+						Path:    request.Changes[1].Path,
+						Status:  "succeeded",
+						Message: "change applied",
+					},
+				},
+			}
+		},
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueProtocolSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueSyncSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditQueuePanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditQueueTargetProtocolSelector, "ssh"),
+		setControlValue(auditQueueSyncStrategySelector, web.AuditChangeSyncStrategyStashChanges),
+	))
+
+	queueSummary, queueSummaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+	require.NoError(t, queueSummaryError)
+	require.Equal(t, "2 pending changes", queueSummary)
+
+	queueText, queueTextError := readTextContent(browserContext, auditQueueListSelectorConstant)
+	require.NoError(t, queueTextError)
+	require.Contains(t, queueText, "Fix protocol")
+	require.Contains(t, queueText, "Sync with remote")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		summaryText, summaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+		if summaryError != nil {
+			return false
+		}
+		return summaryText == "0 pending changes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, "ssh")
+	require.Contains(t, auditResultsText, "yes")
 }
 
 func TestWebInterfaceBrowserPrefillsRemoteAndWorkflowTasksAcrossRepositoryScope(t *testing.T) {

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -36,6 +36,8 @@ const (
 	auditQueueSummarySelectorConstant     = "#audit-queue-summary"
 	auditQueueListSelectorConstant        = "#audit-queue-list"
 	auditQueueApplySelectorConstant       = "#audit-queue-apply"
+	auditQueueDeleteSelectorConstant      = "[data-audit-action='delete_folder']"
+	auditQueueDeleteConfirmSelector       = "[data-queue-confirm-delete]"
 	auditQueueRenameSelectorConstant      = "[data-audit-action='rename_folder']"
 	branchTaskButtonSelectorConstant      = "#task-branch"
 	filesTaskButtonSelectorConstant       = "#task-files"
@@ -303,6 +305,118 @@ func TestWebInterfaceBrowserQueuesRenameChangeAndAppliesIt(t *testing.T) {
 	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
 	require.NoError(t, auditResultsError)
 	require.Contains(t, auditResultsText, "yes")
+}
+
+func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	deleteApplied := false
+	httpServer, repositoryCatalog := newBrowserTestServerWithAuditHandlers(
+		t,
+		repositoryPath,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			rows := []web.AuditInspectionRow{
+				{
+					Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+					FolderName:             "example",
+					IsGitRepository:        true,
+					FinalGitHubRepository:  "canonical/example",
+					OriginRemoteStatus:     "configured",
+					NameMatches:            "yes",
+					RemoteDefaultBranch:    "main",
+					LocalBranch:            "main",
+					InSync:                 "yes",
+					RemoteProtocol:         "https",
+					OriginMatchesCanonical: "yes",
+					WorktreeDirty:          "no",
+					DirtyFiles:             "",
+				},
+			}
+			if deleteApplied {
+				rows = nil
+			}
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows:  rows,
+			}
+		},
+		func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			require.Len(t, request.Changes, 1)
+			require.Equal(t, web.AuditChangeKindDeleteFolder, request.Changes[0].Kind)
+			require.True(t, request.Changes[0].ConfirmDelete)
+			deleteApplied = true
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "delete applied",
+					},
+				},
+			}
+		},
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueDeleteSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditQueuePanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	queueSummary, queueSummaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+	require.NoError(t, queueSummaryError)
+	require.Equal(t, "1 pending change", queueSummary)
+
+	queueText, queueTextError := readTextContent(browserContext, auditQueueListSelectorConstant)
+	require.NoError(t, queueTextError)
+	require.Contains(t, queueText, "Delete folder")
+	require.Contains(t, queueText, auditCustomRootValueConstant)
+
+	applyDisabled, applyDisabledError := readDisabledState(browserContext, auditQueueApplySelectorConstant)
+	require.NoError(t, applyDisabledError)
+	require.True(t, applyDisabled)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setCheckboxValue(auditQueueDeleteConfirmSelector, true),
+	))
+
+	require.Eventually(t, func() bool {
+		disabled, disabledError := readDisabledState(browserContext, auditQueueApplySelectorConstant)
+		if disabledError != nil {
+			return false
+		}
+		return !disabled
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		summaryText, summaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+		if summaryError != nil {
+			return false
+		}
+		return summaryText == "0 pending changes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
+	require.NoError(t, auditSummaryError)
+	require.Equal(t, "0 rows", auditSummary)
 }
 
 func TestWebInterfaceBrowserPrefillsRemoteAndWorkflowTasksAcrossRepositoryScope(t *testing.T) {
@@ -623,6 +737,16 @@ func readValue(browserContext context.Context, selector string) (string, error) 
 	var controlValue string
 	actionError := chromedp.Run(browserContext, chromedp.Value(selector, &controlValue, chromedp.ByQuery))
 	return controlValue, actionError
+}
+
+func readDisabledState(browserContext context.Context, selector string) (bool, error) {
+	var disabled bool
+	script := fmt.Sprintf(`(() => {
+		const element = document.querySelector(%q);
+		return element ? Boolean(element.disabled) : false;
+	})()`, selector)
+	actionError := chromedp.Run(browserContext, chromedp.Evaluate(script, &disabled))
+	return disabled, actionError
 }
 
 func setControlValue(selector string, value string) chromedp.Action {

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -311,6 +311,116 @@ func TestWebInterfaceBrowserQueuesRenameChangeAndAppliesIt(t *testing.T) {
 	require.Contains(t, auditResultsText, "yes")
 }
 
+func TestWebInterfaceBrowserAppliesQueueUsingLastInspectedScope(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	renameQueued := false
+	alternateRoot := "/tmp/browser-audit-root-alternate"
+	httpServer, repositoryCatalog := newBrowserTestServerWithAuditHandlers(
+		t,
+		repositoryPath,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			if len(request.Roots) == 1 && request.Roots[0] == alternateRoot {
+				return web.AuditInspectionResponse{
+					Roots: request.Roots,
+					Rows: []web.AuditInspectionRow{
+						{
+							Path:                   filepath.Join(alternateRoot, "other"),
+							FolderName:             "other",
+							IsGitRepository:        true,
+							FinalGitHubRepository:  "canonical/other",
+							OriginRemoteStatus:     "configured",
+							NameMatches:            "no",
+							RemoteDefaultBranch:    "main",
+							LocalBranch:            "main",
+							InSync:                 "yes",
+							RemoteProtocol:         "https",
+							OriginMatchesCanonical: "yes",
+							WorktreeDirty:          "no",
+							DirtyFiles:             "",
+						},
+					},
+				}
+			}
+
+			nameMatchStatus := "no"
+			if renameQueued {
+				nameMatchStatus = "yes"
+			}
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            nameMatchStatus,
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "main",
+						InSync:                 "yes",
+						RemoteProtocol:         "https",
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			require.Len(t, request.Changes, 1)
+			require.Equal(t, web.AuditChangeKindRenameFolder, request.Changes[0].Kind)
+			renameQueued = true
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "rename applied",
+					},
+				},
+			}
+		},
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueRenameSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditQueuePanelSelectorConstant, chromedp.ByQuery),
+		setControlValue(auditRootsInputSelectorConstant, alternateRoot),
+		chromedp.Click(auditQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		summaryText, summaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+		if summaryError != nil {
+			return false
+		}
+		return summaryText == "0 pending changes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, auditCustomRootValueConstant)
+	require.Contains(t, auditResultsText, "yes")
+	require.NotContains(t, auditResultsText, alternateRoot)
+}
+
 func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing.T) {
 	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
 

--- a/cmd/cli/application_web_test.go
+++ b/cmd/cli/application_web_test.go
@@ -269,6 +269,41 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 			}
 		},
 		Execute: application.newWebCommandExecutor(),
+		InspectAudit: func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   "/tmp/custom/example",
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            "yes",
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "main",
+						InSync:                 "yes",
+						RemoteProtocol:         "https",
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		ApplyAuditChanges: func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "queued change applied",
+					},
+				},
+			}
+		},
 	})
 	require.NoError(t, serverError)
 
@@ -290,8 +325,11 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 	require.Contains(t, indexDocument.String(), "<h3>Paths</h3>")
 	require.Contains(t, indexDocument.String(), "<h3>Tasks</h3>")
 	require.Contains(t, indexDocument.String(), "id=\"target-ref-select\"")
-	require.Contains(t, indexDocument.String(), "Run audit command")
+	require.Contains(t, indexDocument.String(), "id=\"audit-roots-input\"")
+	require.Contains(t, indexDocument.String(), "Inspect audit table")
 	require.Contains(t, indexDocument.String(), "id=\"audit-results-panel\"")
+	require.Contains(t, indexDocument.String(), "id=\"audit-queue-panel\"")
+	require.Contains(t, indexDocument.String(), "Pending Changes")
 	require.Contains(t, indexDocument.String(), "Run remote normalization command")
 	require.Contains(t, indexDocument.String(), "Run workflow command")
 
@@ -329,6 +367,31 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 	require.Len(t, branches.Branches, 2)
 	require.Equal(t, "feature/demo", branches.Branches[0].Name)
 	require.True(t, branches.Branches[0].Current)
+
+	auditBody := strings.NewReader(`{"roots":["/tmp/custom"],"include_all":true}`)
+	auditResponse, auditError := http.Post(httpServer.URL+"/api/audit/inspect", "application/json", auditBody)
+	require.NoError(t, auditError)
+	defer auditResponse.Body.Close()
+	require.Equal(t, http.StatusOK, auditResponse.StatusCode)
+
+	var auditInspection web.AuditInspectionResponse
+	require.NoError(t, json.NewDecoder(auditResponse.Body).Decode(&auditInspection))
+	require.Equal(t, []string{"/tmp/custom"}, auditInspection.Roots)
+	require.Len(t, auditInspection.Rows, 1)
+	require.Equal(t, "/tmp/custom/example", auditInspection.Rows[0].Path)
+	require.Equal(t, "configured", auditInspection.Rows[0].OriginRemoteStatus)
+
+	applyBody := strings.NewReader(`{"changes":[{"id":"chg-001","kind":"rename_folder","path":"/tmp/custom/example","require_clean":true}]}`)
+	applyResponse, applyError := http.Post(httpServer.URL+"/api/audit/apply", "application/json", applyBody)
+	require.NoError(t, applyError)
+	defer applyResponse.Body.Close()
+	require.Equal(t, http.StatusOK, applyResponse.StatusCode)
+
+	var applyInspection web.AuditChangeApplyResponse
+	require.NoError(t, json.NewDecoder(applyResponse.Body).Decode(&applyInspection))
+	require.Len(t, applyInspection.Results, 1)
+	require.Equal(t, "chg-001", applyInspection.Results[0].ID)
+	require.Equal(t, "succeeded", applyInspection.Results[0].Status)
 
 	runBody := strings.NewReader(`{"arguments":["version"]}`)
 	runResponse, runError := http.Post(httpServer.URL+"/api/runs", "application/json", runBody)

--- a/cmd/cli/application_web_test.go
+++ b/cmd/cli/application_web_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,7 +16,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tyemirov/gix/internal/repos/shared"
 	"github.com/tyemirov/gix/internal/web"
+	"github.com/tyemirov/gix/internal/workflow"
 )
 
 func TestExecuteWithOptionsVersionFlagWritesToProvidedOutput(t *testing.T) {
@@ -424,6 +427,41 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 	require.Contains(t, finalRun.StandardOutput, "gix version: v4.5.6")
 	require.Empty(t, finalRun.StandardError)
 	require.Empty(t, finalRun.Error)
+}
+
+func TestWebAuditChangeExecutorRejectsRelativePaths(t *testing.T) {
+	application := NewApplication()
+	response := application.newWebAuditChangeExecutor()(context.Background(), web.AuditChangeApplyRequest{
+		Changes: []web.AuditQueuedChange{
+			{
+				ID:            "chg-001",
+				Kind:          web.AuditChangeKindDeleteFolder,
+				Path:          "../sibling",
+				ConfirmDelete: true,
+			},
+		},
+	})
+
+	require.Empty(t, response.Error)
+	require.Len(t, response.Results, 1)
+	require.Equal(t, "failed", response.Results[0].Status)
+	require.Contains(t, response.Results[0].Error, "absolute")
+}
+
+func TestWebAuditChangeResultStatusMarksSkippedOutcomes(t *testing.T) {
+	outcome := workflow.ExecutionOutcome{
+		ReporterSummaryData: shared.SummaryData{
+			StepOutcomeCounts: map[string]map[string]int{
+				"audit-sync": {
+					"skipped": 1,
+				},
+			},
+		},
+	}
+
+	require.Equal(t, webAuditChangeStatusSkippedConstant, webAuditChangeResultStatus(outcome, nil))
+	require.Equal(t, webAuditChangeStatusSucceededConstant, webAuditChangeResultStatus(workflow.ExecutionOutcome{}, nil))
+	require.Equal(t, webAuditChangeStatusFailedConstant, webAuditChangeResultStatus(workflow.ExecutionOutcome{}, errors.New("boom")))
 }
 
 func catalogContainsCommand(catalog web.CommandCatalog, commandPath string) bool {

--- a/internal/audit/constants.go
+++ b/internal/audit/constants.go
@@ -14,6 +14,7 @@ const (
 	debugCheckingTemplate                       = "DEBUG: checking %s\n"
 	csvHeaderFinalRepository                    = "final_github_repo"
 	csvHeaderFolderName                         = "folder_name"
+	csvHeaderOriginRemoteStatus                 = "origin_remote_status"
 	csvHeaderNameMatches                        = "name_matches"
 	csvHeaderRemoteDefault                      = "remote_default_branch"
 	csvHeaderLocalBranch                        = "local_branch"

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -135,6 +135,7 @@ func (service *Service) writeAuditReport(inspections []RepositoryInspection) err
 	header := []string{
 		csvHeaderFolderName,
 		csvHeaderFinalRepository,
+		csvHeaderOriginRemoteStatus,
 		csvHeaderNameMatches,
 		csvHeaderRemoteDefault,
 		csvHeaderLocalBranch,
@@ -238,6 +239,7 @@ func (service *Service) inspectRepository(executionContext context.Context, repo
 			CanonicalOwnerRepo:     "",
 			FinalOwnerRepo:         "",
 			DesiredFolderName:      folderName,
+			OriginRemoteStatus:     OriginRemoteStatusMissing,
 			RemoteProtocol:         RemoteProtocolOther,
 			RemoteDefaultBranch:    "",
 			LocalBranch:            localBranch,
@@ -297,6 +299,7 @@ func (service *Service) inspectRepository(executionContext context.Context, repo
 		CanonicalOwnerRepo:     canonicalOwnerRepo,
 		FinalOwnerRepo:         finalOwnerRepo,
 		DesiredFolderName:      finalRepositoryName(finalOwnerRepo),
+		OriginRemoteStatus:     OriginRemoteStatusConfigured,
 		RemoteProtocol:         remoteProtocol,
 		RemoteDefaultBranch:    remoteDefaultBranch,
 		LocalBranch:            localBranch,
@@ -336,12 +339,14 @@ func inspectionReportRow(inspection RepositoryInspection) AuditReportRow {
 	localBranch := inspection.LocalBranch
 	inSync := inspection.InSyncStatus
 	remoteProtocol := inspection.RemoteProtocol
+	originRemoteStatus := inspection.OriginRemoteStatus
 	originMatches := inspection.OriginMatchesCanonical
 	var worktreeDirty TernaryValue
 	dirtyFilesValue := ""
 
 	if !inspection.IsGitRepository {
 		finalRepo = string(TernaryValueNotApplicable)
+		originRemoteStatus = OriginRemoteStatusNotApplicable
 		remoteDefaultBranch = string(TernaryValueNotApplicable)
 		localBranch = string(TernaryValueNotApplicable)
 		inSync = TernaryValueNotApplicable
@@ -349,6 +354,10 @@ func inspectionReportRow(inspection RepositoryInspection) AuditReportRow {
 		originMatches = TernaryValueNotApplicable
 		worktreeDirty = TernaryValueNotApplicable
 	} else {
+		if originRemoteStatus == OriginRemoteStatusMissing {
+			finalRepo = string(TernaryValueNotApplicable)
+			remoteProtocol = RemoteProtocolType(string(TernaryValueNotApplicable))
+		}
 		if len(inspection.WorktreeDirtyFiles) > 0 {
 			worktreeDirty = TernaryValueYes
 			dirtyFilesValue = strings.Join(inspection.WorktreeDirtyFiles, "; ")
@@ -359,6 +368,7 @@ func inspectionReportRow(inspection RepositoryInspection) AuditReportRow {
 	return AuditReportRow{
 		FolderName:             inspection.FolderName,
 		FinalRepository:        finalRepo,
+		OriginRemoteStatus:     originRemoteStatus,
 		NameMatches:            nameMatches,
 		RemoteDefaultBranch:    remoteDefaultBranch,
 		LocalBranch:            localBranch,
@@ -463,6 +473,7 @@ func buildNonRepositoryInspection(path string, folderName string) RepositoryInsp
 	return RepositoryInspection{
 		Path:                   filepath.Clean(path),
 		FolderName:             folderName,
+		OriginRemoteStatus:     OriginRemoteStatusNotApplicable,
 		RemoteDefaultBranch:    placeholder,
 		LocalBranch:            placeholder,
 		InSyncStatus:           TernaryValueNotApplicable,

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	currentDirectoryRelativePathConstant = "."
-	auditServiceCSVHeader                = "folder_name,final_github_repo,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
+	auditServiceCSVHeader                = "folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
 )
 
 type stubDiscoverer struct {
@@ -151,7 +151,7 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 					DefaultBranch: "main",
 				},
 			},
-			expectedOutput: auditServiceCSVHeader + "example,canonical/example,yes,main,main,n/a,https,no,no,\n",
+			expectedOutput: auditServiceCSVHeader + "example,canonical/example,configured,yes,main,main,n/a,https,no,no,\n",
 			expectedError:  "",
 		},
 		{
@@ -179,7 +179,7 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 					DefaultBranch: "main",
 				},
 			},
-			expectedOutput: auditServiceCSVHeader + "example,canonical/example,yes,main,main,n/a,https,no,yes,M main.go; ?? README.md\n",
+			expectedOutput: auditServiceCSVHeader + "example,canonical/example,configured,yes,main,main,n/a,https,no,yes,M main.go; ?? README.md\n",
 			expectedError:  "",
 		},
 		{
@@ -204,7 +204,7 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 					DefaultBranch: "main",
 				},
 			},
-			expectedOutput:       auditServiceCSVHeader + "example,canonical/example,yes,main,,n/a,https,no,no,\n",
+			expectedOutput:       auditServiceCSVHeader + "example,canonical/example,configured,yes,main,,n/a,https,no,no,\n",
 			expectedError:        "",
 			panicOnUnexpectedGit: true,
 		},
@@ -230,7 +230,7 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 					DefaultBranch: "main",
 				},
 			},
-			expectedOutput: auditServiceCSVHeader + "example,canonical/example,yes,main,main,n/a,https,no,no,\n",
+			expectedOutput: auditServiceCSVHeader + "example,canonical/example,configured,yes,main,main,n/a,https,no,no,\n",
 			expectedError:  "DEBUG: discovered 1 candidate repos under: /tmp/example\nDEBUG: checking /tmp/example\n",
 		},
 		{
@@ -249,7 +249,26 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 				branchName:    "main",
 				remoteURL:     "https://github.com/origin/example.git",
 			},
-			expectedOutput: auditServiceCSVHeader + "example,origin/example,yes,main,,n/a,https,n/a,no,\n",
+			expectedOutput: auditServiceCSVHeader + "example,origin/example,configured,yes,main,,n/a,https,n/a,no,\n",
+			expectedError:  "",
+		},
+		{
+			name: "missing_origin_remote_reports_missing_status",
+			options: audit.CommandOptions{
+				Roots:           []string{"/tmp/example"},
+				InspectionDepth: audit.InspectionDepthMinimal,
+			},
+			discoverer: stubDiscoverer{repositories: []string{"/tmp/example"}},
+			executorOutputs: map[string]execshell.ExecutionResult{
+				"rev-parse --is-inside-work-tree": {StandardOutput: "true"},
+			},
+			gitManager: stubGitManager{
+				cleanWorktree:       true,
+				branchName:          "main",
+				remoteURL:           "",
+				panicOnBranchLookup: true,
+			},
+			expectedOutput: auditServiceCSVHeader + "example,n/a,missing,yes,,,n/a,n/a,n/a,no,\n",
 			expectedError:  "",
 		},
 		{
@@ -274,7 +293,7 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 					DefaultBranch: "main",
 				},
 			},
-			expectedOutput: auditServiceCSVHeader + "example,canonical/example,yes,main,,n/a,https,no,no,\n",
+			expectedOutput: auditServiceCSVHeader + "example,canonical/example,configured,yes,main,,n/a,https,no,no,\n",
 			expectedError:  "",
 		},
 	}
@@ -352,7 +371,7 @@ func TestServiceRunNormalizesRepositoryPaths(testInstance *testing.T) {
 	}
 
 	expectedCSVOutput := fmt.Sprintf(
-		auditServiceCSVHeader+"%s,canonical/example,%s,main,,n/a,https,no,no,\n",
+		auditServiceCSVHeader+"%s,canonical/example,configured,%s,main,,n/a,https,no,no,\n",
 		repositoryFolderName,
 		expectedNameMatches,
 	)
@@ -411,8 +430,8 @@ func TestServiceRunIncludesAllFolders(testInstance *testing.T) {
 
 	expectedOutput := fmt.Sprintf(
 		auditServiceCSVHeader+
-			"%s,canonical/example,no,main,,n/a,https,no,no,\n"+
-			"%s,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,\n",
+			"%s,canonical/example,configured,no,main,,n/a,https,no,no,\n"+
+			"%s,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,\n",
 		gitRepositoryFolderName,
 		nonRepositoryFolderName,
 	)
@@ -457,7 +476,7 @@ func TestServiceRunUsesRelativeFolderNames(testInstance *testing.T) {
 	require.NoError(testInstance, runError)
 
 	expectedOutput := fmt.Sprintf(
-		auditServiceCSVHeader+"%s,canonical/git-project,yes,main,,n/a,https,no,no,\n",
+		auditServiceCSVHeader+"%s,canonical/git-project,configured,yes,main,,n/a,https,no,no,\n",
 		filepath.ToSlash(relativeFolderPath),
 	)
 	require.Equal(testInstance, expectedOutput, outputBuffer.String())

--- a/internal/audit/types.go
+++ b/internal/audit/types.go
@@ -13,6 +13,16 @@ const (
 	RemoteProtocolOther RemoteProtocolType = shared.RemoteProtocolOther
 )
 
+// OriginRemoteStatus describes whether the origin remote is configured.
+type OriginRemoteStatus string
+
+// Supported origin-remote status values.
+const (
+	OriginRemoteStatusConfigured    OriginRemoteStatus = "configured"
+	OriginRemoteStatusMissing       OriginRemoteStatus = "missing"
+	OriginRemoteStatusNotApplicable OriginRemoteStatus = "n/a"
+)
+
 // TernaryValue represents yes/no/not-applicable values used in reports.
 type TernaryValue string
 
@@ -49,6 +59,7 @@ type RepositoryInspection struct {
 	CanonicalOwnerRepo     string
 	FinalOwnerRepo         string
 	DesiredFolderName      string
+	OriginRemoteStatus     OriginRemoteStatus
 	RemoteProtocol         RemoteProtocolType
 	RemoteDefaultBranch    string
 	LocalBranch            string
@@ -62,6 +73,7 @@ type RepositoryInspection struct {
 type AuditReportRow struct {
 	FolderName             string
 	FinalRepository        string
+	OriginRemoteStatus     OriginRemoteStatus
 	NameMatches            TernaryValue
 	RemoteDefaultBranch    string
 	LocalBranch            string
@@ -77,6 +89,7 @@ func (row AuditReportRow) CSVRecord() []string {
 	return []string{
 		row.FolderName,
 		row.FinalRepository,
+		string(row.OriginRemoteStatus),
 		string(row.NameMatches),
 		row.RemoteDefaultBranch,
 		row.LocalBranch,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -21,6 +21,8 @@ const (
 	apiRepositoryBranchesRouteConstant  = "/api/repos/:id/branches"
 	apiBranchesRoutePathConstant        = "/api/branches"
 	apiCommandsRoutePathConstant        = "/api/commands"
+	apiAuditInspectRoutePathConstant    = "/api/audit/inspect"
+	apiAuditApplyRoutePathConstant      = "/api/audit/apply"
 	apiRunsRoutePathConstant            = "/api/runs"
 	apiRunRoutePathTemplateConstant     = "/api/runs/:id"
 	indexDocumentFilePathConstant       = "ui/index.html"
@@ -29,6 +31,8 @@ const (
 	missingServerAddressErrorConstant   = "missing server address"
 	missingCommandExecutorErrorConstant = "missing command executor"
 	missingBranchLoaderErrorConstant    = "missing branch loader"
+	missingAuditInspectorErrorConstant  = "missing audit inspector"
+	missingAuditChangeExecutorConstant  = "missing audit change executor"
 	missingRepositoryIDErrorConstant    = "missing repository identifier"
 	repositoryNotFoundTemplateConstant  = "repository %q was not found"
 )
@@ -42,6 +46,8 @@ type serverRuntimeOptions struct {
 	catalog      CommandCatalog
 	loadBranches BranchCatalogLoader
 	execute      CommandExecutor
+	inspectAudit AuditInspector
+	applyAudit   AuditChangeExecutor
 }
 
 // Server hosts the embedded gix browser interface and JSON API.
@@ -158,6 +164,12 @@ func newServerRuntimeOptions(options ServerOptions) (serverRuntimeOptions, error
 	if options.LoadBranches == nil {
 		return serverRuntimeOptions{}, errors.New(missingBranchLoaderErrorConstant)
 	}
+	if options.InspectAudit == nil {
+		return serverRuntimeOptions{}, errors.New(missingAuditInspectorErrorConstant)
+	}
+	if options.ApplyAuditChanges == nil {
+		return serverRuntimeOptions{}, errors.New(missingAuditChangeExecutorConstant)
+	}
 
 	return serverRuntimeOptions{
 		address:      trimmedAddress,
@@ -165,6 +177,8 @@ func newServerRuntimeOptions(options ServerOptions) (serverRuntimeOptions, error
 		catalog:      options.Catalog,
 		loadBranches: options.LoadBranches,
 		execute:      options.Execute,
+		inspectAudit: options.InspectAudit,
+		applyAudit:   options.ApplyAuditChanges,
 	}, nil
 }
 
@@ -189,6 +203,8 @@ func (server *Server) registerRoutes(assetsFileSystem http.FileSystem) {
 	server.engine.GET(apiRepositoryBranchesRouteConstant, server.handleRepositoryBranches)
 	server.engine.GET(apiBranchesRoutePathConstant, server.handleBranches)
 	server.engine.GET(apiCommandsRoutePathConstant, server.handleCommands)
+	server.engine.POST(apiAuditInspectRoutePathConstant, server.handleInspectAudit)
+	server.engine.POST(apiAuditApplyRoutePathConstant, server.handleApplyAuditChanges)
 	server.engine.POST(apiRunsRoutePathConstant, server.handleCreateRun)
 	server.engine.GET(apiRunRoutePathTemplateConstant, server.handleGetRun)
 }
@@ -232,6 +248,26 @@ func (server *Server) handleBranches(requestContext *gin.Context) {
 
 func (server *Server) handleCommands(requestContext *gin.Context) {
 	requestContext.JSON(http.StatusOK, server.options.catalog)
+}
+
+func (server *Server) handleInspectAudit(requestContext *gin.Context) {
+	var request AuditInspectionRequest
+	if bindError := requestContext.ShouldBindJSON(&request); bindError != nil {
+		requestContext.JSON(http.StatusBadRequest, errorResponse{Error: bindError.Error()})
+		return
+	}
+
+	requestContext.JSON(http.StatusOK, server.options.inspectAudit(requestContext.Request.Context(), request))
+}
+
+func (server *Server) handleApplyAuditChanges(requestContext *gin.Context) {
+	var request AuditChangeApplyRequest
+	if bindError := requestContext.ShouldBindJSON(&request); bindError != nil {
+		requestContext.JSON(http.StatusBadRequest, errorResponse{Error: bindError.Error()})
+		return
+	}
+
+	requestContext.JSON(http.StatusOK, server.options.applyAudit(requestContext.Request.Context(), request))
 }
 
 func (server *Server) selectedRepository() *RepositoryDescriptor {

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -11,13 +11,21 @@ type CommandExecutor func(context.Context, []string, io.Reader, io.Writer, io.Wr
 // BranchCatalogLoader resolves branch metadata for one repository descriptor.
 type BranchCatalogLoader func(context.Context, RepositoryDescriptor) BranchCatalog
 
+// AuditInspector resolves typed audit rows for explicit roots.
+type AuditInspector func(context.Context, AuditInspectionRequest) AuditInspectionResponse
+
+// AuditChangeExecutor applies queued audit changes.
+type AuditChangeExecutor func(context.Context, AuditChangeApplyRequest) AuditChangeApplyResponse
+
 // ServerOptions configures the local web server.
 type ServerOptions struct {
-	Address      string
-	Repositories RepositoryCatalog
-	Catalog      CommandCatalog
-	LoadBranches BranchCatalogLoader
-	Execute      CommandExecutor
+	Address           string
+	Repositories      RepositoryCatalog
+	Catalog           CommandCatalog
+	LoadBranches      BranchCatalogLoader
+	Execute           CommandExecutor
+	InspectAudit      AuditInspector
+	ApplyAuditChanges AuditChangeExecutor
 }
 
 // RepositoryCatalog describes the repositories visible to the web interface at launch time.
@@ -106,4 +114,84 @@ type FlagDescriptor struct {
 	Default      string `json:"default,omitempty"`
 	NoOptDefault string `json:"no_opt_default,omitempty"`
 	Required     bool   `json:"required"`
+}
+
+// AuditInspectionRequest captures web-driven audit inputs.
+type AuditInspectionRequest struct {
+	Roots      []string `json:"roots"`
+	IncludeAll bool     `json:"include_all"`
+}
+
+// AuditInspectionResponse returns typed audit rows to the browser.
+type AuditInspectionResponse struct {
+	Roots []string             `json:"roots,omitempty"`
+	Rows  []AuditInspectionRow `json:"rows,omitempty"`
+	Error string               `json:"error,omitempty"`
+}
+
+// AuditInspectionRow captures one typed audit result row.
+type AuditInspectionRow struct {
+	Path                   string `json:"path"`
+	FolderName             string `json:"folder_name"`
+	IsGitRepository        bool   `json:"is_git_repository"`
+	FinalGitHubRepository  string `json:"final_github_repo"`
+	OriginRemoteStatus     string `json:"origin_remote_status"`
+	NameMatches            string `json:"name_matches"`
+	RemoteDefaultBranch    string `json:"remote_default_branch"`
+	LocalBranch            string `json:"local_branch"`
+	InSync                 string `json:"in_sync"`
+	RemoteProtocol         string `json:"remote_protocol"`
+	OriginMatchesCanonical string `json:"origin_matches_canonical"`
+	WorktreeDirty          string `json:"worktree_dirty"`
+	DirtyFiles             string `json:"dirty_files"`
+}
+
+// AuditChangeKind identifies one queued audit remediation.
+type AuditChangeKind string
+
+const (
+	AuditChangeKindRenameFolder          AuditChangeKind = "rename_folder"
+	AuditChangeKindUpdateCanonical       AuditChangeKind = "update_remote_canonical"
+	AuditChangeKindConvertProtocol       AuditChangeKind = "convert_protocol"
+	AuditChangeKindSyncWithRemote        AuditChangeKind = "sync_with_remote"
+	AuditChangeKindDeleteFolder          AuditChangeKind = "delete_folder"
+	AuditChangeSyncStrategyRequireClean  string          = "require_clean"
+	AuditChangeSyncStrategyStashChanges  string          = "stash_changes"
+	AuditChangeSyncStrategyCommitChanges string          = "commit_changes"
+)
+
+// AuditQueuedChange captures one queued audit remediation from the browser.
+type AuditQueuedChange struct {
+	ID             string          `json:"id"`
+	Kind           AuditChangeKind `json:"kind"`
+	Path           string          `json:"path"`
+	IncludeOwner   bool            `json:"include_owner,omitempty"`
+	RequireClean   bool            `json:"require_clean,omitempty"`
+	SourceProtocol string          `json:"source_protocol,omitempty"`
+	TargetProtocol string          `json:"target_protocol,omitempty"`
+	SyncStrategy   string          `json:"sync_strategy,omitempty"`
+	ConfirmDelete  bool            `json:"confirm_delete,omitempty"`
+}
+
+// AuditChangeApplyRequest captures one queued apply request.
+type AuditChangeApplyRequest struct {
+	Changes []AuditQueuedChange `json:"changes"`
+}
+
+// AuditChangeApplyResult reports the result of one queued change.
+type AuditChangeApplyResult struct {
+	ID      string          `json:"id"`
+	Kind    AuditChangeKind `json:"kind"`
+	Path    string          `json:"path"`
+	Status  string          `json:"status"`
+	Message string          `json:"message,omitempty"`
+	Stdout  string          `json:"stdout,omitempty"`
+	Stderr  string          `json:"stderr,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+// AuditChangeApplyResponse returns per-change execution results.
+type AuditChangeApplyResponse struct {
+	Results []AuditChangeApplyResult `json:"results,omitempty"`
+	Error   string                   `json:"error,omitempty"`
 }

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -104,6 +104,13 @@
 /**
  * @typedef {{
  *   roots?: string[],
+ *   include_all?: boolean,
+ * }} AuditInspectionRequest
+ */
+
+/**
+ * @typedef {{
+ *   roots?: string[],
  *   rows?: AuditInspectionRow[],
  *   error?: string,
  * }} AuditInspectionResponse
@@ -239,6 +246,7 @@ const auditSyncStrategyRequireCleanValue = "require_clean";
 const auditSyncStrategyStashChangesValue = "stash_changes";
 const auditSyncStrategyCommitChangesValue = "commit_changes";
 const auditChangeStatusSucceededValue = "succeeded";
+const auditChangeStatusSkippedValue = "skipped";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
   "folder_name",
@@ -847,14 +855,27 @@ async function runAuditTask() {
  * @param {boolean} clearOutput
  */
 async function inspectAuditRoots(clearOutput) {
-  const auditRoots = resolveAuditRoots();
-  if (auditRoots.length === 0) {
+  const inspectionRequest = {
+    roots: resolveAuditRoots(),
+    include_all: Boolean(elements.auditIncludeAll.checked),
+  };
+  if ((inspectionRequest.roots || []).length === 0) {
     hideAuditResults();
     clearPolling();
     renderRunError("Enter at least one audit root or choose a repository scope to inspect.");
     setStatus("failed");
     return;
   }
+
+  await inspectAuditRequest(inspectionRequest, clearOutput);
+}
+
+/**
+ * @param {AuditInspectionRequest} inspectionRequest
+ * @param {boolean} clearOutput
+ */
+async function inspectAuditRequest(inspectionRequest, clearOutput) {
+  const auditRoots = (inspectionRequest.roots || []).slice();
 
   clearPolling();
   hideAuditResults();
@@ -872,7 +893,7 @@ async function inspectAuditRoots(clearOutput) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         roots: auditRoots,
-        include_all: Boolean(elements.auditIncludeAll.checked),
+        include_all: Boolean(inspectionRequest.include_all),
       }),
     });
     if (!response.ok) {
@@ -886,6 +907,8 @@ async function inspectAuditRoots(clearOutput) {
       throw new Error(inspection.error);
     }
 
+    state.auditInspectionRoots = auditRoots;
+    state.auditInspectionIncludeAll = Boolean(inspectionRequest.include_all);
     renderTypedAuditResults(inspection);
     setStatus("succeeded");
   } catch (error) {
@@ -2203,9 +2226,7 @@ function renderRunAuditResults(snapshot) {
  * @param {AuditInspectionResponse} inspection
  */
 function renderTypedAuditResults(inspection) {
-  state.auditInspectionRoots = (inspection.roots || []).slice();
   state.auditInspectionRows = (inspection.rows || []).slice();
-  state.auditInspectionIncludeAll = Boolean(elements.auditIncludeAll.checked);
   state.auditQueueVisible = true;
 
   renderTypedAuditTable(state.auditInspectionRows);
@@ -2772,12 +2793,18 @@ async function applyAuditQueue() {
     state.auditQueue = state.auditQueue.filter((change) => !succeededIDs.has(change.id));
 
     if (state.auditInspectionRoots.length > 0) {
-      await inspectAuditRoots(false);
+      await inspectAuditRequest(
+        {
+          roots: state.auditInspectionRoots.slice(),
+          include_all: state.auditInspectionIncludeAll,
+        },
+        false,
+      );
     }
 
     const failedResults = results.filter((result) => result.status !== auditChangeStatusSucceededValue);
     if (failedResults.length > 0) {
-      renderRunError(failedResults.map((result) => result.error || `${result.kind} failed for ${result.path}`).join("\n"));
+      renderRunError(failedResults.map(formatAuditApplyIssue).join("\n"));
       setStatus("failed");
     } else {
       setStatus("succeeded");
@@ -2830,6 +2857,20 @@ function renderAuditApplyResults(results) {
 
   elements.stdoutOutput.textContent = stdoutSections.join("\n\n");
   elements.stderrOutput.textContent = stderrSections.join("\n\n");
+}
+
+/**
+ * @param {AuditChangeApplyResult} result
+ * @returns {string}
+ */
+function formatAuditApplyIssue(result) {
+  if (result.error) {
+    return result.error;
+  }
+  if (result.status === auditChangeStatusSkippedValue) {
+    return `${formatAuditChangeKind(result.kind)} skipped for ${result.path}`;
+  }
+  return `${formatAuditChangeKind(result.kind)} failed for ${result.path}`;
 }
 
 /**

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -232,6 +232,7 @@ const commandPathWorkflowValue = "gix workflow";
 const auditCommandNameValue = "audit";
 const auditChangeKindRenameFolderValue = "rename_folder";
 const auditChangeKindUpdateCanonicalValue = "update_remote_canonical";
+const auditChangeKindDeleteFolderValue = "delete_folder";
 const auditChangeStatusSucceededValue = "succeeded";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
@@ -561,6 +562,7 @@ function bindEvents() {
   elements.auditIncludeAll.addEventListener("change", handleAuditDraftChange);
   elements.auditResultsBody.addEventListener("click", handleAuditResultsClick);
   elements.auditQueueList.addEventListener("click", handleAuditQueueListClick);
+  elements.auditQueueList.addEventListener("change", handleAuditQueueListChange);
   elements.auditQueueClear.addEventListener("click", clearAuditQueue);
   elements.auditQueueApply.addEventListener("click", () => {
     void applyAuditQueue();
@@ -2430,43 +2432,87 @@ function handleAuditQueueListClick(event) {
 }
 
 /**
+ * @param {Event} event
+ */
+function handleAuditQueueListChange(event) {
+  const eventTarget = event.target;
+  if (!(eventTarget instanceof HTMLElement)) {
+    return;
+  }
+
+  const deleteCheckbox = eventTarget.closest("[data-queue-confirm-delete]");
+  if (!(deleteCheckbox instanceof HTMLInputElement)) {
+    return;
+  }
+
+  const changeID = deleteCheckbox.dataset.queueConfirmDelete || "";
+  if (!changeID) {
+    return;
+  }
+
+  state.auditQueue = state.auditQueue.map((change) => {
+    if (change.id !== changeID) {
+      return change;
+    }
+    return {
+      ...change,
+      confirm_delete: deleteCheckbox.checked,
+    };
+  });
+  renderRunError("");
+  renderAuditQueue();
+}
+
+/**
  * @param {AuditInspectionRow} row
  * @returns {AuditRowActionDefinition[]}
  */
 function buildAuditRowActions(row) {
   /** @type {AuditRowActionDefinition[]} */
   const actions = [];
-  if (!row.is_git_repository) {
-    return actions;
-  }
-
-  if (row.name_matches === "no") {
-    actions.push({
-      kind: auditChangeKindRenameFolderValue,
-      label: "Queue rename",
-      title: "Rename folder",
-      description: row.final_github_repo && row.final_github_repo !== "n/a"
-        ? `Rename the folder to match ${row.final_github_repo}.`
-        : "Rename the folder to match the audited repository name.",
-      buildChange: () => ({
+  if (row.is_git_repository) {
+    if (row.name_matches === "no") {
+      actions.push({
         kind: auditChangeKindRenameFolderValue,
-        path: row.path,
-        require_clean: true,
-      }),
-    });
+        label: "Queue rename",
+        title: "Rename folder",
+        description: row.final_github_repo && row.final_github_repo !== "n/a"
+          ? `Rename the folder to match ${row.final_github_repo}.`
+          : "Rename the folder to match the audited repository name.",
+        buildChange: () => ({
+          kind: auditChangeKindRenameFolderValue,
+          path: row.path,
+          require_clean: true,
+        }),
+      });
+    }
+
+    if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
+      actions.push({
+        kind: auditChangeKindUpdateCanonicalValue,
+        label: "Queue remote fix",
+        title: "Fix canonical remote",
+        description: row.final_github_repo && row.final_github_repo !== "n/a"
+          ? `Update origin to the canonical repository ${row.final_github_repo}.`
+          : "Update origin to the canonical repository.",
+        buildChange: () => ({
+          kind: auditChangeKindUpdateCanonicalValue,
+          path: row.path,
+        }),
+      });
+    }
   }
 
-  if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
+  if (row.path) {
     actions.push({
-      kind: auditChangeKindUpdateCanonicalValue,
-      label: "Queue remote fix",
-      title: "Fix canonical remote",
-      description: row.final_github_repo && row.final_github_repo !== "n/a"
-        ? `Update origin to the canonical repository ${row.final_github_repo}.`
-        : "Update origin to the canonical repository.",
+      kind: auditChangeKindDeleteFolderValue,
+      label: "Queue delete",
+      title: "Delete folder",
+      description: `Delete ${row.path} from disk from the web audit workspace after explicit confirmation.`,
       buildChange: () => ({
-        kind: auditChangeKindUpdateCanonicalValue,
+        kind: auditChangeKindDeleteFolderValue,
         path: row.path,
+        confirm_delete: false,
       }),
     });
   }
@@ -2491,14 +2537,14 @@ function queueAuditChange(row, action) {
     ...changeDefinition,
   };
 
-  const existingDeleteChange = state.auditQueue.find((change) => change.path === candidate.path && change.kind === "delete_folder");
-  if (existingDeleteChange && candidate.kind !== "delete_folder") {
+  const existingDeleteChange = state.auditQueue.find((change) => change.path === candidate.path && change.kind === auditChangeKindDeleteFolderValue);
+  if (existingDeleteChange && candidate.kind !== auditChangeKindDeleteFolderValue) {
     renderRunError(`Delete folder is already queued for ${candidate.path}. Remove it before adding another fix.`);
     return;
   }
 
   const existingIndex = state.auditQueue.findIndex((change) => change.path === candidate.path && change.kind === candidate.kind);
-  if (candidate.kind === "delete_folder" && state.auditQueue.some((change) => change.path === candidate.path && change.kind !== candidate.kind)) {
+  if (candidate.kind === auditChangeKindDeleteFolderValue && state.auditQueue.some((change) => change.path === candidate.path && change.kind !== candidate.kind)) {
     renderRunError(`Remove existing queued fixes for ${candidate.path} before queueing folder deletion.`);
     return;
   }
@@ -2570,16 +2616,24 @@ function renderAuditQueue() {
       appendToken(meta, change.path, "token-context");
 
       container.append(heading, description, meta);
+      const options = renderAuditQueueOptions(change);
+      if (options) {
+        container.append(options);
+      }
       elements.auditQueueList.append(container);
     });
   }
 
   elements.auditQueueClear.disabled = state.auditQueue.length === 0 || state.auditQueueApplying;
-  elements.auditQueueApply.disabled = state.auditQueue.length === 0 || state.auditQueueApplying;
+  elements.auditQueueApply.disabled = state.auditQueue.length === 0 || state.auditQueueApplying || !auditQueueCanApply();
 }
 
 async function applyAuditQueue() {
   if (state.auditQueue.length === 0 || state.auditQueueApplying) {
+    return;
+  }
+  if (!auditQueueCanApply()) {
+    renderRunError("Review the pending changes and complete all required confirmations before applying the queue.");
     return;
   }
 
@@ -2709,9 +2763,55 @@ function formatAuditChangeKind(kind) {
       return "Rename folder";
     case auditChangeKindUpdateCanonicalValue:
       return "Fix canonical remote";
+    case auditChangeKindDeleteFolderValue:
+      return "Delete folder";
     default:
       return kind;
   }
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement | null}
+ */
+function renderAuditQueueOptions(change) {
+  if (change.kind !== auditChangeKindDeleteFolderValue) {
+    return null;
+  }
+
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const warning = document.createElement("p");
+  warning.className = "audit-queue-warning";
+  warning.textContent = "This permanently removes the folder from disk. Confirm before applying.";
+
+  const label = document.createElement("label");
+  label.className = "checkbox-row audit-queue-confirm";
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.checked = Boolean(change.confirm_delete);
+  checkbox.dataset.queueConfirmDelete = change.id;
+
+  const copy = document.createElement("span");
+  copy.textContent = "I understand this deletes the folder permanently";
+
+  label.append(checkbox, copy);
+  container.append(warning, label);
+  return container;
+}
+
+/**
+ * @returns {boolean}
+ */
+function auditQueueCanApply() {
+  return state.auditQueue.every((change) => {
+    if (change.kind === auditChangeKindDeleteFolderValue) {
+      return Boolean(change.confirm_delete);
+    }
+    return true;
+  });
 }
 
 /**

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -232,7 +232,12 @@ const commandPathWorkflowValue = "gix workflow";
 const auditCommandNameValue = "audit";
 const auditChangeKindRenameFolderValue = "rename_folder";
 const auditChangeKindUpdateCanonicalValue = "update_remote_canonical";
+const auditChangeKindConvertProtocolValue = "convert_protocol";
 const auditChangeKindDeleteFolderValue = "delete_folder";
+const auditChangeKindSyncWithRemoteValue = "sync_with_remote";
+const auditSyncStrategyRequireCleanValue = "require_clean";
+const auditSyncStrategyStashChangesValue = "stash_changes";
+const auditSyncStrategyCommitChangesValue = "commit_changes";
 const auditChangeStatusSucceededValue = "succeeded";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
@@ -2442,10 +2447,40 @@ function handleAuditQueueListChange(event) {
 
   const deleteCheckbox = eventTarget.closest("[data-queue-confirm-delete]");
   if (!(deleteCheckbox instanceof HTMLInputElement)) {
+    const renameIncludeOwnerCheckbox = eventTarget.closest("[data-queue-include-owner]");
+    if (renameIncludeOwnerCheckbox instanceof HTMLInputElement) {
+      updateAuditQueueBoolean(renameIncludeOwnerCheckbox.dataset.queueIncludeOwner || "", "include_owner", renameIncludeOwnerCheckbox.checked);
+      return;
+    }
+
+    const renameRequireCleanCheckbox = eventTarget.closest("[data-queue-require-clean]");
+    if (renameRequireCleanCheckbox instanceof HTMLInputElement) {
+      updateAuditQueueBoolean(renameRequireCleanCheckbox.dataset.queueRequireClean || "", "require_clean", renameRequireCleanCheckbox.checked);
+      return;
+    }
+
+    const targetProtocolSelect = eventTarget.closest("[data-queue-target-protocol]");
+    if (targetProtocolSelect instanceof HTMLSelectElement) {
+      updateAuditQueueText(targetProtocolSelect.dataset.queueTargetProtocol || "", "target_protocol", targetProtocolSelect.value);
+      return;
+    }
+
+    const syncStrategySelect = eventTarget.closest("[data-queue-sync-strategy]");
+    if (syncStrategySelect instanceof HTMLSelectElement) {
+      updateAuditQueueText(syncStrategySelect.dataset.queueSyncStrategy || "", "sync_strategy", syncStrategySelect.value);
+    }
     return;
   }
 
-  const changeID = deleteCheckbox.dataset.queueConfirmDelete || "";
+  updateAuditQueueBoolean(deleteCheckbox.dataset.queueConfirmDelete || "", "confirm_delete", deleteCheckbox.checked);
+}
+
+/**
+ * @param {string} changeID
+ * @param {"confirm_delete" | "include_owner" | "require_clean"} fieldName
+ * @param {boolean} fieldValue
+ */
+function updateAuditQueueBoolean(changeID, fieldName, fieldValue) {
   if (!changeID) {
     return;
   }
@@ -2456,7 +2491,30 @@ function handleAuditQueueListChange(event) {
     }
     return {
       ...change,
-      confirm_delete: deleteCheckbox.checked,
+      [fieldName]: fieldValue,
+    };
+  });
+  renderRunError("");
+  renderAuditQueue();
+}
+
+/**
+ * @param {string} changeID
+ * @param {"target_protocol" | "sync_strategy"} fieldName
+ * @param {string} fieldValue
+ */
+function updateAuditQueueText(changeID, fieldName, fieldValue) {
+  if (!changeID) {
+    return;
+  }
+
+  state.auditQueue = state.auditQueue.map((change) => {
+    if (change.id !== changeID) {
+      return change;
+    }
+    return {
+      ...change,
+      [fieldName]: fieldValue,
     };
   });
   renderRunError("");
@@ -2487,6 +2545,21 @@ function buildAuditRowActions(row) {
       });
     }
 
+    if (protocolFixAvailable(row)) {
+      actions.push({
+        kind: auditChangeKindConvertProtocolValue,
+        label: "Queue protocol fix",
+        title: "Fix protocol",
+        description: `Convert origin from ${row.remote_protocol} to a reviewed target protocol.`,
+        buildChange: () => ({
+          kind: auditChangeKindConvertProtocolValue,
+          path: row.path,
+          source_protocol: row.remote_protocol,
+          target_protocol: defaultTargetProtocol(row.remote_protocol),
+        }),
+      });
+    }
+
     if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
       actions.push({
         kind: auditChangeKindUpdateCanonicalValue,
@@ -2498,6 +2571,20 @@ function buildAuditRowActions(row) {
         buildChange: () => ({
           kind: auditChangeKindUpdateCanonicalValue,
           path: row.path,
+        }),
+      });
+    }
+
+    if (row.origin_remote_status === "configured" && row.in_sync === "no" && row.remote_default_branch && row.remote_default_branch !== "n/a") {
+      actions.push({
+        kind: auditChangeKindSyncWithRemoteValue,
+        label: "Queue sync",
+        title: "Sync with remote",
+        description: `Refresh the local repository state against ${row.remote_default_branch} using a reviewed dirty-worktree policy.`,
+        buildChange: () => ({
+          kind: auditChangeKindSyncWithRemoteValue,
+          path: row.path,
+          sync_strategy: auditSyncStrategyRequireCleanValue,
         }),
       });
     }
@@ -2612,7 +2699,7 @@ function renderAuditQueue() {
 
       const meta = document.createElement("div");
       meta.className = "audit-queue-meta";
-      appendToken(meta, change.kind, "token-default");
+      appendToken(meta, formatAuditChangeKind(change.kind), "token-default");
       appendToken(meta, change.path, "token-context");
 
       container.append(heading, description, meta);
@@ -2650,7 +2737,7 @@ async function applyAuditQueue() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        changes: state.auditQueue.map((change) => ({
+        changes: sortAuditQueueForApply(state.auditQueue).map((change) => ({
           id: change.id,
           kind: change.kind,
           path: change.path,
@@ -2761,8 +2848,12 @@ function formatAuditChangeKind(kind) {
   switch (kind) {
     case auditChangeKindRenameFolderValue:
       return "Rename folder";
+    case auditChangeKindConvertProtocolValue:
+      return "Fix protocol";
     case auditChangeKindUpdateCanonicalValue:
       return "Fix canonical remote";
+    case auditChangeKindSyncWithRemoteValue:
+      return "Sync with remote";
     case auditChangeKindDeleteFolderValue:
       return "Delete folder";
     default:
@@ -2775,10 +2866,45 @@ function formatAuditChangeKind(kind) {
  * @returns {HTMLElement | null}
  */
 function renderAuditQueueOptions(change) {
-  if (change.kind !== auditChangeKindDeleteFolderValue) {
-    return null;
+  switch (change.kind) {
+    case auditChangeKindRenameFolderValue:
+      return renderRenameQueueOptions(change);
+    case auditChangeKindConvertProtocolValue:
+      return renderProtocolQueueOptions(change);
+    case auditChangeKindSyncWithRemoteValue:
+      return renderSyncQueueOptions(change);
+    case auditChangeKindDeleteFolderValue:
+      return renderDeleteQueueOptions(change);
+    default:
+      return null;
   }
+}
 
+/**
+ * @returns {boolean}
+ */
+function auditQueueCanApply() {
+  return state.auditQueue.every((change) => {
+    if (change.kind === auditChangeKindDeleteFolderValue) {
+      return Boolean(change.confirm_delete);
+    }
+    if (change.kind === auditChangeKindConvertProtocolValue) {
+      const sourceProtocol = String(change.source_protocol || "").trim();
+      const targetProtocol = String(change.target_protocol || "").trim();
+      return protocolValueAllowed(sourceProtocol) && protocolValueAllowed(targetProtocol) && sourceProtocol !== targetProtocol;
+    }
+    if (change.kind === auditChangeKindSyncWithRemoteValue) {
+      return syncStrategyAllowed(String(change.sync_strategy || ""));
+    }
+    return true;
+  });
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderDeleteQueueOptions(change) {
   const container = document.createElement("div");
   container.className = "audit-queue-options";
 
@@ -2803,15 +2929,209 @@ function renderAuditQueueOptions(change) {
 }
 
 /**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderRenameQueueOptions(change) {
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const heading = document.createElement("div");
+  heading.className = "audit-queue-options-heading";
+  heading.textContent = "Rename options";
+
+  const includeOwnerLabel = document.createElement("label");
+  includeOwnerLabel.className = "checkbox-row audit-queue-confirm";
+
+  const includeOwnerCheckbox = document.createElement("input");
+  includeOwnerCheckbox.type = "checkbox";
+  includeOwnerCheckbox.checked = Boolean(change.include_owner);
+  includeOwnerCheckbox.dataset.queueIncludeOwner = change.id;
+
+  const includeOwnerCopy = document.createElement("span");
+  includeOwnerCopy.textContent = "Include the owner in the destination folder name";
+
+  includeOwnerLabel.append(includeOwnerCheckbox, includeOwnerCopy);
+
+  const requireCleanLabel = document.createElement("label");
+  requireCleanLabel.className = "checkbox-row audit-queue-confirm";
+
+  const requireCleanCheckbox = document.createElement("input");
+  requireCleanCheckbox.type = "checkbox";
+  requireCleanCheckbox.checked = Boolean(change.require_clean);
+  requireCleanCheckbox.dataset.queueRequireClean = change.id;
+
+  const requireCleanCopy = document.createElement("span");
+  requireCleanCopy.textContent = "Require a clean worktree before renaming";
+
+  requireCleanLabel.append(requireCleanCheckbox, requireCleanCopy);
+
+  container.append(heading, includeOwnerLabel, requireCleanLabel);
+  return container;
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderProtocolQueueOptions(change) {
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const heading = document.createElement("div");
+  heading.className = "audit-queue-options-heading";
+  heading.textContent = "Protocol options";
+
+  const source = document.createElement("p");
+  source.className = "audit-queue-option-note";
+  source.textContent = `Current protocol: ${change.source_protocol || "unknown"}`;
+
+  const label = document.createElement("label");
+  label.className = "audit-queue-option-row";
+  label.textContent = "Target protocol";
+
+  const select = document.createElement("select");
+  select.className = "select-input audit-queue-select";
+  select.dataset.queueTargetProtocol = change.id;
+
+  protocolOptionValues().forEach((value) => {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    select.append(option);
+  });
+
+  if (change.target_protocol && protocolValueAllowed(change.target_protocol)) {
+    select.value = change.target_protocol;
+  }
+
+  container.append(heading, source, label, select);
+  return container;
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderSyncQueueOptions(change) {
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const heading = document.createElement("div");
+  heading.className = "audit-queue-options-heading";
+  heading.textContent = "Sync options";
+
+  const label = document.createElement("label");
+  label.className = "audit-queue-option-row";
+  label.textContent = "Dirty-worktree policy";
+
+  const select = document.createElement("select");
+  select.className = "select-input audit-queue-select";
+  select.dataset.queueSyncStrategy = change.id;
+
+  syncStrategyOptions().forEach((optionValue) => {
+    const option = document.createElement("option");
+    option.value = optionValue.value;
+    option.textContent = optionValue.label;
+    select.append(option);
+  });
+
+  const syncStrategy = change.sync_strategy || auditSyncStrategyRequireCleanValue;
+  if (syncStrategyAllowed(syncStrategy)) {
+    select.value = syncStrategy;
+  }
+
+  container.append(heading, label, select);
+  return container;
+}
+
+/**
+ * @param {string} protocolValue
  * @returns {boolean}
  */
-function auditQueueCanApply() {
-  return state.auditQueue.every((change) => {
-    if (change.kind === auditChangeKindDeleteFolderValue) {
-      return Boolean(change.confirm_delete);
-    }
-    return true;
-  });
+function protocolFixAvailableRowValue(protocolValue) {
+  return protocolValueAllowed(protocolValue);
+}
+
+/**
+ * @param {AuditInspectionRow} row
+ * @returns {boolean}
+ */
+function protocolFixAvailable(row) {
+  return row.origin_remote_status === "configured" && protocolFixAvailableRowValue(row.remote_protocol);
+}
+
+/**
+ * @param {string} currentProtocol
+ * @returns {string}
+ */
+function defaultTargetProtocol(currentProtocol) {
+  return currentProtocol === "ssh" ? "https" : "ssh";
+}
+
+/**
+ * @returns {string[]}
+ */
+function protocolOptionValues() {
+  return ["git", "ssh", "https"];
+}
+
+/**
+ * @param {string} protocolValue
+ * @returns {boolean}
+ */
+function protocolValueAllowed(protocolValue) {
+  return protocolOptionValues().includes(protocolValue);
+}
+
+/**
+ * @returns {{ value: string, label: string }[]}
+ */
+function syncStrategyOptions() {
+  return [
+    { value: auditSyncStrategyRequireCleanValue, label: "Require clean worktree" },
+    { value: auditSyncStrategyStashChangesValue, label: "Stash tracked changes" },
+    { value: auditSyncStrategyCommitChangesValue, label: "Commit tracked changes" },
+  ];
+}
+
+/**
+ * @param {string} syncStrategy
+ * @returns {boolean}
+ */
+function syncStrategyAllowed(syncStrategy) {
+  return syncStrategyOptions().some((optionValue) => optionValue.value === syncStrategy);
+}
+
+/**
+ * @param {AuditQueueEntry[]} changes
+ * @returns {AuditQueueEntry[]}
+ */
+function sortAuditQueueForApply(changes) {
+  return changes
+    .slice()
+    .sort((left, right) => auditApplyPriority(left.kind) - auditApplyPriority(right.kind));
+}
+
+/**
+ * @param {string} kind
+ * @returns {number}
+ */
+function auditApplyPriority(kind) {
+  switch (kind) {
+    case auditChangeKindUpdateCanonicalValue:
+      return 10;
+    case auditChangeKindConvertProtocolValue:
+      return 20;
+    case auditChangeKindSyncWithRemoteValue:
+      return 30;
+    case auditChangeKindRenameFolderValue:
+      return 40;
+    case auditChangeKindDeleteFolderValue:
+      return 50;
+    default:
+      return 100;
+  }
 }
 
 /**

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -103,6 +103,83 @@
 
 /**
  * @typedef {{
+ *   roots?: string[],
+ *   rows?: AuditInspectionRow[],
+ *   error?: string,
+ * }} AuditInspectionResponse
+ */
+
+/**
+ * @typedef {{
+ *   path: string,
+ *   folder_name: string,
+ *   is_git_repository: boolean,
+ *   final_github_repo: string,
+ *   origin_remote_status: string,
+ *   name_matches: string,
+ *   remote_default_branch: string,
+ *   local_branch: string,
+ *   in_sync: string,
+ *   remote_protocol: string,
+ *   origin_matches_canonical: string,
+ *   worktree_dirty: string,
+ *   dirty_files: string,
+ * }} AuditInspectionRow
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   kind: string,
+ *   path: string,
+ *   include_owner?: boolean,
+ *   require_clean?: boolean,
+ *   source_protocol?: string,
+ *   target_protocol?: string,
+ *   sync_strategy?: string,
+ *   confirm_delete?: boolean,
+ * }} AuditQueuedChange
+ */
+
+/**
+ * @typedef {AuditQueuedChange & {
+ *   title: string,
+ *   description: string,
+ * }} AuditQueueEntry
+ */
+
+/**
+ * @typedef {{
+ *   results?: AuditChangeApplyResult[],
+ *   error?: string,
+ * }} AuditChangeApplyResponse
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   kind: string,
+ *   path: string,
+ *   status: string,
+ *   message?: string,
+ *   stdout?: string,
+ *   stderr?: string,
+ *   error?: string,
+ * }} AuditChangeApplyResult
+ */
+
+/**
+ * @typedef {{
+ *   kind: string,
+ *   label: string,
+ *   title: string,
+ *   description: string,
+ *   buildChange: (row: AuditInspectionRow) => Partial<AuditQueuedChange>,
+ * }} AuditRowActionDefinition
+ */
+
+/**
+ * @typedef {{
  *   id: string,
  *   title: string,
  *   description: string,
@@ -111,6 +188,8 @@
 
 const repositoriesEndpoint = "/api/repos";
 const commandsEndpoint = "/api/commands";
+const auditInspectEndpoint = "/api/audit/inspect";
+const auditApplyEndpoint = "/api/audit/apply";
 const runsEndpoint = "/api/runs";
 const pollIntervalMilliseconds = 800;
 const currentRepoLaunchMode = "current_repo";
@@ -151,10 +230,28 @@ const commandPathPullRequestsDeleteValue = "gix prs delete";
 const commandPathPackagesDeleteValue = "gix packages delete";
 const commandPathWorkflowValue = "gix workflow";
 const auditCommandNameValue = "audit";
+const auditChangeKindRenameFolderValue = "rename_folder";
+const auditChangeKindUpdateCanonicalValue = "update_remote_canonical";
+const auditChangeStatusSucceededValue = "succeeded";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
   "folder_name",
   "final_github_repo",
+  "origin_remote_status",
+  "name_matches",
+  "remote_default_branch",
+  "local_branch",
+  "in_sync",
+  "remote_protocol",
+  "origin_matches_canonical",
+  "worktree_dirty",
+  "dirty_files",
+];
+const typedAuditHeaderColumns = [
+  "path",
+  "folder_name",
+  "final_github_repo",
+  "origin_remote_status",
   "name_matches",
   "remote_default_branch",
   "local_branch",
@@ -165,8 +262,10 @@ const auditHeaderColumns = [
   "dirty_files",
 ];
 const auditColumnLabels = Object.freeze({
+  path: "Path",
   folder_name: "Folder",
   final_github_repo: "GitHub Repo",
+  origin_remote_status: "Origin Remote",
   name_matches: "Name Matches",
   remote_default_branch: "Remote Default",
   local_branch: "Local Branch",
@@ -218,6 +317,13 @@ const commandGroupDefinitions = [
  *   actionableCommands: CommandDescriptor[],
  *   advancedCommands: CommandDescriptor[],
  *   selectedPath: string,
+ *   auditInspectionRoots: string[],
+ *   auditInspectionRows: AuditInspectionRow[],
+ *   auditInspectionIncludeAll: boolean,
+ *   auditQueue: AuditQueueEntry[],
+ *   auditQueueVisible: boolean,
+ *   auditQueueApplying: boolean,
+ *   nextAuditChangeSequence: number,
  *   pollTimer: number | null,
  * }} */
 const state = {
@@ -237,6 +343,13 @@ const state = {
   actionableCommands: [],
   advancedCommands: [],
   selectedPath: "",
+  auditInspectionRoots: [],
+  auditInspectionRows: [],
+  auditInspectionIncludeAll: false,
+  auditQueue: [],
+  auditQueueVisible: false,
+  auditQueueApplying: false,
+  nextAuditChangeSequence: 1,
   pollTimer: null,
 };
 
@@ -283,6 +396,8 @@ const elements = {
   taskPanelCleanup: document.querySelector("#task-panel-cleanup"),
   taskPanelWorkflows: document.querySelector("#task-panel-workflows"),
   taskPanelAdvanced: document.querySelector("#task-panel-advanced"),
+  auditRootsInput: document.querySelector("#audit-roots-input"),
+  auditIncludeAll: document.querySelector("#audit-include-all"),
   taskInspectLoad: document.querySelector("#task-inspect-load"),
   fileTaskMode: document.querySelector("#file-task-mode"),
   fileTaskAddFields: document.querySelector("#file-task-add-fields"),
@@ -320,6 +435,11 @@ const elements = {
   auditResultsSummary: document.querySelector("#audit-results-summary"),
   auditResultsHead: document.querySelector("#audit-results-head"),
   auditResultsBody: document.querySelector("#audit-results-body"),
+  auditQueuePanel: document.querySelector("#audit-queue-panel"),
+  auditQueueSummary: document.querySelector("#audit-queue-summary"),
+  auditQueueList: document.querySelector("#audit-queue-list"),
+  auditQueueClear: document.querySelector("#audit-queue-clear"),
+  auditQueueApply: document.querySelector("#audit-queue-apply"),
   stdoutOutput: document.querySelector("#stdout-output"),
   stderrOutput: document.querySelector("#stderr-output"),
   runError: document.querySelector("#run-error"),
@@ -428,6 +548,22 @@ function bindEvents() {
 
   elements.taskInspectLoad.addEventListener("click", () => {
     void runAuditTask();
+  });
+
+  const handleAuditDraftChange = () => {
+    renderTaskState();
+    if (state.selectedPath === commandPathAuditValue) {
+      repopulateSelectedCommand();
+    }
+  };
+
+  elements.auditRootsInput.addEventListener("input", handleAuditDraftChange);
+  elements.auditIncludeAll.addEventListener("change", handleAuditDraftChange);
+  elements.auditResultsBody.addEventListener("click", handleAuditResultsClick);
+  elements.auditQueueList.addEventListener("click", handleAuditQueueListClick);
+  elements.auditQueueClear.addEventListener("click", clearAuditQueue);
+  elements.auditQueueApply.addEventListener("click", () => {
+    void applyAuditQueue();
   });
 
   elements.scopeSelected.addEventListener("click", () => {
@@ -629,7 +765,7 @@ function renderTaskState() {
   elements.taskPanelWorkflows.hidden = state.activeTask !== taskWorkflowsValue;
   elements.taskPanelAdvanced.hidden = state.activeTask !== taskAdvancedValue;
 
-  elements.taskInspectLoad.disabled = !repositoryTargetsAvailable;
+  renderAuditTaskState();
   elements.fileTaskLoad.disabled = !repositoryTargetsAvailable;
   elements.taskRemoteLoad.disabled = !repositoryTargetsAvailable;
   elements.taskCleanupPullRequests.disabled = !repositoryTargetsAvailable;
@@ -666,6 +802,15 @@ function renderFileTaskState() {
   }
 }
 
+function renderAuditTaskState() {
+  const fallbackRoots = repositoryScopeRoots();
+  const placeholder = fallbackRoots.length > 0
+    ? `${fallbackRoots.join("\n")}\n`
+    : "One root per line. Leave blank to use the current repository scope.";
+  elements.auditRootsInput.placeholder = placeholder;
+  elements.taskInspectLoad.disabled = resolveAuditRoots().length === 0;
+}
+
 function loadFileTaskCommand() {
   if (state.fileTaskMode === fileTaskModeAddValue) {
     selectCommand(commandPathFilesAddValue);
@@ -688,7 +833,61 @@ function loadWorkflowTaskCommand() {
 
 async function runAuditTask() {
   selectCommand(commandPathAuditValue);
-  await submitRun();
+  await inspectAuditRoots(true);
+}
+
+/**
+ * @param {boolean} clearOutput
+ */
+async function inspectAuditRoots(clearOutput) {
+  const auditRoots = resolveAuditRoots();
+  if (auditRoots.length === 0) {
+    hideAuditResults();
+    clearPolling();
+    renderRunError("Enter at least one audit root or choose a repository scope to inspect.");
+    setStatus("failed");
+    return;
+  }
+
+  clearPolling();
+  hideAuditResults();
+  if (clearOutput) {
+    clearRunnerOutput();
+  }
+  renderRunError("");
+  setStatus("loading");
+  elements.runID.textContent = "audit inspect";
+  elements.taskInspectLoad.disabled = true;
+
+  try {
+    const response = await fetch(auditInspectEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        roots: auditRoots,
+        include_all: Boolean(elements.auditIncludeAll.checked),
+      }),
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+      throw new Error(payload.error || `Failed to inspect audit roots: ${response.status}`);
+    }
+
+    /** @type {AuditInspectionResponse} */
+    const inspection = await response.json();
+    if (inspection.error) {
+      throw new Error(inspection.error);
+    }
+
+    renderTypedAuditResults(inspection);
+    setStatus("succeeded");
+  } catch (error) {
+    hideAuditResults();
+    renderRunError(String(error));
+    setStatus("failed");
+  } finally {
+    renderTaskState();
+  }
 }
 
 function renderRepositoryLaunchSummary() {
@@ -1064,11 +1263,13 @@ function updateActionContext() {
 
   switch (state.activeTask) {
     case taskInspectValue:
-      if (scopeRepositories.length === 0) {
-        elements.actionContext.textContent = "Choose a repository target set to audit.";
+      if (resolveAuditRoots().length === 0) {
+        elements.actionContext.textContent = "Enter one or more audit roots or choose a repository target set to inspect.";
         return;
       }
-      elements.actionContext.textContent = `Audit ${repositorySummary}. Run the audit command when you want a CLI snapshot of the current scope.`;
+      elements.actionContext.textContent = elements.auditRootsInput.value.trim().length > 0
+        ? `Inspect ${resolveAuditRoots().length} explicit audit ${resolveAuditRoots().length === 1 ? "root" : "roots"}.`
+        : `Inspect ${repositorySummary} from the current scope.`;
       return;
     case taskBranchValue:
       if (selectedCommand && selectedCommand.target.group === commandGroupBranchValue && commandDraft?.reason) {
@@ -1338,6 +1539,10 @@ function populateArguments(command, argumentsOverride = null) {
  * @returns {{ arguments: string[], reason: string }}
  */
 function resolveCommandDraft(command) {
+  if (command.path === commandPathAuditValue) {
+    return buildAuditTaskArguments();
+  }
+
   if (command.path === commandPathWorkflowValue) {
     return buildWorkflowTaskArguments();
   }
@@ -1377,6 +1582,29 @@ function resolveCommandDraft(command) {
     arguments: [...command.path.split(" ").slice(1), ...rootArguments],
     reason: "",
   };
+}
+
+/**
+ * @returns {{ arguments: string[], reason: string }}
+ */
+function buildAuditTaskArguments() {
+  const auditRoots = resolveAuditRoots();
+  if (auditRoots.length === 0) {
+    return {
+      arguments: [],
+      reason: "Enter at least one audit root or choose a repository target set to inspect.",
+    };
+  }
+
+  const argumentsList = ["audit"];
+  if (elements.auditIncludeAll.checked) {
+    argumentsList.push("--all");
+  }
+  auditRoots.forEach((rootPath) => {
+    argumentsList.push("--roots", rootPath);
+  });
+
+  return { arguments: argumentsList, reason: "" };
 }
 
 /**
@@ -1743,6 +1971,15 @@ function splitNonEmptyLines(value) {
 }
 
 /**
+ * @returns {string[]}
+ */
+function resolveAuditRoots() {
+  const explicitRoots = splitNonEmptyLines(elements.auditRootsInput?.value || "");
+  const rootValues = explicitRoots.length > 0 ? explicitRoots : repositoryScopeRoots();
+  return Array.from(new Set(rootValues));
+}
+
+/**
  * @param {string[]} aliases
  */
 function renderAliases(aliases) {
@@ -1896,9 +2133,14 @@ function updateRun(snapshot) {
   elements.runID.textContent = snapshot.id;
   elements.stdoutOutput.textContent = snapshot.stdout || "";
   elements.stderrOutput.textContent = snapshot.stderr || "";
-  renderAuditResults(snapshot);
+  renderRunAuditResults(snapshot);
   renderRunError(snapshot.error || "");
   setStatus(snapshot.status);
+}
+
+function clearRunnerOutput() {
+  elements.stdoutOutput.textContent = "";
+  elements.stderrOutput.textContent = "";
 }
 
 /**
@@ -1940,18 +2182,40 @@ function clearPolling() {
 /**
  * @param {RunSnapshot | null} snapshot
  */
-function renderAuditResults(snapshot) {
+function renderRunAuditResults(snapshot) {
   const auditResults = resolveAuditResults(snapshot);
   if (!auditResults) {
     hideAuditResults();
     return;
   }
 
+  renderAuditTable(auditResults.headers, auditResults.rows, "No audit rows returned.");
+}
+
+/**
+ * @param {AuditInspectionResponse} inspection
+ */
+function renderTypedAuditResults(inspection) {
+  state.auditInspectionRoots = (inspection.roots || []).slice();
+  state.auditInspectionRows = (inspection.rows || []).slice();
+  state.auditInspectionIncludeAll = Boolean(elements.auditIncludeAll.checked);
+  state.auditQueueVisible = true;
+
+  renderTypedAuditTable(state.auditInspectionRows);
+  renderAuditQueue();
+}
+
+/**
+ * @param {string[]} headers
+ * @param {string[][]} rows
+ * @param {string} emptyMessage
+ */
+function renderAuditTable(headers, rows, emptyMessage) {
   elements.auditResultsHead.innerHTML = "";
   elements.auditResultsBody.innerHTML = "";
 
   const headerRow = document.createElement("tr");
-  auditResults.headers.forEach((headerName) => {
+  headers.forEach((headerName) => {
     const headerCell = document.createElement("th");
     headerCell.scope = "col";
     headerCell.textContent = auditColumnLabels[headerName] || headerName;
@@ -1959,20 +2223,105 @@ function renderAuditResults(snapshot) {
   });
   elements.auditResultsHead.append(headerRow);
 
-  auditResults.rows.forEach((record) => {
-    const rowElement = document.createElement("tr");
-    record.forEach((value, valueIndex) => {
-      const cell = document.createElement(valueIndex === 0 ? "th" : "td");
-      if (valueIndex === 0) {
-        cell.scope = "row";
-      }
-      cell.textContent = value || " ";
-      rowElement.append(cell);
+  if (rows.length === 0) {
+    const emptyRow = document.createElement("tr");
+    const emptyCell = document.createElement("td");
+    emptyCell.colSpan = headers.length;
+    emptyCell.textContent = emptyMessage;
+    emptyRow.append(emptyCell);
+    elements.auditResultsBody.append(emptyRow);
+  } else {
+    rows.forEach((record) => {
+      const rowElement = document.createElement("tr");
+      record.forEach((value, valueIndex) => {
+        const cell = document.createElement(valueIndex === 0 ? "th" : "td");
+        if (valueIndex === 0) {
+          cell.scope = "row";
+        }
+        cell.textContent = value || " ";
+        rowElement.append(cell);
+      });
+      elements.auditResultsBody.append(rowElement);
     });
-    elements.auditResultsBody.append(rowElement);
+  }
+
+  const rowCount = rows.length;
+  elements.auditResultsSummary.textContent = `${rowCount} ${rowCount === 1 ? "row" : "rows"}`;
+  elements.auditResultsPanel.hidden = false;
+}
+
+/**
+ * @param {AuditInspectionRow[]} rows
+ */
+function renderTypedAuditTable(rows) {
+  elements.auditResultsHead.innerHTML = "";
+  elements.auditResultsBody.innerHTML = "";
+
+  const headerRow = document.createElement("tr");
+  typedAuditHeaderColumns.forEach((headerName) => {
+    const headerCell = document.createElement("th");
+    headerCell.scope = "col";
+    headerCell.textContent = auditColumnLabels[headerName] || headerName;
+    headerRow.append(headerCell);
   });
 
-  const rowCount = auditResults.rows.length;
+  const actionsHeaderCell = document.createElement("th");
+  actionsHeaderCell.scope = "col";
+  actionsHeaderCell.textContent = "Actions";
+  headerRow.append(actionsHeaderCell);
+  elements.auditResultsHead.append(headerRow);
+
+  if (rows.length === 0) {
+    const emptyRow = document.createElement("tr");
+    const emptyCell = document.createElement("td");
+    emptyCell.colSpan = typedAuditHeaderColumns.length + 1;
+    emptyCell.textContent = "No repositories or folders matched the inspected roots.";
+    emptyRow.append(emptyCell);
+    elements.auditResultsBody.append(emptyRow);
+  } else {
+    rows.forEach((row) => {
+      const rowElement = document.createElement("tr");
+      const record = typedAuditRecord(row);
+
+      record.forEach((value, valueIndex) => {
+        const cell = document.createElement(valueIndex === 0 ? "th" : "td");
+        if (valueIndex === 0) {
+          cell.scope = "row";
+        }
+        cell.textContent = value || " ";
+        rowElement.append(cell);
+      });
+
+      const actionsCell = document.createElement("td");
+      actionsCell.className = "audit-actions-cell";
+
+      const actions = buildAuditRowActions(row);
+      if (actions.length === 0) {
+        const mutedLabel = document.createElement("span");
+        mutedLabel.className = "panel-note";
+        mutedLabel.textContent = "No queued fixes";
+        actionsCell.append(mutedLabel);
+      } else {
+        const actionsList = document.createElement("div");
+        actionsList.className = "audit-actions-list";
+        actions.forEach((action) => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = "secondary-button audit-action-button";
+          button.dataset.auditAction = action.kind;
+          button.dataset.auditPath = row.path;
+          button.textContent = action.label;
+          actionsList.append(button);
+        });
+        actionsCell.append(actionsList);
+      }
+
+      rowElement.append(actionsCell);
+      elements.auditResultsBody.append(rowElement);
+    });
+  }
+
+  const rowCount = rows.length;
   elements.auditResultsSummary.textContent = `${rowCount} ${rowCount === 1 ? "row" : "rows"}`;
   elements.auditResultsPanel.hidden = false;
 }
@@ -1982,6 +2331,387 @@ function hideAuditResults() {
   elements.auditResultsSummary.textContent = "";
   elements.auditResultsHead.innerHTML = "";
   elements.auditResultsBody.innerHTML = "";
+}
+
+/**
+ * @param {AuditInspectionRow} row
+ * @returns {string[]}
+ */
+function typedAuditRecord(row) {
+  return typedAuditHeaderColumns.map((headerName) => {
+    switch (headerName) {
+      case "path":
+        return row.path;
+      case "folder_name":
+        return row.folder_name;
+      case "final_github_repo":
+        return row.final_github_repo;
+      case "origin_remote_status":
+        return row.origin_remote_status;
+      case "name_matches":
+        return row.name_matches;
+      case "remote_default_branch":
+        return row.remote_default_branch;
+      case "local_branch":
+        return row.local_branch;
+      case "in_sync":
+        return row.in_sync;
+      case "remote_protocol":
+        return row.remote_protocol;
+      case "origin_matches_canonical":
+        return row.origin_matches_canonical;
+      case "worktree_dirty":
+        return row.worktree_dirty;
+      case "dirty_files":
+        return row.dirty_files;
+      default:
+        return "";
+    }
+  });
+}
+
+/**
+ * @param {MouseEvent} event
+ */
+function handleAuditResultsClick(event) {
+  const eventTarget = event.target;
+  if (!(eventTarget instanceof HTMLElement)) {
+    return;
+  }
+
+  const actionButton = eventTarget.closest("[data-audit-action]");
+  if (!(actionButton instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  const actionKind = actionButton.dataset.auditAction || "";
+  const actionPath = actionButton.dataset.auditPath || "";
+  if (!actionKind || !actionPath) {
+    return;
+  }
+
+  const row = state.auditInspectionRows.find((candidate) => candidate.path === actionPath);
+  if (!row) {
+    renderRunError(`Audit row ${actionPath} is no longer available.`);
+    return;
+  }
+
+  const action = buildAuditRowActions(row).find((candidate) => candidate.kind === actionKind);
+  if (!action) {
+    renderRunError(`Audit action ${actionKind} is not available for ${actionPath}.`);
+    return;
+  }
+
+  queueAuditChange(row, action);
+}
+
+/**
+ * @param {MouseEvent} event
+ */
+function handleAuditQueueListClick(event) {
+  const eventTarget = event.target;
+  if (!(eventTarget instanceof HTMLElement)) {
+    return;
+  }
+
+  const removeButton = eventTarget.closest("[data-queue-remove-id]");
+  if (!(removeButton instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  const changeID = removeButton.dataset.queueRemoveId || "";
+  if (!changeID) {
+    return;
+  }
+
+  state.auditQueue = state.auditQueue.filter((change) => change.id !== changeID);
+  renderRunError("");
+  renderAuditQueue();
+}
+
+/**
+ * @param {AuditInspectionRow} row
+ * @returns {AuditRowActionDefinition[]}
+ */
+function buildAuditRowActions(row) {
+  /** @type {AuditRowActionDefinition[]} */
+  const actions = [];
+  if (!row.is_git_repository) {
+    return actions;
+  }
+
+  if (row.name_matches === "no") {
+    actions.push({
+      kind: auditChangeKindRenameFolderValue,
+      label: "Queue rename",
+      title: "Rename folder",
+      description: row.final_github_repo && row.final_github_repo !== "n/a"
+        ? `Rename the folder to match ${row.final_github_repo}.`
+        : "Rename the folder to match the audited repository name.",
+      buildChange: () => ({
+        kind: auditChangeKindRenameFolderValue,
+        path: row.path,
+        require_clean: true,
+      }),
+    });
+  }
+
+  if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
+    actions.push({
+      kind: auditChangeKindUpdateCanonicalValue,
+      label: "Queue remote fix",
+      title: "Fix canonical remote",
+      description: row.final_github_repo && row.final_github_repo !== "n/a"
+        ? `Update origin to the canonical repository ${row.final_github_repo}.`
+        : "Update origin to the canonical repository.",
+      buildChange: () => ({
+        kind: auditChangeKindUpdateCanonicalValue,
+        path: row.path,
+      }),
+    });
+  }
+
+  return actions;
+}
+
+/**
+ * @param {AuditInspectionRow} row
+ * @param {AuditRowActionDefinition} action
+ */
+function queueAuditChange(row, action) {
+  const nextChangeID = `audit-change-${state.nextAuditChangeSequence}`;
+  const changeDefinition = action.buildChange(row);
+  /** @type {AuditQueueEntry} */
+  const candidate = {
+    id: nextChangeID,
+    kind: action.kind,
+    path: row.path,
+    title: action.title,
+    description: action.description,
+    ...changeDefinition,
+  };
+
+  const existingDeleteChange = state.auditQueue.find((change) => change.path === candidate.path && change.kind === "delete_folder");
+  if (existingDeleteChange && candidate.kind !== "delete_folder") {
+    renderRunError(`Delete folder is already queued for ${candidate.path}. Remove it before adding another fix.`);
+    return;
+  }
+
+  const existingIndex = state.auditQueue.findIndex((change) => change.path === candidate.path && change.kind === candidate.kind);
+  if (candidate.kind === "delete_folder" && state.auditQueue.some((change) => change.path === candidate.path && change.kind !== candidate.kind)) {
+    renderRunError(`Remove existing queued fixes for ${candidate.path} before queueing folder deletion.`);
+    return;
+  }
+
+  if (existingIndex >= 0) {
+    const existingChange = state.auditQueue[existingIndex];
+    state.auditQueue[existingIndex] = {
+      ...existingChange,
+      ...candidate,
+      id: existingChange.id,
+    };
+  } else {
+    state.nextAuditChangeSequence += 1;
+    state.auditQueue = state.auditQueue.concat(candidate);
+  }
+
+  state.auditQueueVisible = true;
+  renderRunError("");
+  renderAuditQueue();
+}
+
+function clearAuditQueue() {
+  state.auditQueue = [];
+  renderRunError("");
+  renderAuditQueue();
+}
+
+function renderAuditQueue() {
+  const shouldShowQueue = state.auditQueueVisible || state.auditQueue.length > 0;
+  if (!shouldShowQueue) {
+    elements.auditQueuePanel.hidden = true;
+    elements.auditQueueSummary.textContent = "";
+    elements.auditQueueList.innerHTML = "";
+    return;
+  }
+
+  elements.auditQueuePanel.hidden = false;
+  elements.auditQueueSummary.textContent = auditQueueSummary(state.auditQueue.length);
+  elements.auditQueueList.innerHTML = "";
+
+  if (state.auditQueue.length === 0) {
+    appendEmptyState(elements.auditQueueList, "No pending changes queued from the current audit table.");
+  } else {
+    state.auditQueue.forEach((change) => {
+      const container = document.createElement("article");
+      container.className = "audit-queue-item";
+
+      const heading = document.createElement("div");
+      heading.className = "audit-queue-item-heading";
+
+      const title = document.createElement("strong");
+      title.textContent = change.title;
+      heading.append(title);
+
+      const removeButton = document.createElement("button");
+      removeButton.type = "button";
+      removeButton.className = "secondary-button audit-queue-remove";
+      removeButton.dataset.queueRemoveId = change.id;
+      removeButton.textContent = "Remove";
+      heading.append(removeButton);
+
+      const description = document.createElement("p");
+      description.className = "audit-queue-description";
+      description.textContent = change.description;
+
+      const meta = document.createElement("div");
+      meta.className = "audit-queue-meta";
+      appendToken(meta, change.kind, "token-default");
+      appendToken(meta, change.path, "token-context");
+
+      container.append(heading, description, meta);
+      elements.auditQueueList.append(container);
+    });
+  }
+
+  elements.auditQueueClear.disabled = state.auditQueue.length === 0 || state.auditQueueApplying;
+  elements.auditQueueApply.disabled = state.auditQueue.length === 0 || state.auditQueueApplying;
+}
+
+async function applyAuditQueue() {
+  if (state.auditQueue.length === 0 || state.auditQueueApplying) {
+    return;
+  }
+
+  state.auditQueueApplying = true;
+  renderAuditQueue();
+  clearRunnerOutput();
+  clearPolling();
+  renderRunError("");
+  setStatus("loading");
+  elements.runID.textContent = "audit apply";
+
+  try {
+    const response = await fetch(auditApplyEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        changes: state.auditQueue.map((change) => ({
+          id: change.id,
+          kind: change.kind,
+          path: change.path,
+          include_owner: Boolean(change.include_owner),
+          require_clean: Boolean(change.require_clean),
+          source_protocol: change.source_protocol || "",
+          target_protocol: change.target_protocol || "",
+          sync_strategy: change.sync_strategy || "",
+          confirm_delete: Boolean(change.confirm_delete),
+        })),
+      }),
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+      throw new Error(payload.error || `Failed to apply queued audit changes: ${response.status}`);
+    }
+
+    /** @type {AuditChangeApplyResponse} */
+    const applyResponse = await response.json();
+    if (applyResponse.error) {
+      throw new Error(applyResponse.error);
+    }
+
+    const results = applyResponse.results || [];
+    renderAuditApplyResults(results);
+
+    const succeededIDs = new Set(
+      results
+        .filter((result) => result.status === auditChangeStatusSucceededValue)
+        .map((result) => result.id),
+    );
+    state.auditQueue = state.auditQueue.filter((change) => !succeededIDs.has(change.id));
+
+    if (state.auditInspectionRoots.length > 0) {
+      await inspectAuditRoots(false);
+    }
+
+    const failedResults = results.filter((result) => result.status !== auditChangeStatusSucceededValue);
+    if (failedResults.length > 0) {
+      renderRunError(failedResults.map((result) => result.error || `${result.kind} failed for ${result.path}`).join("\n"));
+      setStatus("failed");
+    } else {
+      setStatus("succeeded");
+    }
+  } catch (error) {
+    renderRunError(String(error));
+    setStatus("failed");
+  } finally {
+    state.auditQueueApplying = false;
+    renderAuditQueue();
+  }
+}
+
+/**
+ * @param {AuditChangeApplyResult[]} results
+ */
+function renderAuditApplyResults(results) {
+  const stdoutSections = [];
+  const stderrSections = [];
+
+  results.forEach((result) => {
+    const headingParts = [formatAuditChangeKind(result.kind)];
+    if (result.path) {
+      headingParts.push(result.path);
+    }
+    const heading = headingParts.join(" · ");
+
+    const stdoutLines = [];
+    if (result.message) {
+      stdoutLines.push(result.message);
+    }
+    if (result.stdout) {
+      stdoutLines.push(result.stdout.trim());
+    }
+    if (stdoutLines.length > 0) {
+      stdoutSections.push(`${heading}\n${stdoutLines.filter(Boolean).join("\n")}`.trim());
+    }
+
+    const stderrLines = [];
+    if (result.error) {
+      stderrLines.push(result.error);
+    }
+    if (result.stderr) {
+      stderrLines.push(result.stderr.trim());
+    }
+    if (stderrLines.length > 0) {
+      stderrSections.push(`${heading}\n${stderrLines.filter(Boolean).join("\n")}`.trim());
+    }
+  });
+
+  elements.stdoutOutput.textContent = stdoutSections.join("\n\n");
+  elements.stderrOutput.textContent = stderrSections.join("\n\n");
+}
+
+/**
+ * @param {number} count
+ * @returns {string}
+ */
+function auditQueueSummary(count) {
+  return `${count} pending ${count === 1 ? "change" : "changes"}`;
+}
+
+/**
+ * @param {string} kind
+ * @returns {string}
+ */
+function formatAuditChangeKind(kind) {
+  switch (kind) {
+    case auditChangeKindRenameFolderValue:
+      return "Rename folder";
+    case auditChangeKindUpdateCanonicalValue:
+      return "Fix canonical remote";
+    default:
+      return kind;
+  }
 }
 
 /**

--- a/internal/web/ui/assets/styles.css
+++ b/internal/web/ui/assets/styles.css
@@ -609,6 +609,10 @@ h4 {
   min-height: 6rem;
 }
 
+.audit-roots-input {
+  min-height: 7rem;
+}
+
 .checkbox-row {
   display: flex;
   align-items: center;
@@ -831,6 +835,63 @@ h4 {
 .audit-table tbody tr:last-child th,
 .audit-table tbody tr:last-child td {
   border-bottom: none;
+}
+
+.audit-actions-cell {
+  min-width: 14rem;
+}
+
+.audit-actions-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.audit-action-button {
+  min-width: 10.5rem;
+}
+
+.audit-queue-panel {
+  margin-top: 0.9rem;
+  padding: 0.95rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-medium);
+  background: rgba(255, 250, 242, 0.72);
+}
+
+.audit-queue-list {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0.7rem 0 0.95rem;
+}
+
+.audit-queue-item {
+  padding: 0.9rem;
+  border: 1px solid rgba(73, 46, 27, 0.12);
+  border-radius: var(--radius-medium);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.audit-queue-item-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.audit-queue-description {
+  margin: 0.65rem 0;
+  color: var(--text-soft);
+}
+
+.audit-queue-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.audit-queue-remove {
+  white-space: nowrap;
 }
 
 .flag-item {

--- a/internal/web/ui/assets/styles.css
+++ b/internal/web/ui/assets/styles.css
@@ -896,6 +896,29 @@ h4 {
   border-top: 1px solid rgba(73, 46, 27, 0.12);
 }
 
+.audit-queue-options-heading {
+  margin-bottom: 0.55rem;
+  font-size: 0.84rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.audit-queue-option-note {
+  margin: 0 0 0.65rem;
+  color: var(--text-soft);
+}
+
+.audit-queue-option-row {
+  display: block;
+  margin-top: 0.65rem;
+  color: var(--muted);
+}
+
+.audit-queue-select {
+  margin-top: 0.45rem;
+}
+
 .audit-queue-warning {
   margin: 0 0 0.65rem;
   color: var(--danger);

--- a/internal/web/ui/assets/styles.css
+++ b/internal/web/ui/assets/styles.css
@@ -890,6 +890,17 @@ h4 {
   gap: 0.45rem;
 }
 
+.audit-queue-options {
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid rgba(73, 46, 27, 0.12);
+}
+
+.audit-queue-warning {
+  margin: 0 0 0.65rem;
+  color: var(--danger);
+}
+
 .audit-queue-remove {
   white-space: nowrap;
 }

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -110,10 +110,16 @@
 
           <section id="task-panel-inspect" class="task-panel">
             <div class="task-copy">
-              <h4>Audit Selected Scope</h4>
-              <p class="panel-note">Use the target bar to choose the repository scope, then run the audit command when you want the CLI view of that state.</p>
+              <h4>Inspect Audit Roots</h4>
+              <p class="panel-note">Leave roots blank to inspect the current repository scope from the target bar, or enter explicit filesystem roots when you want to audit a wider workspace.</p>
             </div>
-            <button id="task-inspect-load" class="secondary-button" type="button">Run audit command</button>
+            <label class="field-label" for="audit-roots-input">Audit Roots</label>
+            <textarea id="audit-roots-input" class="code-input audit-roots-input" spellcheck="false" placeholder="One root per line. Leave blank to use the current repository scope."></textarea>
+            <label class="checkbox-row" for="audit-include-all">
+              <input id="audit-include-all" type="checkbox">
+              <span>Include non-Git folders in the inspected roots</span>
+            </label>
+            <button id="task-inspect-load" class="secondary-button" type="button">Inspect audit table</button>
           </section>
 
           <section id="task-panel-branch" class="task-panel" hidden>
@@ -282,6 +288,17 @@
                   <thead id="audit-results-head"></thead>
                   <tbody id="audit-results-body"></tbody>
                 </table>
+              </div>
+            </section>
+            <section id="audit-queue-panel" class="audit-queue-panel" hidden>
+              <div class="panel-heading">
+                <h4>Pending Changes</h4>
+                <span id="audit-queue-summary" class="panel-note"></span>
+              </div>
+              <div id="audit-queue-list" class="audit-queue-list"></div>
+              <div class="button-row">
+                <button id="audit-queue-clear" class="secondary-button" type="button">Clear queue</button>
+                <button id="audit-queue-apply" class="primary-button" type="button">Apply queue</button>
               </div>
             </section>
             <div class="output-grid">

--- a/internal/workflow/operations_audit.go
+++ b/internal/workflow/operations_audit.go
@@ -19,6 +19,7 @@ const (
 	auditDirectoryPermissionsConstant     = 0o755
 	auditCSVHeaderFinalRepositoryConstant = "final_github_repo"
 	auditCSVHeaderFolderNameConstant      = "folder_name"
+	auditCSVHeaderRemoteStatusConstant    = "origin_remote_status"
 	auditCSVHeaderNameMatchesConstant     = "name_matches"
 	auditCSVHeaderRemoteDefaultConstant   = "remote_default_branch"
 	auditCSVHeaderLocalBranchConstant     = "local_branch"
@@ -89,6 +90,7 @@ func (operation *AuditReportOperation) Execute(executionContext context.Context,
 	header := []string{
 		auditCSVHeaderFolderNameConstant,
 		auditCSVHeaderFinalRepositoryConstant,
+		auditCSVHeaderRemoteStatusConstant,
 		auditCSVHeaderNameMatchesConstant,
 		auditCSVHeaderRemoteDefaultConstant,
 		auditCSVHeaderLocalBranchConstant,
@@ -140,6 +142,7 @@ func buildAuditReportRow(inspection audit.RepositoryInspection) []string {
 	remoteDefaultBranch := inspection.RemoteDefaultBranch
 	localBranch := inspection.LocalBranch
 	inSync := inspection.InSyncStatus
+	originRemoteStatus := inspection.OriginRemoteStatus
 	remoteProtocol := string(inspection.RemoteProtocol)
 	originMatches := string(inspection.OriginMatchesCanonical)
 
@@ -148,6 +151,7 @@ func buildAuditReportRow(inspection audit.RepositoryInspection) []string {
 
 	if !inspection.IsGitRepository {
 		finalRepository = string(audit.TernaryValueNotApplicable)
+		originRemoteStatus = audit.OriginRemoteStatusNotApplicable
 		remoteDefaultBranch = string(audit.TernaryValueNotApplicable)
 		localBranch = string(audit.TernaryValueNotApplicable)
 		inSync = audit.TernaryValueNotApplicable
@@ -155,6 +159,10 @@ func buildAuditReportRow(inspection audit.RepositoryInspection) []string {
 		originMatches = string(audit.TernaryValueNotApplicable)
 		worktreeDirty = audit.TernaryValueNotApplicable
 	} else {
+		if originRemoteStatus == audit.OriginRemoteStatusMissing {
+			finalRepository = string(audit.TernaryValueNotApplicable)
+			remoteProtocol = string(audit.TernaryValueNotApplicable)
+		}
 		if len(inspection.WorktreeDirtyFiles) > 0 {
 			worktreeDirty = audit.TernaryValueYes
 			dirtyFiles = strings.Join(inspection.WorktreeDirtyFiles, "; ")
@@ -166,6 +174,7 @@ func buildAuditReportRow(inspection audit.RepositoryInspection) []string {
 	return []string{
 		inspection.FolderName,
 		finalRepository,
+		string(originRemoteStatus),
 		string(nameMatches),
 		remoteDefaultBranch,
 		localBranch,

--- a/internal/workflow/operations_audit_test.go
+++ b/internal/workflow/operations_audit_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	auditReportTestFileNameConstant       = "audit_report.csv"
 	auditReportWhitespacePaddingConstant  = " "
-	auditReportExpectedHeaderLineConstant = "folder_name,final_github_repo,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files"
+	auditReportExpectedHeaderLineConstant = "folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files"
 )
 
 func TestAuditReportOperationCreatesNestedOutput(testInstance *testing.T) {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -128,6 +128,122 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - [ ] **CLI Exit Refinement**: Adjust the CLI execution flow to ensure that errors already emitted by the reporter do not trigger a second print at the application exit point.
   - [ ] **Verification**: Add an integration test case that triggers a predictable Git failure and asserts that the resulting error message appears exactly once in the combined output stream.
 
+- [x] [F004] Audit in the web client needs a first-class inspection flow with user-selected roots instead of parsing CLI stdout.
+  Requested on 2026-03-08 while refining the `gix --web` audit UX.
+  Resolved on 2026-03-08 by adding `POST /api/audit/inspect`, wiring `audit.Service.DiscoverInspections` into the web launcher, adding explicit audit-root controls in the browser, and rendering typed audit rows directly in the web table while keeping the generic runner available for raw CLI execution.
+  ### Summary
+  The current web interface treats audit as a generic command run and renders the CSV only after `gix audit` executes through the runner. That blocks the next UX steps because the browser has no typed audit model, no independent root selection, and no stable contract for row-level actions.
+
+  ### Analysis
+  - `internal/web/server.go` currently exposes repositories, branches, commands, and generic runs only. There is no dedicated audit endpoint.
+  - `internal/web/ui/assets/app.js` renders audit results by parsing `stdout` from a `RunSnapshot`, so the browser only sees CSV text rather than typed inspection rows.
+  - `cmd/cli/application_web.go` launches the web server with repository discovery rooted in the process working directory. That startup catalog is useful as context, but it is not a substitute for explicit audit roots.
+  - The existing audit service in `internal/audit/service.go` already provides the right backend primitive: `DiscoverInspections(ctx, roots, includeAll, debug, depth)` returns typed repository inspections before CSV formatting.
+  - The remediation UX requested by the user depends on stable row identity (`path`, `folder_name`, remote state, branch state), which should come from JSON instead of CSV parsing.
+
+  ### Deliverables
+  - [x] Add a dedicated web audit inspection API (for example `POST /api/audit/inspect`) that accepts explicit roots plus `include_all`.
+  - [x] Return typed audit rows from the backend rather than only CSV text.
+  - [x] Add audit-root controls in the web UI so the operator can inspect arbitrary roots without relaunching `gix --web`.
+  - [x] Preserve the generic command runner for raw CLI access; the audit workspace should not depend on it for table rendering.
+  - [x] Add server/API and browser coverage for user-selected roots and typed audit table rendering.
+
+- [ ] [F005] Audit remediation in the web client must be modeled as a pending change queue before execution.
+  Requested on 2026-03-08 while defining follow-up UX after the audit table landed.
+  ### Summary
+  Row-level fixes in the browser should never execute immediately. The user wants every remediation action to become a queued pending change first, with explicit review before apply.
+
+  ### Analysis
+  - The current web UI has draft behavior for some commands (`draft_template` usage in `internal/web/ui/assets/app.js`), but it does not have a generalized queue, conflict resolution, or a typed pending-change model.
+  - Existing repository operations already exist in the workflow/task layers for rename, canonical remote update, protocol conversion, and default-branch promotion. The missing piece is a browser-side queue model plus a backend execution contract for batched pending items.
+  - Some requested actions conflict by construction. Example: deleting a folder conflicts with any queued fix for the same path; multiple remote fixes for one repo should merge or be rejected; sync should be blocked when destructive changes are pending for the same repository.
+  - If the queue is modeled as raw argv strings, the browser will be forced to reverse-engineer conflicts and capabilities from command text. The queue needs typed operations instead.
+
+  ### Deliverables
+  - [ ] Define a typed pending-change model shared by web UI and backend execution.
+  - [ ] Add queue operations in the UI: add, edit options, remove, clear, and review.
+  - [ ] Reject or merge conflicting queued operations deterministically.
+  - [ ] Execute queued changes through typed backend handlers or workflow operations rather than ad hoc shell text.
+  - [ ] Re-run audit for affected roots after queue execution and refresh the table from typed results.
+
+- [x] [F006] Audit output must report remote presence explicitly in both CLI and web/API contracts.
+  Requested on 2026-03-08 after reviewing how missing remotes appear in audit results.
+  Resolved on 2026-03-08 by extending audit and workflow CSV output with `origin_remote_status`, making missing remotes emit `missing` with `n/a` protocol/canonical fields, and updating the web inspection API plus integration coverage to surface the status directly.
+  ### Summary
+  When a repository has no `origin`, audit should say so explicitly. Today the CLI/web output exposes enough indirect fields to infer the situation, but the contract does not contain a dedicated remote-status field, which makes the UX ambiguous and blocks correct remediation suggestions.
+
+  ### Analysis
+  - `internal/audit/service.go` already distinguishes the no-remote case internally by returning an inspection with empty `OriginURL`, empty owner/repo fields, and `OriginMatchesCanonical = n/a`.
+  - The CSV/report contract drops that distinction. Operators only see related columns such as `final_github_repo`, `remote_protocol`, and `origin_matches_canonical`, none of which explicitly say `no remote configured`.
+  - The web client currently labels audit state from parsed CSV, so it inherits the same ambiguity.
+  - A dedicated remote-status field is the lowest-risk contract extension because it avoids overloading `origin_matches_canonical` with two meanings.
+  - This change must be wired through every audit output path, including direct audit CSV and workflow-backed audit reports in `internal/workflow/operations_audit.go`.
+
+  ### Deliverables
+  - [x] Add an explicit audit field/column for origin remote status (for example `configured`, `missing`, `n/a`).
+  - [x] Ensure missing-remotes render as such in the web table and are not framed as canonical-remote mismatches.
+  - [x] Update CLI and integration tests that assert audit CSV headers and rows.
+  - [x] Keep current `origin_matches_canonical` semantics for real remotes; do not repurpose it to mean remote absence.
+
+- [ ] [F007] The web audit workspace needs a UX-only folder deletion operation, queued before apply.
+  Requested on 2026-03-08 as part of the row-action audit UX.
+  ### Summary
+  The browser should support deleting a folder directly from the audit workspace, but only as a queued web action rather than a new immediate CLI behavior.
+
+  ### Analysis
+  - There is no existing CLI command dedicated to removing an inspected folder from disk. The existing `repo-history-remove` flow rewrites Git history and is unrelated.
+  - Because folder deletion is destructive and outside the existing command surface, it should remain web-only until the UX, safety model, and scope are validated.
+  - The most sensitive design choice is whether deletion applies only to non-git folders discovered via `include_all` or also to full repositories. The request currently says “delete a folder that matches the repo altogether,” which implies repository deletion may be intended, but that requires stronger guardrails than a simple button.
+  - The queue model from [F005] is a prerequisite because this action must never execute immediately from a table row.
+
+  ### Deliverables
+  - [ ] Define a web-only queued delete-folder operation with explicit confirmation requirements.
+  - [ ] Restrict or phase the scope intentionally (for example non-git folders first, then repositories if approved).
+  - [ ] Surface the operation only in the web audit workspace, not in the generic CLI runner.
+  - [ ] Add end-to-end tests that verify deletion is queued first and only applied after explicit confirmation.
+
+- [ ] [F008] The web audit queue needs repository sync and protocol-fix actions backed by existing operations.
+  Requested on 2026-03-08 as part of the audit remediation UX.
+  ### Summary
+  The audit table should let operators queue protocol fixes and “sync local with remote” changes directly from mismatched rows.
+
+  ### Analysis
+  - Protocol conversion already exists through `remote update-protocol` and `ProtocolConversionOperation`.
+  - Local/remote sync is less direct. `gix default` promotes a branch to the remote default branch and changes GitHub configuration; that is too heavy for a generic “bring local into sync” table action. The more appropriate existing behavior is closer to `branch.change` / `gix cd`, which fetches, switches, and rebases for repository roots.
+  - The queue UX therefore needs a clearer action taxonomy than the current audit columns provide. A row with `in_sync = no` should produce a queue item that describes the exact operation that will run, branch target, and dirty-worktree policy.
+  - These fixes should refresh audit state after apply so the table becomes the post-change source of truth.
+
+  ### Deliverables
+  - [ ] Add queued protocol-fix actions backed by the existing protocol conversion operation.
+  - [ ] Add queued local-sync actions backed by an explicit branch-refresh/change workflow, not default-branch migration.
+  - [ ] Surface per-item options needed for safe execution (branch target, dirty-worktree handling, protocol target).
+  - [ ] Add integration/browser coverage that verifies queueing plus execution updates the table state.
+
+- Update on 2026-03-08 for [F005].
+  Implemented the queue foundation without closing the full remediation program.
+  ### What Landed
+  - Added a typed apply contract at `POST /api/audit/apply` through `internal/web/types.go`, `internal/web/server.go`, and `cmd/cli/application_web.go`. The browser now sends structured queued changes instead of argv text.
+  - Added a browser-side pending-change model in `internal/web/ui/assets/app.js` with queue add/remove/clear/apply behavior, queue summary rendering, and post-apply audit reinspection against the active audit roots.
+  - Added backend execution mapping for queued change kinds to existing workflow/task primitives:
+    - `rename_folder` -> `workflow.RenameOperation`
+    - `update_remote_canonical` -> `workflow.CanonicalRemoteOperation`
+    - `convert_protocol` -> `workflow.ProtocolConversionOperation`
+    - `sync_with_remote` -> `branch.change` task action with refresh enabled
+    - `delete_folder` -> web-only filesystem deletion path guarded by `confirm_delete`
+  - Added end-to-end coverage in `cmd/cli/application_web_test.go` and `cmd/cli/application_web_browser_test.go` for queue submission and rename apply flow.
+
+  ### Queue Semantics Implemented
+  - The queue is typed by `kind` plus repository `path`, with stable queue IDs generated in the browser.
+  - Re-queueing the same `kind` for the same `path` replaces the existing queued item in place instead of duplicating it.
+  - `delete_folder` is treated as exclusive for a path: if deletion is already queued, other fixes for that path are rejected; if other fixes exist, deletion is rejected until they are removed.
+  - Successful apply results are removed from the pending queue; failed items remain queued.
+  - After apply, the web client reruns typed audit inspection for the previously inspected roots so the table reflects post-change state instead of stale pre-apply rows.
+
+  ### Remaining Gaps
+  - The queue UI does not yet expose editable per-item options. Current surfaced row actions use fixed defaults.
+  - The browser currently exposes row actions only for rename and canonical-remote fixes; protocol, sync, and delete execution paths exist on the backend but are intentionally not yet surfaced pending the UX work tracked in [F007] and [F008].
+  - Conflict handling is implemented for same-item replacement and delete exclusivity, but broader merge policy across protocol/sync/remote changes remains part of the remaining [F005]/[F008] work.
+
 
 ## Planning
 *do not implement yet*

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -148,8 +148,9 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - [x] Preserve the generic command runner for raw CLI access; the audit workspace should not depend on it for table rendering.
   - [x] Add server/API and browser coverage for user-selected roots and typed audit table rendering.
 
-- [ ] [F005] Audit remediation in the web client must be modeled as a pending change queue before execution.
+- [x] [F005] Audit remediation in the web client must be modeled as a pending change queue before execution.
   Requested on 2026-03-08 while defining follow-up UX after the audit table landed.
+  Resolved on 2026-03-08 by adding a typed pending-change queue to the web audit workspace, surfacing editable per-item options in the queue, and applying queued changes in a deterministic order so path-changing rename operations run after repository-state fixes.
   ### Summary
   Row-level fixes in the browser should never execute immediately. The user wants every remediation action to become a queued pending change first, with explicit review before apply.
 
@@ -160,11 +161,11 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - If the queue is modeled as raw argv strings, the browser will be forced to reverse-engineer conflicts and capabilities from command text. The queue needs typed operations instead.
 
   ### Deliverables
-  - [ ] Define a typed pending-change model shared by web UI and backend execution.
-  - [ ] Add queue operations in the UI: add, edit options, remove, clear, and review.
-  - [ ] Reject or merge conflicting queued operations deterministically.
-  - [ ] Execute queued changes through typed backend handlers or workflow operations rather than ad hoc shell text.
-  - [ ] Re-run audit for affected roots after queue execution and refresh the table from typed results.
+  - [x] Define a typed pending-change model shared by web UI and backend execution.
+  - [x] Add queue operations in the UI: add, edit options, remove, clear, and review.
+  - [x] Reject or merge conflicting queued operations deterministically.
+  - [x] Execute queued changes through typed backend handlers or workflow operations rather than ad hoc shell text.
+  - [x] Re-run audit for affected roots after queue execution and refresh the table from typed results.
 
 - [x] [F006] Audit output must report remote presence explicitly in both CLI and web/API contracts.
   Requested on 2026-03-08 after reviewing how missing remotes appear in audit results.
@@ -198,13 +199,14 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - The queue model from [F005] is a prerequisite because this action must never execute immediately from a table row.
 
   ### Deliverables
-  - [ ] Define a web-only queued delete-folder operation with explicit confirmation requirements.
-  - [ ] Restrict or phase the scope intentionally (for example non-git folders first, then repositories if approved).
-  - [ ] Surface the operation only in the web audit workspace, not in the generic CLI runner.
-  - [ ] Add end-to-end tests that verify deletion is queued first and only applied after explicit confirmation.
+  - [x] Define a web-only queued delete-folder operation with explicit confirmation requirements.
+  - [x] Restrict or phase the scope intentionally (for example non-git folders first, then repositories if approved).
+  - [x] Surface the operation only in the web audit workspace, not in the generic CLI runner.
+  - [x] Add end-to-end tests that verify deletion is queued first and only applied after explicit confirmation.
 
-- [ ] [F008] The web audit queue needs repository sync and protocol-fix actions backed by existing operations.
+- [x] [F008] The web audit queue needs repository sync and protocol-fix actions backed by existing operations.
   Requested on 2026-03-08 as part of the audit remediation UX.
+  Resolved on 2026-03-08 by surfacing queued protocol-fix and sync row actions in the web audit table, adding editable target-protocol and dirty-worktree-policy controls in the queue, and covering the queue/apply/refresh flow with a browser test.
   ### Summary
   The audit table should let operators queue protocol fixes and “sync local with remote” changes directly from mismatched rows.
 
@@ -215,10 +217,10 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - These fixes should refresh audit state after apply so the table becomes the post-change source of truth.
 
   ### Deliverables
-  - [ ] Add queued protocol-fix actions backed by the existing protocol conversion operation.
-  - [ ] Add queued local-sync actions backed by an explicit branch-refresh/change workflow, not default-branch migration.
-  - [ ] Surface per-item options needed for safe execution (branch target, dirty-worktree handling, protocol target).
-  - [ ] Add integration/browser coverage that verifies queueing plus execution updates the table state.
+  - [x] Add queued protocol-fix actions backed by the existing protocol conversion operation.
+  - [x] Add queued local-sync actions backed by an explicit branch-refresh/change workflow, not default-branch migration.
+  - [x] Surface per-item options needed for safe execution (branch target, dirty-worktree handling, protocol target).
+  - [x] Add integration/browser coverage that verifies queueing plus execution updates the table state.
 
 - Update on 2026-03-08 for [F005].
   Implemented the queue foundation without closing the full remediation program.
@@ -240,10 +242,10 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Successful apply results are removed from the pending queue; failed items remain queued.
   - After apply, the web client reruns typed audit inspection for the previously inspected roots so the table reflects post-change state instead of stale pre-apply rows.
 
-  ### Remaining Gaps
-  - The queue UI does not yet expose editable per-item options. Current surfaced row actions use fixed defaults.
-  - The browser currently exposes row actions only for rename and canonical-remote fixes; protocol, sync, and delete execution paths exist on the backend but are intentionally not yet surfaced pending the UX work tracked in [F007] and [F008].
-  - Conflict handling is implemented for same-item replacement and delete exclusivity, but broader merge policy across protocol/sync/remote changes remains part of the remaining [F005]/[F008] work.
+  ### Completion Notes
+  - The queue now exposes editable options for rename, delete, protocol conversion, and sync items.
+  - The browser now surfaces row actions for rename, canonical-remote fixes, protocol fixes, sync, and web-only folder deletion.
+  - Queue application is ordered deterministically so repository-state fixes run before rename and delete, avoiding stale-path execution during multi-step remediation.
 
 
 ## Planning

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -185,8 +185,9 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - [x] Update CLI and integration tests that assert audit CSV headers and rows.
   - [x] Keep current `origin_matches_canonical` semantics for real remotes; do not repurpose it to mean remote absence.
 
-- [ ] [F007] The web audit workspace needs a UX-only folder deletion operation, queued before apply.
+- [x] [F007] The web audit workspace needs a UX-only folder deletion operation, queued before apply.
   Requested on 2026-03-08 as part of the row-action audit UX.
+  Resolved on 2026-03-08 by surfacing a web-only `delete_folder` row action in the audit table, requiring explicit queue confirmation before apply, and covering the queue/apply/refresh flow with a browser test. The current scope intentionally allows deleting any audited folder path from the web queue, including repository folders, while still blocking filesystem-root deletion in the backend.
   ### Summary
   The browser should support deleting a folder directly from the audit workspace, but only as a queued web action rather than a new immediate CLI behavior.
 

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -247,6 +247,25 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - The browser now surfaces row actions for rename, canonical-remote fixes, protocol fixes, sync, and web-only folder deletion.
   - Queue application is ordered deterministically so repository-state fixes run before rename and delete, avoiding stale-path execution during multi-step remediation.
 
+- Update on 2026-03-08 for review follow-up on [F005], [F007], and [F008].
+  Addressed three post-review correctness regressions in the queued web audit flow and locked them with regression coverage before patching.
+  ### Summary
+  The initial queued-remediation implementation had three edge-case failures: apply could refresh the wrong audit scope, workflow-backed changes that reported `skipped` were surfaced as successful, and the apply endpoint accepted relative paths for destructive operations.
+
+  ### Analysis
+  - The browser stored the last successful audit rows, but `applyAuditQueue()` refreshed via `inspectAuditRoots(false)`, which rebuilt the request from the live form and repository catalog. That was incorrect because queued changes semantically belong to the last inspected scope, not whatever the controls happen to contain at apply time.
+  - This mismatch was especially dangerous after path-changing operations. If the operator edited the roots input after queueing, or if the repository catalog was stale relative to rename/delete actions, the table refresh could show an unrelated scope or fail to reflect the just-applied changes.
+  - The Go apply executor treated `nil` workflow errors as unconditional success. That was too optimistic because workflow/task execution already communicates `skipped` outcomes through `workflow.ExecutionOutcome.ReporterSummaryData.StepOutcomeCounts`, and some remediation actions intentionally skip without returning a hard error.
+  - Surfacing `skipped` as `succeeded` caused the browser to drop queued items that had not actually been applied and to report a misleading success state to the operator.
+  - `normalizeWebAuditChangePath` only trimmed and cleaned the submitted path. That allowed relative inputs such as `../sibling` to escape the inspected directory context at the API boundary, which is unacceptable now that `/api/audit/apply` can drive destructive filesystem operations.
+
+  ### Deliverables
+  - [x] Added a browser regression test that queues a rename, mutates the roots input, applies the queue, and verifies the post-apply refresh still uses the last inspected audit scope.
+  - [x] Split audit inspection in the web client into “build request from controls” and “rerun a saved request,” then updated queue apply to re-inspect with `state.auditInspectionRoots` and `state.auditInspectionIncludeAll`.
+  - [x] Added backend regression coverage for relative-path rejection and for mapping workflow execution outcomes to `succeeded` vs `skipped` vs `failed`.
+  - [x] Changed workflow-backed apply execution to derive result status from `workflow.ExecutionOutcome`, preserving skipped items in the queue and avoiding misleading success messages.
+  - [x] Hardened `/api/audit/apply` path normalization so only absolute paths are accepted for queued audit changes.
+
 
 ## Planning
 *do not implement yet*

--- a/tests/audit_integration_test.go
+++ b/tests/audit_integration_test.go
@@ -33,8 +33,8 @@ const (
 	auditIntegrationStubScript                 = "#!/bin/sh\nif [ \"$1\" = \"repo\" ] && [ \"$2\" = \"view\" ]; then\n  cat <<'EOF'\n{\"nameWithOwner\":\"canonical/example\",\"defaultBranchRef\":{\"name\":\"main\"},\"description\":\"\"}\nEOF\n  exit 0\nfi\nexit 0\n"
 	auditIntegrationRepositoryPrefixConstant   = "audit-integration-repository-"
 	auditIntegrationHomeShortcutPrefixConstant = "~/"
-	auditIntegrationCSVHeaderConstant          = "folder_name,final_github_repo,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
-	auditIntegrationCSVRowTemplate             = "%[1]s,canonical/example,no,main,,n/a,https,no,no,\n"
+	auditIntegrationCSVHeaderConstant          = "folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
+	auditIntegrationCSVRowTemplate             = "%[1]s,canonical/example,configured,no,main,,n/a,https,no,no,\n"
 	auditIntegrationCSVTemplate                = auditIntegrationCSVHeaderConstant + auditIntegrationCSVRowTemplate
 	auditIntegrationCSVCaseNameConstant        = "audit_csv"
 	auditIntegrationDebugCaseNameConstant      = "audit_debug"
@@ -155,7 +155,7 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 			name:      auditIntegrationIncludeAllCaseNameConstant,
 			arguments: includeAllArguments,
 			expectedOutput: fmt.Sprintf(
-				"folder_name,final_github_repo,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n%[1]s,canonical/example,no,main,,n/a,https,no,no,\n%[2]s,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,\n",
+				"folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n%[1]s,canonical/example,configured,no,main,,n/a,https,no,no,\n%[2]s,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,\n",
 				includeAllRepositoryFolderName,
 				nonGitFolderName,
 			),

--- a/tests/workflow_integration_test.go
+++ b/tests/workflow_integration_test.go
@@ -59,7 +59,7 @@ const (
 	workflowIntegrationCanonicalStepReasonLine = "  reason: 'already canonical'"
 	workflowIntegrationDefaultExpectedTemplate = "WORKFLOW-DEFAULT: %s (main → master)"
 	workflowIntegrationAuditExpectedTemplate   = "WORKFLOW-AUDIT: wrote report to %s\n"
-	workflowIntegrationCSVHeader               = "folder_name,final_github_repo,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
+	workflowIntegrationCSVHeader               = "folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
 	workflowIntegrationSubtestNameTemplate     = "%d_%s"
 	workflowIntegrationDefaultCaseName         = "protocol_default_audit"
 	workflowIntegrationConfigFlagCaseName      = "config_flag_without_positional"
@@ -714,12 +714,13 @@ func verifyWorkflowRepositoryState(testInstance *testing.T, repositoryPath strin
 	require.Equal(testInstance, strings.Split(strings.TrimSuffix(workflowIntegrationCSVHeader, "\n"), ","), records[0])
 	require.Equal(testInstance, "legacy", records[1][0])
 	require.Equal(testInstance, "canonical/example", records[1][1])
-	require.Equal(testInstance, "no", records[1][2])
-	require.Equal(testInstance, "master", records[1][3])
+	require.Equal(testInstance, "configured", records[1][2])
+	require.Equal(testInstance, "no", records[1][3])
 	require.Equal(testInstance, "master", records[1][4])
-	require.Equal(testInstance, "n/a", records[1][5])
-	require.Equal(testInstance, "ssh", records[1][6])
-	require.Equal(testInstance, "yes", records[1][7])
+	require.Equal(testInstance, "master", records[1][5])
+	require.Equal(testInstance, "n/a", records[1][6])
+	require.Equal(testInstance, "ssh", records[1][7])
+	require.Equal(testInstance, "yes", records[1][8])
 }
 
 func parseStageEntries(orderLog string) []string {


### PR DESCRIPTION
## Summary
- add a typed audit apply API and backend execution mapping for queued audit changes
- add a pending-change queue to the web audit workspace with add/remove/clear/apply flows
- rerun typed audit inspection after apply and document the queue foundation state in ISSUES.md

## Testing
- make format
- make test
- make lint
- make ci