### PR TITLE
feat(web): queue audit folder deletions

### DIFF
--- a/cmd/cli/application_web.go
+++ b/cmd/cli/application_web.go
@@ -62,12 +62,14 @@ const (
 	webDraftTemplateFilesRemoveConstant         = "files_remove"
 	webAuditQueuedChangesRequiredConstant       = "at least one queued audit change is required"
 	webAuditChangePathRequiredConstant          = "audit change path is required"
+	webAuditChangePathAbsoluteRequiredConstant  = "audit change path must be absolute"
 	webAuditChangeDeleteRejectedConstant        = "delete_folder requires confirm_delete"
 	webAuditChangeDeleteRootRejectedConstant    = "delete_folder does not allow deleting filesystem roots"
 	webAuditChangeProtocolMissingConstant       = "convert_protocol requires source_protocol and target_protocol"
 	webAuditChangeSyncStrategyTemplateConstant  = "unsupported sync strategy %q"
 	webAuditChangeKindTemplateConstant          = "unsupported audit change kind %q"
 	webAuditChangeStatusSucceededConstant       = "succeeded"
+	webAuditChangeStatusSkippedConstant         = "skipped"
 	webAuditChangeStatusFailedConstant          = "failed"
 )
 
@@ -313,6 +315,7 @@ func (application *Application) applyWebAuditChange(executionContext context.Con
 	errorBuffer := &bytes.Buffer{}
 
 	applyError := error(nil)
+	executionOutcome := workflow.ExecutionOutcome{}
 	message := ""
 
 	switch change.Kind {
@@ -330,7 +333,6 @@ func (application *Application) applyWebAuditChange(executionContext context.Con
 			break
 		}
 		_, _ = fmt.Fprintf(outputBuffer, "DELETED: %s\n", normalizedPath)
-		message = "Folder deleted"
 	default:
 		dependencies, dependencyError := application.webTaskRunnerDependencies(outputBuffer, errorBuffer)
 		if dependencyError != nil {
@@ -338,22 +340,27 @@ func (application *Application) applyWebAuditChange(executionContext context.Con
 			break
 		}
 
-		applyError = executeWebAuditWorkflowChange(executionContext, dependencies.Workflow, normalizedPath, change)
-		message = webAuditChangeMessage(change.Kind)
+		executionOutcome, applyError = executeWebAuditWorkflowChange(executionContext, dependencies.Workflow, normalizedPath, change)
 	}
 
 	result.Stdout = outputBuffer.String()
 	result.Stderr = errorBuffer.String()
-	if len(message) > 0 {
-		result.Message = message
-	}
-	if applyError != nil {
+	result.Status = webAuditChangeResultStatus(executionOutcome, applyError)
+	if result.Status == webAuditChangeStatusFailedConstant {
 		result.Status = webAuditChangeStatusFailedConstant
 		result.Error = applyError.Error()
 		return result
 	}
 
-	result.Status = webAuditChangeStatusSucceededConstant
+	if result.Status == webAuditChangeStatusSkippedConstant {
+		message = webAuditChangeSkippedMessage(change.Kind)
+	} else {
+		message = webAuditChangeMessage(change.Kind)
+	}
+	if len(message) > 0 {
+		result.Message = message
+	}
+
 	return result
 }
 
@@ -473,7 +480,7 @@ func executeWebAuditWorkflowChange(
 	dependencies workflow.Dependencies,
 	repositoryPath string,
 	change web.AuditQueuedChange,
-) error {
+) (workflow.ExecutionOutcome, error) {
 	switch change.Kind {
 	case web.AuditChangeKindRenameFolder:
 		return executeWebAuditOperation(
@@ -495,11 +502,11 @@ func executeWebAuditWorkflowChange(
 	case web.AuditChangeKindConvertProtocol:
 		sourceProtocol, sourceError := shared.ParseRemoteProtocol(change.SourceProtocol)
 		if sourceError != nil {
-			return errors.New(webAuditChangeProtocolMissingConstant)
+			return workflow.ExecutionOutcome{}, errors.New(webAuditChangeProtocolMissingConstant)
 		}
 		targetProtocol, targetError := shared.ParseRemoteProtocol(change.TargetProtocol)
 		if targetError != nil {
-			return errors.New(webAuditChangeProtocolMissingConstant)
+			return workflow.ExecutionOutcome{}, errors.New(webAuditChangeProtocolMissingConstant)
 		}
 		return executeWebAuditOperation(
 			executionContext,
@@ -513,7 +520,7 @@ func executeWebAuditWorkflowChange(
 	case web.AuditChangeKindSyncWithRemote:
 		taskDefinition, taskDefinitionError := webAuditSyncTaskDefinition(change.SyncStrategy)
 		if taskDefinitionError != nil {
-			return taskDefinitionError
+			return workflow.ExecutionOutcome{}, taskDefinitionError
 		}
 		return executeWebAuditTasks(
 			executionContext,
@@ -522,7 +529,7 @@ func executeWebAuditWorkflowChange(
 			[]workflow.TaskDefinition{taskDefinition},
 		)
 	default:
-		return fmt.Errorf(webAuditChangeKindTemplateConstant, change.Kind)
+		return workflow.ExecutionOutcome{}, fmt.Errorf(webAuditChangeKindTemplateConstant, change.Kind)
 	}
 }
 
@@ -531,9 +538,9 @@ func executeWebAuditOperation(
 	dependencies workflow.Dependencies,
 	repositoryPath string,
 	operation workflow.Operation,
-) error {
+) (workflow.ExecutionOutcome, error) {
 	executor := workflow.NewExecutor([]workflow.Operation{operation}, dependencies)
-	_, executionError := executor.Execute(
+	return executor.Execute(
 		executionContext,
 		[]string{repositoryPath},
 		workflow.RuntimeOptions{
@@ -541,7 +548,6 @@ func executeWebAuditOperation(
 			WorkflowParallelism: 1,
 		},
 	)
-	return executionError
 }
 
 func executeWebAuditTasks(
@@ -549,9 +555,9 @@ func executeWebAuditTasks(
 	dependencies workflow.Dependencies,
 	repositoryPath string,
 	definitions []workflow.TaskDefinition,
-) error {
+) (workflow.ExecutionOutcome, error) {
 	runner := workflow.NewTaskRunner(dependencies)
-	_, executionError := runner.Run(
+	return runner.Run(
 		executionContext,
 		[]string{repositoryPath},
 		definitions,
@@ -560,7 +566,6 @@ func executeWebAuditTasks(
 			WorkflowParallelism: 1,
 		},
 	)
-	return executionError
 }
 
 func webAuditSyncTaskDefinition(syncStrategy string) (workflow.TaskDefinition, error) {
@@ -608,6 +613,47 @@ func webAuditChangeMessage(kind web.AuditChangeKind) string {
 	}
 }
 
+func webAuditChangeSkippedMessage(kind web.AuditChangeKind) string {
+	switch kind {
+	case web.AuditChangeKindRenameFolder:
+		return "Rename folder skipped"
+	case web.AuditChangeKindUpdateCanonical:
+		return "Canonical remote update skipped"
+	case web.AuditChangeKindConvertProtocol:
+		return "Remote protocol update skipped"
+	case web.AuditChangeKindSyncWithRemote:
+		return "Repository synchronization skipped"
+	case web.AuditChangeKindDeleteFolder:
+		return "Folder deletion skipped"
+	default:
+		return ""
+	}
+}
+
+func webAuditChangeResultStatus(executionOutcome workflow.ExecutionOutcome, executionError error) string {
+	if executionError != nil {
+		return webAuditChangeStatusFailedConstant
+	}
+	if webAuditExecutionOutcomeContainsStepOutcome(executionOutcome, webAuditChangeStatusSkippedConstant) {
+		return webAuditChangeStatusSkippedConstant
+	}
+	return webAuditChangeStatusSucceededConstant
+}
+
+func webAuditExecutionOutcomeContainsStepOutcome(executionOutcome workflow.ExecutionOutcome, outcomeLabel string) bool {
+	if len(outcomeLabel) == 0 {
+		return false
+	}
+
+	for _, stepOutcomeCounts := range executionOutcome.ReporterSummaryData.StepOutcomeCounts {
+		if stepOutcomeCounts[outcomeLabel] > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 func cmpWebAuditChangePriority(left web.AuditChangeKind, right web.AuditChangeKind) int {
 	return webAuditChangePriority(left) - webAuditChangePriority(right)
 }
@@ -634,7 +680,11 @@ func normalizeWebAuditChangePath(rawPath string) (string, error) {
 	if len(trimmedPath) == 0 {
 		return "", errors.New(webAuditChangePathRequiredConstant)
 	}
-	return filepath.Clean(trimmedPath), nil
+	cleanPath := filepath.Clean(trimmedPath)
+	if !filepath.IsAbs(cleanPath) {
+		return "", errors.New(webAuditChangePathAbsoluteRequiredConstant)
+	}
+	return cleanPath, nil
 }
 
 func auditInspectionReportRow(inspection audit.RepositoryInspection) audit.AuditReportRow {

--- a/cmd/cli/application_web.go
+++ b/cmd/cli/application_web.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -260,9 +261,14 @@ func (application *Application) newWebAuditChangeExecutor() web.AuditChangeExecu
 			return web.AuditChangeApplyResponse{Error: webAuditQueuedChangesRequiredConstant}
 		}
 
-		results := make([]web.AuditChangeApplyResult, 0, len(request.Changes))
-		for changeIndex := range request.Changes {
-			results = append(results, application.applyWebAuditChange(executionContext, request.Changes[changeIndex]))
+		changes := append([]web.AuditQueuedChange(nil), request.Changes...)
+		slices.SortStableFunc(changes, func(left web.AuditQueuedChange, right web.AuditQueuedChange) int {
+			return cmpWebAuditChangePriority(left.Kind, right.Kind)
+		})
+
+		results := make([]web.AuditChangeApplyResult, 0, len(changes))
+		for changeIndex := range changes {
+			results = append(results, application.applyWebAuditChange(executionContext, changes[changeIndex]))
 		}
 
 		return web.AuditChangeApplyResponse{Results: results}
@@ -599,6 +605,27 @@ func webAuditChangeMessage(kind web.AuditChangeKind) string {
 		return "Folder deleted"
 	default:
 		return ""
+	}
+}
+
+func cmpWebAuditChangePriority(left web.AuditChangeKind, right web.AuditChangeKind) int {
+	return webAuditChangePriority(left) - webAuditChangePriority(right)
+}
+
+func webAuditChangePriority(kind web.AuditChangeKind) int {
+	switch kind {
+	case web.AuditChangeKindUpdateCanonical:
+		return 10
+	case web.AuditChangeKindConvertProtocol:
+		return 20
+	case web.AuditChangeKindSyncWithRemote:
+		return 30
+	case web.AuditChangeKindRenameFolder:
+		return 40
+	case web.AuditChangeKindDeleteFolder:
+		return 50
+	default:
+		return 100
 	}
 }
 

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -38,7 +38,11 @@ const (
 	auditQueueApplySelectorConstant       = "#audit-queue-apply"
 	auditQueueDeleteSelectorConstant      = "[data-audit-action='delete_folder']"
 	auditQueueDeleteConfirmSelector       = "[data-queue-confirm-delete]"
+	auditQueueProtocolSelectorConstant    = "[data-audit-action='convert_protocol']"
 	auditQueueRenameSelectorConstant      = "[data-audit-action='rename_folder']"
+	auditQueueSyncSelectorConstant        = "[data-audit-action='sync_with_remote']"
+	auditQueueTargetProtocolSelector      = "[data-queue-target-protocol]"
+	auditQueueSyncStrategySelector        = "[data-queue-sync-strategy]"
 	branchTaskButtonSelectorConstant      = "#task-branch"
 	filesTaskButtonSelectorConstant       = "#task-files"
 	remotesTaskButtonSelectorConstant     = "#task-remotes"
@@ -417,6 +421,133 @@ func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing
 	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
 	require.NoError(t, auditSummaryError)
 	require.Equal(t, "0 rows", auditSummary)
+}
+
+func TestWebInterfaceBrowserQueuesProtocolAndSyncChangesWithEditableOptions(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	protocolUpdated := false
+	syncUpdated := false
+	httpServer, repositoryCatalog := newBrowserTestServerWithAuditHandlers(
+		t,
+		repositoryPath,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			remoteProtocol := "https"
+			inSyncStatus := "no"
+			if protocolUpdated {
+				remoteProtocol = "ssh"
+			}
+			if syncUpdated {
+				inSyncStatus = "yes"
+			}
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            "yes",
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "feature/demo",
+						InSync:                 inSyncStatus,
+						RemoteProtocol:         remoteProtocol,
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			require.Len(t, request.Changes, 2)
+
+			for _, change := range request.Changes {
+				switch change.Kind {
+				case web.AuditChangeKindConvertProtocol:
+					require.Equal(t, "https", change.SourceProtocol)
+					require.Equal(t, "ssh", change.TargetProtocol)
+					protocolUpdated = true
+				case web.AuditChangeKindSyncWithRemote:
+					require.Equal(t, web.AuditChangeSyncStrategyStashChanges, change.SyncStrategy)
+					syncUpdated = true
+				default:
+					t.Fatalf("unexpected change kind %s", change.Kind)
+				}
+			}
+
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "change applied",
+					},
+					{
+						ID:      request.Changes[1].ID,
+						Kind:    request.Changes[1].Kind,
+						Path:    request.Changes[1].Path,
+						Status:  "succeeded",
+						Message: "change applied",
+					},
+				},
+			}
+		},
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueProtocolSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueSyncSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditQueuePanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditQueueTargetProtocolSelector, "ssh"),
+		setControlValue(auditQueueSyncStrategySelector, web.AuditChangeSyncStrategyStashChanges),
+	))
+
+	queueSummary, queueSummaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+	require.NoError(t, queueSummaryError)
+	require.Equal(t, "2 pending changes", queueSummary)
+
+	queueText, queueTextError := readTextContent(browserContext, auditQueueListSelectorConstant)
+	require.NoError(t, queueTextError)
+	require.Contains(t, queueText, "Fix protocol")
+	require.Contains(t, queueText, "Sync with remote")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		summaryText, summaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+		if summaryError != nil {
+			return false
+		}
+		return summaryText == "0 pending changes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, "ssh")
+	require.Contains(t, auditResultsText, "yes")
 }
 
 func TestWebInterfaceBrowserPrefillsRemoteAndWorkflowTasksAcrossRepositoryScope(t *testing.T) {

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -36,6 +36,8 @@ const (
 	auditQueueSummarySelectorConstant     = "#audit-queue-summary"
 	auditQueueListSelectorConstant        = "#audit-queue-list"
 	auditQueueApplySelectorConstant       = "#audit-queue-apply"
+	auditQueueDeleteSelectorConstant      = "[data-audit-action='delete_folder']"
+	auditQueueDeleteConfirmSelector       = "[data-queue-confirm-delete]"
 	auditQueueRenameSelectorConstant      = "[data-audit-action='rename_folder']"
 	branchTaskButtonSelectorConstant      = "#task-branch"
 	filesTaskButtonSelectorConstant       = "#task-files"
@@ -303,6 +305,118 @@ func TestWebInterfaceBrowserQueuesRenameChangeAndAppliesIt(t *testing.T) {
 	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
 	require.NoError(t, auditResultsError)
 	require.Contains(t, auditResultsText, "yes")
+}
+
+func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	deleteApplied := false
+	httpServer, repositoryCatalog := newBrowserTestServerWithAuditHandlers(
+		t,
+		repositoryPath,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			rows := []web.AuditInspectionRow{
+				{
+					Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+					FolderName:             "example",
+					IsGitRepository:        true,
+					FinalGitHubRepository:  "canonical/example",
+					OriginRemoteStatus:     "configured",
+					NameMatches:            "yes",
+					RemoteDefaultBranch:    "main",
+					LocalBranch:            "main",
+					InSync:                 "yes",
+					RemoteProtocol:         "https",
+					OriginMatchesCanonical: "yes",
+					WorktreeDirty:          "no",
+					DirtyFiles:             "",
+				},
+			}
+			if deleteApplied {
+				rows = nil
+			}
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows:  rows,
+			}
+		},
+		func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			require.Len(t, request.Changes, 1)
+			require.Equal(t, web.AuditChangeKindDeleteFolder, request.Changes[0].Kind)
+			require.True(t, request.Changes[0].ConfirmDelete)
+			deleteApplied = true
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "delete applied",
+					},
+				},
+			}
+		},
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueDeleteSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditQueuePanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	queueSummary, queueSummaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+	require.NoError(t, queueSummaryError)
+	require.Equal(t, "1 pending change", queueSummary)
+
+	queueText, queueTextError := readTextContent(browserContext, auditQueueListSelectorConstant)
+	require.NoError(t, queueTextError)
+	require.Contains(t, queueText, "Delete folder")
+	require.Contains(t, queueText, auditCustomRootValueConstant)
+
+	applyDisabled, applyDisabledError := readDisabledState(browserContext, auditQueueApplySelectorConstant)
+	require.NoError(t, applyDisabledError)
+	require.True(t, applyDisabled)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setCheckboxValue(auditQueueDeleteConfirmSelector, true),
+	))
+
+	require.Eventually(t, func() bool {
+		disabled, disabledError := readDisabledState(browserContext, auditQueueApplySelectorConstant)
+		if disabledError != nil {
+			return false
+		}
+		return !disabled
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		summaryText, summaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+		if summaryError != nil {
+			return false
+		}
+		return summaryText == "0 pending changes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
+	require.NoError(t, auditSummaryError)
+	require.Equal(t, "0 rows", auditSummary)
 }
 
 func TestWebInterfaceBrowserPrefillsRemoteAndWorkflowTasksAcrossRepositoryScope(t *testing.T) {
@@ -623,6 +737,16 @@ func readValue(browserContext context.Context, selector string) (string, error) 
 	var controlValue string
 	actionError := chromedp.Run(browserContext, chromedp.Value(selector, &controlValue, chromedp.ByQuery))
 	return controlValue, actionError
+}
+
+func readDisabledState(browserContext context.Context, selector string) (bool, error) {
+	var disabled bool
+	script := fmt.Sprintf(`(() => {
+		const element = document.querySelector(%q);
+		return element ? Boolean(element.disabled) : false;
+	})()`, selector)
+	actionError := chromedp.Run(browserContext, chromedp.Evaluate(script, &disabled))
+	return disabled, actionError
 }
 
 func setControlValue(selector string, value string) chromedp.Action {

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -311,6 +311,116 @@ func TestWebInterfaceBrowserQueuesRenameChangeAndAppliesIt(t *testing.T) {
 	require.Contains(t, auditResultsText, "yes")
 }
 
+func TestWebInterfaceBrowserAppliesQueueUsingLastInspectedScope(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	renameQueued := false
+	alternateRoot := "/tmp/browser-audit-root-alternate"
+	httpServer, repositoryCatalog := newBrowserTestServerWithAuditHandlers(
+		t,
+		repositoryPath,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			if len(request.Roots) == 1 && request.Roots[0] == alternateRoot {
+				return web.AuditInspectionResponse{
+					Roots: request.Roots,
+					Rows: []web.AuditInspectionRow{
+						{
+							Path:                   filepath.Join(alternateRoot, "other"),
+							FolderName:             "other",
+							IsGitRepository:        true,
+							FinalGitHubRepository:  "canonical/other",
+							OriginRemoteStatus:     "configured",
+							NameMatches:            "no",
+							RemoteDefaultBranch:    "main",
+							LocalBranch:            "main",
+							InSync:                 "yes",
+							RemoteProtocol:         "https",
+							OriginMatchesCanonical: "yes",
+							WorktreeDirty:          "no",
+							DirtyFiles:             "",
+						},
+					},
+				}
+			}
+
+			nameMatchStatus := "no"
+			if renameQueued {
+				nameMatchStatus = "yes"
+			}
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(auditCustomRootValueConstant, "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            nameMatchStatus,
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "main",
+						InSync:                 "yes",
+						RemoteProtocol:         "https",
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		func(_ context.Context, request web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			require.Len(t, request.Changes, 1)
+			require.Equal(t, web.AuditChangeKindRenameFolder, request.Changes[0].Kind)
+			renameQueued = true
+			return web.AuditChangeApplyResponse{
+				Results: []web.AuditChangeApplyResult{
+					{
+						ID:      request.Changes[0].ID,
+						Kind:    request.Changes[0].Kind,
+						Path:    request.Changes[0].Path,
+						Status:  "succeeded",
+						Message: "rename applied",
+					},
+				},
+			}
+		},
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(auditRootsInputSelectorConstant, auditCustomRootValueConstant),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditQueueRenameSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditQueuePanelSelectorConstant, chromedp.ByQuery),
+		setControlValue(auditRootsInputSelectorConstant, alternateRoot),
+		chromedp.Click(auditQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		summaryText, summaryError := readTextContent(browserContext, auditQueueSummarySelectorConstant)
+		if summaryError != nil {
+			return false
+		}
+		return summaryText == "0 pending changes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, auditCustomRootValueConstant)
+	require.Contains(t, auditResultsText, "yes")
+	require.NotContains(t, auditResultsText, alternateRoot)
+}
+
 func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing.T) {
 	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
 

--- a/cmd/cli/application_web_test.go
+++ b/cmd/cli/application_web_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,7 +16,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tyemirov/gix/internal/repos/shared"
 	"github.com/tyemirov/gix/internal/web"
+	"github.com/tyemirov/gix/internal/workflow"
 )
 
 func TestExecuteWithOptionsVersionFlagWritesToProvidedOutput(t *testing.T) {
@@ -424,6 +427,41 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 	require.Contains(t, finalRun.StandardOutput, "gix version: v4.5.6")
 	require.Empty(t, finalRun.StandardError)
 	require.Empty(t, finalRun.Error)
+}
+
+func TestWebAuditChangeExecutorRejectsRelativePaths(t *testing.T) {
+	application := NewApplication()
+	response := application.newWebAuditChangeExecutor()(context.Background(), web.AuditChangeApplyRequest{
+		Changes: []web.AuditQueuedChange{
+			{
+				ID:            "chg-001",
+				Kind:          web.AuditChangeKindDeleteFolder,
+				Path:          "../sibling",
+				ConfirmDelete: true,
+			},
+		},
+	})
+
+	require.Empty(t, response.Error)
+	require.Len(t, response.Results, 1)
+	require.Equal(t, "failed", response.Results[0].Status)
+	require.Contains(t, response.Results[0].Error, "absolute")
+}
+
+func TestWebAuditChangeResultStatusMarksSkippedOutcomes(t *testing.T) {
+	outcome := workflow.ExecutionOutcome{
+		ReporterSummaryData: shared.SummaryData{
+			StepOutcomeCounts: map[string]map[string]int{
+				"audit-sync": {
+					"skipped": 1,
+				},
+			},
+		},
+	}
+
+	require.Equal(t, webAuditChangeStatusSkippedConstant, webAuditChangeResultStatus(outcome, nil))
+	require.Equal(t, webAuditChangeStatusSucceededConstant, webAuditChangeResultStatus(workflow.ExecutionOutcome{}, nil))
+	require.Equal(t, webAuditChangeStatusFailedConstant, webAuditChangeResultStatus(workflow.ExecutionOutcome{}, errors.New("boom")))
 }
 
 func catalogContainsCommand(catalog web.CommandCatalog, commandPath string) bool {

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -104,6 +104,13 @@
 /**
  * @typedef {{
  *   roots?: string[],
+ *   include_all?: boolean,
+ * }} AuditInspectionRequest
+ */
+
+/**
+ * @typedef {{
+ *   roots?: string[],
  *   rows?: AuditInspectionRow[],
  *   error?: string,
  * }} AuditInspectionResponse
@@ -239,6 +246,7 @@ const auditSyncStrategyRequireCleanValue = "require_clean";
 const auditSyncStrategyStashChangesValue = "stash_changes";
 const auditSyncStrategyCommitChangesValue = "commit_changes";
 const auditChangeStatusSucceededValue = "succeeded";
+const auditChangeStatusSkippedValue = "skipped";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
   "folder_name",
@@ -847,14 +855,27 @@ async function runAuditTask() {
  * @param {boolean} clearOutput
  */
 async function inspectAuditRoots(clearOutput) {
-  const auditRoots = resolveAuditRoots();
-  if (auditRoots.length === 0) {
+  const inspectionRequest = {
+    roots: resolveAuditRoots(),
+    include_all: Boolean(elements.auditIncludeAll.checked),
+  };
+  if ((inspectionRequest.roots || []).length === 0) {
     hideAuditResults();
     clearPolling();
     renderRunError("Enter at least one audit root or choose a repository scope to inspect.");
     setStatus("failed");
     return;
   }
+
+  await inspectAuditRequest(inspectionRequest, clearOutput);
+}
+
+/**
+ * @param {AuditInspectionRequest} inspectionRequest
+ * @param {boolean} clearOutput
+ */
+async function inspectAuditRequest(inspectionRequest, clearOutput) {
+  const auditRoots = (inspectionRequest.roots || []).slice();
 
   clearPolling();
   hideAuditResults();
@@ -872,7 +893,7 @@ async function inspectAuditRoots(clearOutput) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         roots: auditRoots,
-        include_all: Boolean(elements.auditIncludeAll.checked),
+        include_all: Boolean(inspectionRequest.include_all),
       }),
     });
     if (!response.ok) {
@@ -886,6 +907,8 @@ async function inspectAuditRoots(clearOutput) {
       throw new Error(inspection.error);
     }
 
+    state.auditInspectionRoots = auditRoots;
+    state.auditInspectionIncludeAll = Boolean(inspectionRequest.include_all);
     renderTypedAuditResults(inspection);
     setStatus("succeeded");
   } catch (error) {
@@ -2203,9 +2226,7 @@ function renderRunAuditResults(snapshot) {
  * @param {AuditInspectionResponse} inspection
  */
 function renderTypedAuditResults(inspection) {
-  state.auditInspectionRoots = (inspection.roots || []).slice();
   state.auditInspectionRows = (inspection.rows || []).slice();
-  state.auditInspectionIncludeAll = Boolean(elements.auditIncludeAll.checked);
   state.auditQueueVisible = true;
 
   renderTypedAuditTable(state.auditInspectionRows);
@@ -2772,12 +2793,18 @@ async function applyAuditQueue() {
     state.auditQueue = state.auditQueue.filter((change) => !succeededIDs.has(change.id));
 
     if (state.auditInspectionRoots.length > 0) {
-      await inspectAuditRoots(false);
+      await inspectAuditRequest(
+        {
+          roots: state.auditInspectionRoots.slice(),
+          include_all: state.auditInspectionIncludeAll,
+        },
+        false,
+      );
     }
 
     const failedResults = results.filter((result) => result.status !== auditChangeStatusSucceededValue);
     if (failedResults.length > 0) {
-      renderRunError(failedResults.map((result) => result.error || `${result.kind} failed for ${result.path}`).join("\n"));
+      renderRunError(failedResults.map(formatAuditApplyIssue).join("\n"));
       setStatus("failed");
     } else {
       setStatus("succeeded");
@@ -2830,6 +2857,20 @@ function renderAuditApplyResults(results) {
 
   elements.stdoutOutput.textContent = stdoutSections.join("\n\n");
   elements.stderrOutput.textContent = stderrSections.join("\n\n");
+}
+
+/**
+ * @param {AuditChangeApplyResult} result
+ * @returns {string}
+ */
+function formatAuditApplyIssue(result) {
+  if (result.error) {
+    return result.error;
+  }
+  if (result.status === auditChangeStatusSkippedValue) {
+    return `${formatAuditChangeKind(result.kind)} skipped for ${result.path}`;
+  }
+  return `${formatAuditChangeKind(result.kind)} failed for ${result.path}`;
 }
 
 /**

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -232,6 +232,7 @@ const commandPathWorkflowValue = "gix workflow";
 const auditCommandNameValue = "audit";
 const auditChangeKindRenameFolderValue = "rename_folder";
 const auditChangeKindUpdateCanonicalValue = "update_remote_canonical";
+const auditChangeKindDeleteFolderValue = "delete_folder";
 const auditChangeStatusSucceededValue = "succeeded";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
@@ -561,6 +562,7 @@ function bindEvents() {
   elements.auditIncludeAll.addEventListener("change", handleAuditDraftChange);
   elements.auditResultsBody.addEventListener("click", handleAuditResultsClick);
   elements.auditQueueList.addEventListener("click", handleAuditQueueListClick);
+  elements.auditQueueList.addEventListener("change", handleAuditQueueListChange);
   elements.auditQueueClear.addEventListener("click", clearAuditQueue);
   elements.auditQueueApply.addEventListener("click", () => {
     void applyAuditQueue();
@@ -2430,43 +2432,87 @@ function handleAuditQueueListClick(event) {
 }
 
 /**
+ * @param {Event} event
+ */
+function handleAuditQueueListChange(event) {
+  const eventTarget = event.target;
+  if (!(eventTarget instanceof HTMLElement)) {
+    return;
+  }
+
+  const deleteCheckbox = eventTarget.closest("[data-queue-confirm-delete]");
+  if (!(deleteCheckbox instanceof HTMLInputElement)) {
+    return;
+  }
+
+  const changeID = deleteCheckbox.dataset.queueConfirmDelete || "";
+  if (!changeID) {
+    return;
+  }
+
+  state.auditQueue = state.auditQueue.map((change) => {
+    if (change.id !== changeID) {
+      return change;
+    }
+    return {
+      ...change,
+      confirm_delete: deleteCheckbox.checked,
+    };
+  });
+  renderRunError("");
+  renderAuditQueue();
+}
+
+/**
  * @param {AuditInspectionRow} row
  * @returns {AuditRowActionDefinition[]}
  */
 function buildAuditRowActions(row) {
   /** @type {AuditRowActionDefinition[]} */
   const actions = [];
-  if (!row.is_git_repository) {
-    return actions;
-  }
-
-  if (row.name_matches === "no") {
-    actions.push({
-      kind: auditChangeKindRenameFolderValue,
-      label: "Queue rename",
-      title: "Rename folder",
-      description: row.final_github_repo && row.final_github_repo !== "n/a"
-        ? `Rename the folder to match ${row.final_github_repo}.`
-        : "Rename the folder to match the audited repository name.",
-      buildChange: () => ({
+  if (row.is_git_repository) {
+    if (row.name_matches === "no") {
+      actions.push({
         kind: auditChangeKindRenameFolderValue,
-        path: row.path,
-        require_clean: true,
-      }),
-    });
+        label: "Queue rename",
+        title: "Rename folder",
+        description: row.final_github_repo && row.final_github_repo !== "n/a"
+          ? `Rename the folder to match ${row.final_github_repo}.`
+          : "Rename the folder to match the audited repository name.",
+        buildChange: () => ({
+          kind: auditChangeKindRenameFolderValue,
+          path: row.path,
+          require_clean: true,
+        }),
+      });
+    }
+
+    if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
+      actions.push({
+        kind: auditChangeKindUpdateCanonicalValue,
+        label: "Queue remote fix",
+        title: "Fix canonical remote",
+        description: row.final_github_repo && row.final_github_repo !== "n/a"
+          ? `Update origin to the canonical repository ${row.final_github_repo}.`
+          : "Update origin to the canonical repository.",
+        buildChange: () => ({
+          kind: auditChangeKindUpdateCanonicalValue,
+          path: row.path,
+        }),
+      });
+    }
   }
 
-  if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
+  if (row.path) {
     actions.push({
-      kind: auditChangeKindUpdateCanonicalValue,
-      label: "Queue remote fix",
-      title: "Fix canonical remote",
-      description: row.final_github_repo && row.final_github_repo !== "n/a"
-        ? `Update origin to the canonical repository ${row.final_github_repo}.`
-        : "Update origin to the canonical repository.",
+      kind: auditChangeKindDeleteFolderValue,
+      label: "Queue delete",
+      title: "Delete folder",
+      description: `Delete ${row.path} from disk from the web audit workspace after explicit confirmation.`,
       buildChange: () => ({
-        kind: auditChangeKindUpdateCanonicalValue,
+        kind: auditChangeKindDeleteFolderValue,
         path: row.path,
+        confirm_delete: false,
       }),
     });
   }
@@ -2491,14 +2537,14 @@ function queueAuditChange(row, action) {
     ...changeDefinition,
   };
 
-  const existingDeleteChange = state.auditQueue.find((change) => change.path === candidate.path && change.kind === "delete_folder");
-  if (existingDeleteChange && candidate.kind !== "delete_folder") {
+  const existingDeleteChange = state.auditQueue.find((change) => change.path === candidate.path && change.kind === auditChangeKindDeleteFolderValue);
+  if (existingDeleteChange && candidate.kind !== auditChangeKindDeleteFolderValue) {
     renderRunError(`Delete folder is already queued for ${candidate.path}. Remove it before adding another fix.`);
     return;
   }
 
   const existingIndex = state.auditQueue.findIndex((change) => change.path === candidate.path && change.kind === candidate.kind);
-  if (candidate.kind === "delete_folder" && state.auditQueue.some((change) => change.path === candidate.path && change.kind !== candidate.kind)) {
+  if (candidate.kind === auditChangeKindDeleteFolderValue && state.auditQueue.some((change) => change.path === candidate.path && change.kind !== candidate.kind)) {
     renderRunError(`Remove existing queued fixes for ${candidate.path} before queueing folder deletion.`);
     return;
   }
@@ -2570,16 +2616,24 @@ function renderAuditQueue() {
       appendToken(meta, change.path, "token-context");
 
       container.append(heading, description, meta);
+      const options = renderAuditQueueOptions(change);
+      if (options) {
+        container.append(options);
+      }
       elements.auditQueueList.append(container);
     });
   }
 
   elements.auditQueueClear.disabled = state.auditQueue.length === 0 || state.auditQueueApplying;
-  elements.auditQueueApply.disabled = state.auditQueue.length === 0 || state.auditQueueApplying;
+  elements.auditQueueApply.disabled = state.auditQueue.length === 0 || state.auditQueueApplying || !auditQueueCanApply();
 }
 
 async function applyAuditQueue() {
   if (state.auditQueue.length === 0 || state.auditQueueApplying) {
+    return;
+  }
+  if (!auditQueueCanApply()) {
+    renderRunError("Review the pending changes and complete all required confirmations before applying the queue.");
     return;
   }
 
@@ -2709,9 +2763,55 @@ function formatAuditChangeKind(kind) {
       return "Rename folder";
     case auditChangeKindUpdateCanonicalValue:
       return "Fix canonical remote";
+    case auditChangeKindDeleteFolderValue:
+      return "Delete folder";
     default:
       return kind;
   }
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement | null}
+ */
+function renderAuditQueueOptions(change) {
+  if (change.kind !== auditChangeKindDeleteFolderValue) {
+    return null;
+  }
+
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const warning = document.createElement("p");
+  warning.className = "audit-queue-warning";
+  warning.textContent = "This permanently removes the folder from disk. Confirm before applying.";
+
+  const label = document.createElement("label");
+  label.className = "checkbox-row audit-queue-confirm";
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.checked = Boolean(change.confirm_delete);
+  checkbox.dataset.queueConfirmDelete = change.id;
+
+  const copy = document.createElement("span");
+  copy.textContent = "I understand this deletes the folder permanently";
+
+  label.append(checkbox, copy);
+  container.append(warning, label);
+  return container;
+}
+
+/**
+ * @returns {boolean}
+ */
+function auditQueueCanApply() {
+  return state.auditQueue.every((change) => {
+    if (change.kind === auditChangeKindDeleteFolderValue) {
+      return Boolean(change.confirm_delete);
+    }
+    return true;
+  });
 }
 
 /**

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -232,7 +232,12 @@ const commandPathWorkflowValue = "gix workflow";
 const auditCommandNameValue = "audit";
 const auditChangeKindRenameFolderValue = "rename_folder";
 const auditChangeKindUpdateCanonicalValue = "update_remote_canonical";
+const auditChangeKindConvertProtocolValue = "convert_protocol";
 const auditChangeKindDeleteFolderValue = "delete_folder";
+const auditChangeKindSyncWithRemoteValue = "sync_with_remote";
+const auditSyncStrategyRequireCleanValue = "require_clean";
+const auditSyncStrategyStashChangesValue = "stash_changes";
+const auditSyncStrategyCommitChangesValue = "commit_changes";
 const auditChangeStatusSucceededValue = "succeeded";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
@@ -2442,10 +2447,40 @@ function handleAuditQueueListChange(event) {
 
   const deleteCheckbox = eventTarget.closest("[data-queue-confirm-delete]");
   if (!(deleteCheckbox instanceof HTMLInputElement)) {
+    const renameIncludeOwnerCheckbox = eventTarget.closest("[data-queue-include-owner]");
+    if (renameIncludeOwnerCheckbox instanceof HTMLInputElement) {
+      updateAuditQueueBoolean(renameIncludeOwnerCheckbox.dataset.queueIncludeOwner || "", "include_owner", renameIncludeOwnerCheckbox.checked);
+      return;
+    }
+
+    const renameRequireCleanCheckbox = eventTarget.closest("[data-queue-require-clean]");
+    if (renameRequireCleanCheckbox instanceof HTMLInputElement) {
+      updateAuditQueueBoolean(renameRequireCleanCheckbox.dataset.queueRequireClean || "", "require_clean", renameRequireCleanCheckbox.checked);
+      return;
+    }
+
+    const targetProtocolSelect = eventTarget.closest("[data-queue-target-protocol]");
+    if (targetProtocolSelect instanceof HTMLSelectElement) {
+      updateAuditQueueText(targetProtocolSelect.dataset.queueTargetProtocol || "", "target_protocol", targetProtocolSelect.value);
+      return;
+    }
+
+    const syncStrategySelect = eventTarget.closest("[data-queue-sync-strategy]");
+    if (syncStrategySelect instanceof HTMLSelectElement) {
+      updateAuditQueueText(syncStrategySelect.dataset.queueSyncStrategy || "", "sync_strategy", syncStrategySelect.value);
+    }
     return;
   }
 
-  const changeID = deleteCheckbox.dataset.queueConfirmDelete || "";
+  updateAuditQueueBoolean(deleteCheckbox.dataset.queueConfirmDelete || "", "confirm_delete", deleteCheckbox.checked);
+}
+
+/**
+ * @param {string} changeID
+ * @param {"confirm_delete" | "include_owner" | "require_clean"} fieldName
+ * @param {boolean} fieldValue
+ */
+function updateAuditQueueBoolean(changeID, fieldName, fieldValue) {
   if (!changeID) {
     return;
   }
@@ -2456,7 +2491,30 @@ function handleAuditQueueListChange(event) {
     }
     return {
       ...change,
-      confirm_delete: deleteCheckbox.checked,
+      [fieldName]: fieldValue,
+    };
+  });
+  renderRunError("");
+  renderAuditQueue();
+}
+
+/**
+ * @param {string} changeID
+ * @param {"target_protocol" | "sync_strategy"} fieldName
+ * @param {string} fieldValue
+ */
+function updateAuditQueueText(changeID, fieldName, fieldValue) {
+  if (!changeID) {
+    return;
+  }
+
+  state.auditQueue = state.auditQueue.map((change) => {
+    if (change.id !== changeID) {
+      return change;
+    }
+    return {
+      ...change,
+      [fieldName]: fieldValue,
     };
   });
   renderRunError("");
@@ -2487,6 +2545,21 @@ function buildAuditRowActions(row) {
       });
     }
 
+    if (protocolFixAvailable(row)) {
+      actions.push({
+        kind: auditChangeKindConvertProtocolValue,
+        label: "Queue protocol fix",
+        title: "Fix protocol",
+        description: `Convert origin from ${row.remote_protocol} to a reviewed target protocol.`,
+        buildChange: () => ({
+          kind: auditChangeKindConvertProtocolValue,
+          path: row.path,
+          source_protocol: row.remote_protocol,
+          target_protocol: defaultTargetProtocol(row.remote_protocol),
+        }),
+      });
+    }
+
     if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
       actions.push({
         kind: auditChangeKindUpdateCanonicalValue,
@@ -2498,6 +2571,20 @@ function buildAuditRowActions(row) {
         buildChange: () => ({
           kind: auditChangeKindUpdateCanonicalValue,
           path: row.path,
+        }),
+      });
+    }
+
+    if (row.origin_remote_status === "configured" && row.in_sync === "no" && row.remote_default_branch && row.remote_default_branch !== "n/a") {
+      actions.push({
+        kind: auditChangeKindSyncWithRemoteValue,
+        label: "Queue sync",
+        title: "Sync with remote",
+        description: `Refresh the local repository state against ${row.remote_default_branch} using a reviewed dirty-worktree policy.`,
+        buildChange: () => ({
+          kind: auditChangeKindSyncWithRemoteValue,
+          path: row.path,
+          sync_strategy: auditSyncStrategyRequireCleanValue,
         }),
       });
     }
@@ -2612,7 +2699,7 @@ function renderAuditQueue() {
 
       const meta = document.createElement("div");
       meta.className = "audit-queue-meta";
-      appendToken(meta, change.kind, "token-default");
+      appendToken(meta, formatAuditChangeKind(change.kind), "token-default");
       appendToken(meta, change.path, "token-context");
 
       container.append(heading, description, meta);
@@ -2650,7 +2737,7 @@ async function applyAuditQueue() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        changes: state.auditQueue.map((change) => ({
+        changes: sortAuditQueueForApply(state.auditQueue).map((change) => ({
           id: change.id,
           kind: change.kind,
           path: change.path,
@@ -2761,8 +2848,12 @@ function formatAuditChangeKind(kind) {
   switch (kind) {
     case auditChangeKindRenameFolderValue:
       return "Rename folder";
+    case auditChangeKindConvertProtocolValue:
+      return "Fix protocol";
     case auditChangeKindUpdateCanonicalValue:
       return "Fix canonical remote";
+    case auditChangeKindSyncWithRemoteValue:
+      return "Sync with remote";
     case auditChangeKindDeleteFolderValue:
       return "Delete folder";
     default:
@@ -2775,10 +2866,45 @@ function formatAuditChangeKind(kind) {
  * @returns {HTMLElement | null}
  */
 function renderAuditQueueOptions(change) {
-  if (change.kind !== auditChangeKindDeleteFolderValue) {
-    return null;
+  switch (change.kind) {
+    case auditChangeKindRenameFolderValue:
+      return renderRenameQueueOptions(change);
+    case auditChangeKindConvertProtocolValue:
+      return renderProtocolQueueOptions(change);
+    case auditChangeKindSyncWithRemoteValue:
+      return renderSyncQueueOptions(change);
+    case auditChangeKindDeleteFolderValue:
+      return renderDeleteQueueOptions(change);
+    default:
+      return null;
   }
+}
 
+/**
+ * @returns {boolean}
+ */
+function auditQueueCanApply() {
+  return state.auditQueue.every((change) => {
+    if (change.kind === auditChangeKindDeleteFolderValue) {
+      return Boolean(change.confirm_delete);
+    }
+    if (change.kind === auditChangeKindConvertProtocolValue) {
+      const sourceProtocol = String(change.source_protocol || "").trim();
+      const targetProtocol = String(change.target_protocol || "").trim();
+      return protocolValueAllowed(sourceProtocol) && protocolValueAllowed(targetProtocol) && sourceProtocol !== targetProtocol;
+    }
+    if (change.kind === auditChangeKindSyncWithRemoteValue) {
+      return syncStrategyAllowed(String(change.sync_strategy || ""));
+    }
+    return true;
+  });
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderDeleteQueueOptions(change) {
   const container = document.createElement("div");
   container.className = "audit-queue-options";
 
@@ -2803,15 +2929,209 @@ function renderAuditQueueOptions(change) {
 }
 
 /**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderRenameQueueOptions(change) {
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const heading = document.createElement("div");
+  heading.className = "audit-queue-options-heading";
+  heading.textContent = "Rename options";
+
+  const includeOwnerLabel = document.createElement("label");
+  includeOwnerLabel.className = "checkbox-row audit-queue-confirm";
+
+  const includeOwnerCheckbox = document.createElement("input");
+  includeOwnerCheckbox.type = "checkbox";
+  includeOwnerCheckbox.checked = Boolean(change.include_owner);
+  includeOwnerCheckbox.dataset.queueIncludeOwner = change.id;
+
+  const includeOwnerCopy = document.createElement("span");
+  includeOwnerCopy.textContent = "Include the owner in the destination folder name";
+
+  includeOwnerLabel.append(includeOwnerCheckbox, includeOwnerCopy);
+
+  const requireCleanLabel = document.createElement("label");
+  requireCleanLabel.className = "checkbox-row audit-queue-confirm";
+
+  const requireCleanCheckbox = document.createElement("input");
+  requireCleanCheckbox.type = "checkbox";
+  requireCleanCheckbox.checked = Boolean(change.require_clean);
+  requireCleanCheckbox.dataset.queueRequireClean = change.id;
+
+  const requireCleanCopy = document.createElement("span");
+  requireCleanCopy.textContent = "Require a clean worktree before renaming";
+
+  requireCleanLabel.append(requireCleanCheckbox, requireCleanCopy);
+
+  container.append(heading, includeOwnerLabel, requireCleanLabel);
+  return container;
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderProtocolQueueOptions(change) {
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const heading = document.createElement("div");
+  heading.className = "audit-queue-options-heading";
+  heading.textContent = "Protocol options";
+
+  const source = document.createElement("p");
+  source.className = "audit-queue-option-note";
+  source.textContent = `Current protocol: ${change.source_protocol || "unknown"}`;
+
+  const label = document.createElement("label");
+  label.className = "audit-queue-option-row";
+  label.textContent = "Target protocol";
+
+  const select = document.createElement("select");
+  select.className = "select-input audit-queue-select";
+  select.dataset.queueTargetProtocol = change.id;
+
+  protocolOptionValues().forEach((value) => {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    select.append(option);
+  });
+
+  if (change.target_protocol && protocolValueAllowed(change.target_protocol)) {
+    select.value = change.target_protocol;
+  }
+
+  container.append(heading, source, label, select);
+  return container;
+}
+
+/**
+ * @param {AuditQueueEntry} change
+ * @returns {HTMLElement}
+ */
+function renderSyncQueueOptions(change) {
+  const container = document.createElement("div");
+  container.className = "audit-queue-options";
+
+  const heading = document.createElement("div");
+  heading.className = "audit-queue-options-heading";
+  heading.textContent = "Sync options";
+
+  const label = document.createElement("label");
+  label.className = "audit-queue-option-row";
+  label.textContent = "Dirty-worktree policy";
+
+  const select = document.createElement("select");
+  select.className = "select-input audit-queue-select";
+  select.dataset.queueSyncStrategy = change.id;
+
+  syncStrategyOptions().forEach((optionValue) => {
+    const option = document.createElement("option");
+    option.value = optionValue.value;
+    option.textContent = optionValue.label;
+    select.append(option);
+  });
+
+  const syncStrategy = change.sync_strategy || auditSyncStrategyRequireCleanValue;
+  if (syncStrategyAllowed(syncStrategy)) {
+    select.value = syncStrategy;
+  }
+
+  container.append(heading, label, select);
+  return container;
+}
+
+/**
+ * @param {string} protocolValue
  * @returns {boolean}
  */
-function auditQueueCanApply() {
-  return state.auditQueue.every((change) => {
-    if (change.kind === auditChangeKindDeleteFolderValue) {
-      return Boolean(change.confirm_delete);
-    }
-    return true;
-  });
+function protocolFixAvailableRowValue(protocolValue) {
+  return protocolValueAllowed(protocolValue);
+}
+
+/**
+ * @param {AuditInspectionRow} row
+ * @returns {boolean}
+ */
+function protocolFixAvailable(row) {
+  return row.origin_remote_status === "configured" && protocolFixAvailableRowValue(row.remote_protocol);
+}
+
+/**
+ * @param {string} currentProtocol
+ * @returns {string}
+ */
+function defaultTargetProtocol(currentProtocol) {
+  return currentProtocol === "ssh" ? "https" : "ssh";
+}
+
+/**
+ * @returns {string[]}
+ */
+function protocolOptionValues() {
+  return ["git", "ssh", "https"];
+}
+
+/**
+ * @param {string} protocolValue
+ * @returns {boolean}
+ */
+function protocolValueAllowed(protocolValue) {
+  return protocolOptionValues().includes(protocolValue);
+}
+
+/**
+ * @returns {{ value: string, label: string }[]}
+ */
+function syncStrategyOptions() {
+  return [
+    { value: auditSyncStrategyRequireCleanValue, label: "Require clean worktree" },
+    { value: auditSyncStrategyStashChangesValue, label: "Stash tracked changes" },
+    { value: auditSyncStrategyCommitChangesValue, label: "Commit tracked changes" },
+  ];
+}
+
+/**
+ * @param {string} syncStrategy
+ * @returns {boolean}
+ */
+function syncStrategyAllowed(syncStrategy) {
+  return syncStrategyOptions().some((optionValue) => optionValue.value === syncStrategy);
+}
+
+/**
+ * @param {AuditQueueEntry[]} changes
+ * @returns {AuditQueueEntry[]}
+ */
+function sortAuditQueueForApply(changes) {
+  return changes
+    .slice()
+    .sort((left, right) => auditApplyPriority(left.kind) - auditApplyPriority(right.kind));
+}
+
+/**
+ * @param {string} kind
+ * @returns {number}
+ */
+function auditApplyPriority(kind) {
+  switch (kind) {
+    case auditChangeKindUpdateCanonicalValue:
+      return 10;
+    case auditChangeKindConvertProtocolValue:
+      return 20;
+    case auditChangeKindSyncWithRemoteValue:
+      return 30;
+    case auditChangeKindRenameFolderValue:
+      return 40;
+    case auditChangeKindDeleteFolderValue:
+      return 50;
+    default:
+      return 100;
+  }
 }
 
 /**

--- a/internal/web/ui/assets/styles.css
+++ b/internal/web/ui/assets/styles.css
@@ -896,6 +896,29 @@ h4 {
   border-top: 1px solid rgba(73, 46, 27, 0.12);
 }
 
+.audit-queue-options-heading {
+  margin-bottom: 0.55rem;
+  font-size: 0.84rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.audit-queue-option-note {
+  margin: 0 0 0.65rem;
+  color: var(--text-soft);
+}
+
+.audit-queue-option-row {
+  display: block;
+  margin-top: 0.65rem;
+  color: var(--muted);
+}
+
+.audit-queue-select {
+  margin-top: 0.45rem;
+}
+
 .audit-queue-warning {
   margin: 0 0 0.65rem;
   color: var(--danger);

--- a/internal/web/ui/assets/styles.css
+++ b/internal/web/ui/assets/styles.css
@@ -890,6 +890,17 @@ h4 {
   gap: 0.45rem;
 }
 
+.audit-queue-options {
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid rgba(73, 46, 27, 0.12);
+}
+
+.audit-queue-warning {
+  margin: 0 0 0.65rem;
+  color: var(--danger);
+}
+
 .audit-queue-remove {
   white-space: nowrap;
 }

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -148,8 +148,9 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - [x] Preserve the generic command runner for raw CLI access; the audit workspace should not depend on it for table rendering.
   - [x] Add server/API and browser coverage for user-selected roots and typed audit table rendering.
 
-- [ ] [F005] Audit remediation in the web client must be modeled as a pending change queue before execution.
+- [x] [F005] Audit remediation in the web client must be modeled as a pending change queue before execution.
   Requested on 2026-03-08 while defining follow-up UX after the audit table landed.
+  Resolved on 2026-03-08 by adding a typed pending-change queue to the web audit workspace, surfacing editable per-item options in the queue, and applying queued changes in a deterministic order so path-changing rename operations run after repository-state fixes.
   ### Summary
   Row-level fixes in the browser should never execute immediately. The user wants every remediation action to become a queued pending change first, with explicit review before apply.
 
@@ -160,11 +161,11 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - If the queue is modeled as raw argv strings, the browser will be forced to reverse-engineer conflicts and capabilities from command text. The queue needs typed operations instead.
 
   ### Deliverables
-  - [ ] Define a typed pending-change model shared by web UI and backend execution.
-  - [ ] Add queue operations in the UI: add, edit options, remove, clear, and review.
-  - [ ] Reject or merge conflicting queued operations deterministically.
-  - [ ] Execute queued changes through typed backend handlers or workflow operations rather than ad hoc shell text.
-  - [ ] Re-run audit for affected roots after queue execution and refresh the table from typed results.
+  - [x] Define a typed pending-change model shared by web UI and backend execution.
+  - [x] Add queue operations in the UI: add, edit options, remove, clear, and review.
+  - [x] Reject or merge conflicting queued operations deterministically.
+  - [x] Execute queued changes through typed backend handlers or workflow operations rather than ad hoc shell text.
+  - [x] Re-run audit for affected roots after queue execution and refresh the table from typed results.
 
 - [x] [F006] Audit output must report remote presence explicitly in both CLI and web/API contracts.
   Requested on 2026-03-08 after reviewing how missing remotes appear in audit results.
@@ -198,13 +199,14 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - The queue model from [F005] is a prerequisite because this action must never execute immediately from a table row.
 
   ### Deliverables
-  - [ ] Define a web-only queued delete-folder operation with explicit confirmation requirements.
-  - [ ] Restrict or phase the scope intentionally (for example non-git folders first, then repositories if approved).
-  - [ ] Surface the operation only in the web audit workspace, not in the generic CLI runner.
-  - [ ] Add end-to-end tests that verify deletion is queued first and only applied after explicit confirmation.
+  - [x] Define a web-only queued delete-folder operation with explicit confirmation requirements.
+  - [x] Restrict or phase the scope intentionally (for example non-git folders first, then repositories if approved).
+  - [x] Surface the operation only in the web audit workspace, not in the generic CLI runner.
+  - [x] Add end-to-end tests that verify deletion is queued first and only applied after explicit confirmation.
 
-- [ ] [F008] The web audit queue needs repository sync and protocol-fix actions backed by existing operations.
+- [x] [F008] The web audit queue needs repository sync and protocol-fix actions backed by existing operations.
   Requested on 2026-03-08 as part of the audit remediation UX.
+  Resolved on 2026-03-08 by surfacing queued protocol-fix and sync row actions in the web audit table, adding editable target-protocol and dirty-worktree-policy controls in the queue, and covering the queue/apply/refresh flow with a browser test.
   ### Summary
   The audit table should let operators queue protocol fixes and “sync local with remote” changes directly from mismatched rows.
 
@@ -215,10 +217,10 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - These fixes should refresh audit state after apply so the table becomes the post-change source of truth.
 
   ### Deliverables
-  - [ ] Add queued protocol-fix actions backed by the existing protocol conversion operation.
-  - [ ] Add queued local-sync actions backed by an explicit branch-refresh/change workflow, not default-branch migration.
-  - [ ] Surface per-item options needed for safe execution (branch target, dirty-worktree handling, protocol target).
-  - [ ] Add integration/browser coverage that verifies queueing plus execution updates the table state.
+  - [x] Add queued protocol-fix actions backed by the existing protocol conversion operation.
+  - [x] Add queued local-sync actions backed by an explicit branch-refresh/change workflow, not default-branch migration.
+  - [x] Surface per-item options needed for safe execution (branch target, dirty-worktree handling, protocol target).
+  - [x] Add integration/browser coverage that verifies queueing plus execution updates the table state.
 
 - Update on 2026-03-08 for [F005].
   Implemented the queue foundation without closing the full remediation program.
@@ -240,10 +242,10 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Successful apply results are removed from the pending queue; failed items remain queued.
   - After apply, the web client reruns typed audit inspection for the previously inspected roots so the table reflects post-change state instead of stale pre-apply rows.
 
-  ### Remaining Gaps
-  - The queue UI does not yet expose editable per-item options. Current surfaced row actions use fixed defaults.
-  - The browser currently exposes row actions only for rename and canonical-remote fixes; protocol, sync, and delete execution paths exist on the backend but are intentionally not yet surfaced pending the UX work tracked in [F007] and [F008].
-  - Conflict handling is implemented for same-item replacement and delete exclusivity, but broader merge policy across protocol/sync/remote changes remains part of the remaining [F005]/[F008] work.
+  ### Completion Notes
+  - The queue now exposes editable options for rename, delete, protocol conversion, and sync items.
+  - The browser now surfaces row actions for rename, canonical-remote fixes, protocol fixes, sync, and web-only folder deletion.
+  - Queue application is ordered deterministically so repository-state fixes run before rename and delete, avoiding stale-path execution during multi-step remediation.
 
 
 ## Planning

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -185,8 +185,9 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - [x] Update CLI and integration tests that assert audit CSV headers and rows.
   - [x] Keep current `origin_matches_canonical` semantics for real remotes; do not repurpose it to mean remote absence.
 
-- [ ] [F007] The web audit workspace needs a UX-only folder deletion operation, queued before apply.
+- [x] [F007] The web audit workspace needs a UX-only folder deletion operation, queued before apply.
   Requested on 2026-03-08 as part of the row-action audit UX.
+  Resolved on 2026-03-08 by surfacing a web-only `delete_folder` row action in the audit table, requiring explicit queue confirmation before apply, and covering the queue/apply/refresh flow with a browser test. The current scope intentionally allows deleting any audited folder path from the web queue, including repository folders, while still blocking filesystem-root deletion in the backend.
   ### Summary
   The browser should support deleting a folder directly from the audit workspace, but only as a queued web action rather than a new immediate CLI behavior.
 

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -247,6 +247,25 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - The browser now surfaces row actions for rename, canonical-remote fixes, protocol fixes, sync, and web-only folder deletion.
   - Queue application is ordered deterministically so repository-state fixes run before rename and delete, avoiding stale-path execution during multi-step remediation.
 
+- Update on 2026-03-08 for review follow-up on [F005], [F007], and [F008].
+  Addressed three post-review correctness regressions in the queued web audit flow and locked them with regression coverage before patching.
+  ### Summary
+  The initial queued-remediation implementation had three edge-case failures: apply could refresh the wrong audit scope, workflow-backed changes that reported `skipped` were surfaced as successful, and the apply endpoint accepted relative paths for destructive operations.
+
+  ### Analysis
+  - The browser stored the last successful audit rows, but `applyAuditQueue()` refreshed via `inspectAuditRoots(false)`, which rebuilt the request from the live form and repository catalog. That was incorrect because queued changes semantically belong to the last inspected scope, not whatever the controls happen to contain at apply time.
+  - This mismatch was especially dangerous after path-changing operations. If the operator edited the roots input after queueing, or if the repository catalog was stale relative to rename/delete actions, the table refresh could show an unrelated scope or fail to reflect the just-applied changes.
+  - The Go apply executor treated `nil` workflow errors as unconditional success. That was too optimistic because workflow/task execution already communicates `skipped` outcomes through `workflow.ExecutionOutcome.ReporterSummaryData.StepOutcomeCounts`, and some remediation actions intentionally skip without returning a hard error.
+  - Surfacing `skipped` as `succeeded` caused the browser to drop queued items that had not actually been applied and to report a misleading success state to the operator.
+  - `normalizeWebAuditChangePath` only trimmed and cleaned the submitted path. That allowed relative inputs such as `../sibling` to escape the inspected directory context at the API boundary, which is unacceptable now that `/api/audit/apply` can drive destructive filesystem operations.
+
+  ### Deliverables
+  - [x] Added a browser regression test that queues a rename, mutates the roots input, applies the queue, and verifies the post-apply refresh still uses the last inspected audit scope.
+  - [x] Split audit inspection in the web client into “build request from controls” and “rerun a saved request,” then updated queue apply to re-inspect with `state.auditInspectionRoots` and `state.auditInspectionIncludeAll`.
+  - [x] Added backend regression coverage for relative-path rejection and for mapping workflow execution outcomes to `succeeded` vs `skipped` vs `failed`.
+  - [x] Changed workflow-backed apply execution to derive result status from `workflow.ExecutionOutcome`, preserving skipped items in the queue and avoiding misleading success messages.
+  - [x] Hardened `/api/audit/apply` path normalization so only absolute paths are accepted for queued audit changes.
+
 
 ## Planning
 *do not implement yet*


### PR DESCRIPTION
## Summary
- add a delete-folder row action to the web audit table
- require explicit queue confirmation before delete items can be applied
- cover the queued delete flow in the browser test suite and mark F007 resolved

## Testing
- make format
- make test
- make lint
- make ci