### PR TITLE
Refine web audit workflow and repo browsing

### DIFF
--- a/cmd/cli/application_web.go
+++ b/cmd/cli/application_web.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net"
 	"net/url"
@@ -37,6 +38,7 @@ const (
 	webLaunchModeDiscoveredRepositoriesConstant = "discovered_repositories"
 	webNoRepositoriesErrorTemplateConstant      = "no Git repositories found beneath %s"
 	webRepositoryIDTemplateConstant             = "repo-%03d"
+	webDynamicRepositoryIDTemplateConstant      = "repo-path-%016x"
 	webRepositoryPathRequiredErrorConstant      = "repository path is required"
 	webHelpCommandPathConstant                  = applicationNameConstant + " help"
 	webCompletionCommandPathConstant            = applicationNameConstant + " completion"
@@ -204,14 +206,16 @@ func (application *Application) handleWebLaunch(command *cobra.Command, argument
 	repositoryCatalog := application.repositoryCatalog(executionContext, launchRoots)
 
 	return true, application.webRunner(executionContext, web.ServerOptions{
-		Address:           launchConfiguration.listenAddress(),
-		Repositories:      repositoryCatalog,
-		Catalog:           application.commandCatalog(),
-		LoadBranches:      application.loadRepositoryBranches,
-		BrowseDirectories: application.newWebDirectoryBrowser(),
-		Execute:           application.newWebCommandExecutor(),
-		InspectAudit:      application.newWebAuditInspector(),
-		ApplyAuditChanges: application.newWebAuditChangeExecutor(),
+		Address:                launchConfiguration.listenAddress(),
+		Repositories:           repositoryCatalog,
+		Catalog:                application.commandCatalog(),
+		LoadBranches:           application.loadRepositoryBranches,
+		BrowseDirectories:      application.newWebDirectoryBrowser(),
+		Execute:                application.newWebCommandExecutor(),
+		InspectAudit:           application.newWebAuditInspector(),
+		ApplyAuditChanges:      application.newWebAuditChangeExecutor(),
+		LoadWorkflowPrimitives: application.newWebWorkflowPrimitiveCatalogLoader(),
+		ApplyWorkflowActions:   application.newWebWorkflowPrimitiveExecutor(),
 	})
 }
 
@@ -300,27 +304,68 @@ func (application *Application) newWebCommandExecutor() web.CommandExecutor {
 }
 
 func (application *Application) newWebDirectoryBrowser() web.DirectoryBrowser {
-	return func(_ context.Context, path string) web.DirectoryListing {
+	repositoryDiscoverer := reposdeps.ResolveRepositoryDiscoverer(nil)
+	gitExecutor, repositoryManager, dependencyError := application.webGitDependencies()
+
+	return func(executionContext context.Context, path string) web.DirectoryListing {
 		normalizedPath := canonicalWebPath(path)
 		if len(normalizedPath) == 0 {
 			return web.DirectoryListing{Error: webRepositoryPathRequiredErrorConstant}
 		}
 
-		entries, readError := os.ReadDir(normalizedPath)
-		if readError != nil {
-			return web.DirectoryListing{Path: normalizedPath, Error: readError.Error()}
+		discoveredRepositories, discoverError := repositoryDiscoverer.DiscoverRepositories([]string{normalizedPath})
+		if discoverError != nil {
+			return web.DirectoryListing{Path: normalizedPath, Error: discoverError.Error()}
 		}
 
-		folders := make([]web.FolderDescriptor, 0, len(entries))
-		for _, entry := range entries {
-			if !entry.IsDir() || entry.Name() == webGitMetadataDirectoryNameConstant {
+		folderIndex := make(map[string]int, len(discoveredRepositories))
+		folders := make([]web.FolderDescriptor, 0, len(discoveredRepositories))
+		for _, repositoryPath := range discoveredRepositories {
+			normalizedRepositoryPath := canonicalWebPath(repositoryPath)
+			if normalizedRepositoryPath == normalizedPath {
 				continue
 			}
 
-			folders = append(folders, web.FolderDescriptor{
-				Name: entry.Name(),
-				Path: canonicalWebPath(filepath.Join(normalizedPath, entry.Name())),
-			})
+			relativeRepositoryPath := strings.TrimPrefix(normalizedRepositoryPath, normalizedPath)
+			relativeRepositoryPath = strings.TrimPrefix(relativeRepositoryPath, string(os.PathSeparator))
+			if len(relativeRepositoryPath) == 0 {
+				continue
+			}
+
+			relativeSegments := strings.Split(filepath.ToSlash(relativeRepositoryPath), "/")
+			immediateChildName := strings.TrimSpace(relativeSegments[0])
+			if len(immediateChildName) == 0 || immediateChildName == "." {
+				continue
+			}
+
+			immediateChildPath := canonicalWebPath(filepath.Join(normalizedPath, immediateChildName))
+			folderPosition, folderExists := folderIndex[immediateChildPath]
+			if !folderExists {
+				folderIndex[immediateChildPath] = len(folders)
+				folders = append(folders, web.FolderDescriptor{
+					Name: immediateChildName,
+					Path: immediateChildPath,
+				})
+				folderPosition = len(folders) - 1
+			}
+
+			if len(relativeSegments) != 1 || normalizedRepositoryPath != immediateChildPath {
+				continue
+			}
+
+			repositoryDescriptor := newDynamicWebRepositoryDescriptor(immediateChildPath)
+			if dependencyError != nil {
+				repositoryDescriptor.Error = dependencyError.Error()
+			} else {
+				repositoryDescriptor = application.inspectDynamicRepository(
+					executionContext,
+					immediateChildPath,
+					gitExecutor,
+					repositoryManager,
+				)
+			}
+
+			folders[folderPosition].Repository = &repositoryDescriptor
 		}
 
 		sort.SliceStable(folders, func(first int, second int) bool {
@@ -1004,13 +1049,17 @@ func webAuditChangePriority(kind web.AuditChangeKind) int {
 }
 
 func normalizeWebAuditChangePath(rawPath string) (string, error) {
+	return normalizeWebAbsolutePath(rawPath, webAuditChangePathRequiredConstant, webAuditChangePathAbsoluteRequiredConstant)
+}
+
+func normalizeWebAbsolutePath(rawPath string, missingPathError string, relativePathError string) (string, error) {
 	trimmedPath := strings.TrimSpace(rawPath)
 	if len(trimmedPath) == 0 {
-		return "", errors.New(webAuditChangePathRequiredConstant)
+		return "", errors.New(missingPathError)
 	}
 	cleanPath := filepath.Clean(trimmedPath)
 	if !filepath.IsAbs(cleanPath) {
-		return "", errors.New(webAuditChangePathAbsoluteRequiredConstant)
+		return "", errors.New(relativePathError)
 	}
 	return cleanPath, nil
 }
@@ -1172,12 +1221,41 @@ func (application *Application) inspectRepository(
 	gitExecutor execshellGitExecutor,
 	repositoryManager webGitRepositoryManager,
 ) web.RepositoryDescriptor {
-	descriptor := web.RepositoryDescriptor{
-		ID:             fmt.Sprintf(webRepositoryIDTemplateConstant, repositoryIndex),
-		Name:           filepath.Base(strings.TrimSpace(repositoryPath)),
-		Path:           strings.TrimSpace(repositoryPath),
-		ContextCurrent: contextCurrent,
-	}
+	return application.inspectRepositoryDescriptor(
+		executionContext,
+		repositoryPath,
+		fmt.Sprintf(webRepositoryIDTemplateConstant, repositoryIndex),
+		contextCurrent,
+		gitExecutor,
+		repositoryManager,
+	)
+}
+
+func (application *Application) inspectDynamicRepository(
+	executionContext context.Context,
+	repositoryPath string,
+	gitExecutor execshellGitExecutor,
+	repositoryManager webGitRepositoryManager,
+) web.RepositoryDescriptor {
+	return application.inspectRepositoryDescriptor(
+		executionContext,
+		repositoryPath,
+		dynamicWebRepositoryID(repositoryPath),
+		false,
+		gitExecutor,
+		repositoryManager,
+	)
+}
+
+func (application *Application) inspectRepositoryDescriptor(
+	executionContext context.Context,
+	repositoryPath string,
+	repositoryID string,
+	contextCurrent bool,
+	gitExecutor execshellGitExecutor,
+	repositoryManager webGitRepositoryManager,
+) web.RepositoryDescriptor {
+	descriptor := newWebRepositoryDescriptor(repositoryID, repositoryPath, contextCurrent)
 
 	currentBranch, currentBranchError := repositoryManager.GetCurrentBranch(executionContext, descriptor.Path)
 	if currentBranchError == nil {
@@ -1201,6 +1279,27 @@ func (application *Application) inspectRepository(
 	}
 
 	return descriptor
+}
+
+func newDynamicWebRepositoryDescriptor(repositoryPath string) web.RepositoryDescriptor {
+	return newWebRepositoryDescriptor(dynamicWebRepositoryID(repositoryPath), repositoryPath, false)
+}
+
+func newWebRepositoryDescriptor(repositoryID string, repositoryPath string, contextCurrent bool) web.RepositoryDescriptor {
+	trimmedRepositoryPath := strings.TrimSpace(repositoryPath)
+	return web.RepositoryDescriptor{
+		ID:             strings.TrimSpace(repositoryID),
+		Name:           filepath.Base(trimmedRepositoryPath),
+		Path:           trimmedRepositoryPath,
+		ContextCurrent: contextCurrent,
+	}
+}
+
+func dynamicWebRepositoryID(repositoryPath string) string {
+	normalizedRepositoryPath := canonicalWebPath(repositoryPath)
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(normalizedRepositoryPath))
+	return fmt.Sprintf(webDynamicRepositoryIDTemplateConstant, hasher.Sum64())
 }
 
 func resolveRepositoryDefaultBranch(executionContext context.Context, gitExecutor execshellGitExecutor, repositoryPath string) (string, error) {

--- a/cmd/cli/application_web_browser_test.go
+++ b/cmd/cli/application_web_browser_test.go
@@ -28,78 +28,88 @@ const (
 	browserReadyPollIntervalConstant       = 100 * time.Millisecond
 	repositoryTitleLoadingConstant         = "Loading..."
 
-	auditSelectionBadgeSelectorConstant    = "#audit-selection-badge"
-	auditSelectionSummarySelectorConstant  = "#audit-selection-summary"
-	auditRootsInputSelectorConstant        = "#audit-roots-input"
-	auditIncludeAllSelectorConstant        = "#audit-include-all"
-	auditRunButtonSelectorConstant         = "#task-inspect-load"
-	auditResultsPanelSelectorConstant      = "#audit-results-panel"
-	auditResultsSummarySelectorConstant    = "#audit-results-summary"
-	auditResultsBodySelectorConstant       = "#audit-results-body"
-	auditNameMatchesFilterSelectorConstant = "[data-audit-column-filter='name_matches']"
-	auditQueuePanelSelectorConstant        = "#audit-queue-panel"
-	auditQueueSummarySelectorConstant      = "#audit-queue-summary"
-	auditQueueListSelectorConstant         = "#audit-queue-list"
-	auditQueueApplySelectorConstant        = "#audit-queue-apply"
-	auditQueueDeleteSelectorConstant       = "[data-audit-action='delete_folder']"
-	auditQueueDeleteConfirmSelector        = "[data-queue-confirm-delete]"
-	auditQueueProtocolSelectorConstant     = "[data-audit-action='convert_protocol']"
-	auditQueueRenameSelectorConstant       = "[data-audit-action='rename_folder']"
-	auditQueueSyncSelectorConstant         = "[data-audit-action='sync_with_remote']"
-	auditQueueTargetProtocolSelector       = "[data-queue-target-protocol]"
-	auditQueueSyncStrategySelector         = "[data-queue-sync-strategy]"
-	repoFilterSelectorConstant             = "#repo-filter"
-	repoLaunchSummarySelectorConstant      = "#repo-launch-summary"
-	repoSidebarSelectorConstant            = "#repo-sidebar"
-	repoTreeSelectorConstant               = "#repo-tree"
-	workspaceLayoutSelectorConstant        = "#workspace-layout"
-	workspaceMainSelectorConstant          = "#workspace-main"
-	branchTaskButtonSelectorConstant       = "#task-branch"
-	filesTaskButtonSelectorConstant        = "#task-files"
-	remotesTaskButtonSelectorConstant      = "#task-remotes"
-	workflowsTaskButtonSelectorConstant    = "#task-workflows"
-	advancedTaskButtonSelectorConstant     = "#task-advanced"
-	scopeCheckedButtonSelectorConstant     = "#scope-checked"
-	scopeAllButtonSelectorConstant         = "#scope-all"
-	targetRefModeSelectorConstant          = "#target-ref-mode"
-	targetRefSelectSelectorConstant        = "#target-ref-select"
-	targetPathModeSelectorConstant         = "#target-path-mode"
-	targetPathValueSelectorConstant        = "#target-path-value"
-	fileTaskModeSelectorConstant           = "#file-task-mode"
-	fileFindInputSelectorConstant          = "#file-find-input"
-	fileReplaceInputSelectorConstant       = "#file-replace-input"
-	fileLoadButtonSelectorConstant         = "#task-file-load"
-	remoteOwnerInputSelectorConstant       = "#remote-owner-input"
-	remoteLoadButtonSelectorConstant       = "#task-remote-load"
-	workflowTargetInputSelectorConstant    = "#workflow-target-input"
-	workflowVarsInputSelectorConstant      = "#workflow-vars-input"
-	workflowVarFilesInputSelectorConstant  = "#workflow-var-files-input"
-	workflowWorkersInputSelectorConstant   = "#workflow-workers-input"
-	workflowRequireCleanSelectorConstant   = "#workflow-require-clean"
-	workflowLoadButtonSelectorConstant     = "#task-workflow-load"
-	switchTargetButtonSelectorConstant     = "#action-switch-target"
-	selectedPathSelectorConstant           = "#selected-path"
-	commandGroupsSelectorConstant          = "#command-groups"
-	argumentsInputSelectorConstant         = "#arguments-input"
-	commandPreviewSelectorConstant         = "#command-preview"
-	runCommandSelectorConstant             = "#run-command"
-	auditCommandPathConstant               = "gix audit"
-	branchCommandPathConstant              = "gix cd"
-	filesReplaceCommandPathConstant        = "gix files replace"
-	remoteCanonicalCommandPathConstant     = "gix remote update-to-canonical"
-	workflowCommandPathConstant            = "gix workflow"
-	versionCommandPathConstant             = "gix version"
-	refModeNamedConstant                   = "named"
-	pathModeRelativeConstant               = "relative"
-	fileTaskModeReplaceConstant            = "replace"
-	repositoryReadmePathConstant           = "README.md"
-	replacementFindValueConstant           = "initial"
-	replacementTextValueConstant           = "updated"
-	remoteOwnerValueConstant               = "mprlab"
-	workflowTargetValueConstant            = "configs/proprietary-licensing.yaml"
-	workflowVariableAssignmentConstant     = "license_year=2026"
-	workflowVariableFileConstant           = "./vars.yaml"
-	workflowWorkersValueConstant           = "3"
+	auditSelectionBadgeSelectorConstant      = "#audit-selection-badge"
+	auditSelectionSummarySelectorConstant    = "#audit-selection-summary"
+	auditRootsInputSelectorConstant          = "#audit-roots-input"
+	auditIncludeAllSelectorConstant          = "#audit-include-all"
+	auditRunButtonSelectorConstant           = "#task-inspect-load"
+	auditResultsPanelSelectorConstant        = "#audit-results-panel"
+	auditResultsSummarySelectorConstant      = "#audit-results-summary"
+	auditResultsBodySelectorConstant         = "#audit-results-body"
+	auditNameMatchesFilterSelectorConstant   = "[data-audit-column-filter='name_matches']"
+	auditQueuePanelSelectorConstant          = "#audit-queue-panel"
+	auditQueueSummarySelectorConstant        = "#audit-queue-summary"
+	auditQueueListSelectorConstant           = "#audit-queue-list"
+	auditQueueApplySelectorConstant          = "#audit-queue-apply"
+	auditQueueDeleteSelectorConstant         = "[data-audit-action='delete_folder']"
+	auditQueueDeleteConfirmSelector          = "[data-queue-confirm-delete]"
+	auditQueueProtocolSelectorConstant       = "[data-audit-action='convert_protocol']"
+	auditQueueRenameSelectorConstant         = "[data-audit-action='rename_folder']"
+	auditQueueSyncSelectorConstant           = "[data-audit-action='sync_with_remote']"
+	auditQueueTargetProtocolSelector         = "[data-queue-target-protocol]"
+	auditQueueSyncStrategySelector           = "[data-queue-sync-strategy]"
+	repoFilterSelectorConstant               = "#repo-filter"
+	repoFocusSelectorConstant                = ".repo-focus"
+	repoLaunchSummarySelectorConstant        = "#repo-launch-summary"
+	repoScopeSelectorConstant                = ".repo-scope"
+	repoSidebarSelectorConstant              = "#repo-sidebar"
+	repoTreeSelectorConstant                 = "#repo-tree"
+	queueIntroPanelSelectorConstant          = ".secondary-brand-panel"
+	workspaceLayoutSelectorConstant          = "#workspace-layout"
+	workspaceMainSelectorConstant            = "#workspace-main"
+	branchTaskButtonSelectorConstant         = "#task-branch"
+	filesTaskButtonSelectorConstant          = "#task-files"
+	remotesTaskButtonSelectorConstant        = "#task-remotes"
+	workflowsTaskButtonSelectorConstant      = "#task-workflows"
+	advancedTaskButtonSelectorConstant       = "#task-advanced"
+	fileTaskModeSelectorConstant             = "#file-task-mode"
+	fileFindInputSelectorConstant            = "#file-find-input"
+	fileReplaceInputSelectorConstant         = "#file-replace-input"
+	fileLoadButtonSelectorConstant           = "#task-file-load"
+	remoteOwnerInputSelectorConstant         = "#remote-owner-input"
+	remoteLoadButtonSelectorConstant         = "#task-remote-load"
+	workflowTargetInputSelectorConstant      = "#workflow-target-input"
+	workflowVarsInputSelectorConstant        = "#workflow-vars-input"
+	workflowVarFilesInputSelectorConstant    = "#workflow-var-files-input"
+	workflowWorkersInputSelectorConstant     = "#workflow-workers-input"
+	workflowRequireCleanSelectorConstant     = "#workflow-require-clean"
+	workflowLoadButtonSelectorConstant       = "#task-workflow-load"
+	workflowActionRepoSelectorConstant       = "#workflow-action-repo"
+	workflowPrimitiveSelectSelectorConstant  = "#workflow-primitive-select"
+	workflowPrimitiveSummarySelectorConstant = "#workflow-primitive-summary"
+	workflowPrimitiveFieldsSelectorConstant  = "#workflow-primitive-fields"
+	workflowActionQueueSelectorConstant      = "#workflow-action-queue"
+	workflowQueueSummarySelectorConstant     = "#workflow-queue-summary"
+	workflowQueueListSelectorConstant        = "#workflow-queue-list"
+	workflowQueueApplySelectorConstant       = "#workflow-queue-apply"
+	workflowPatternsSelectorConstant         = "[data-workflow-param-key='patterns']"
+	workflowFindSelectorConstant             = "[data-workflow-param-key='find']"
+	workflowReplaceSelectorConstant          = "[data-workflow-param-key='replace']"
+	switchTargetButtonSelectorConstant       = "#action-switch-target"
+	selectedPathSelectorConstant             = "#selected-path"
+	commandGroupsSelectorConstant            = "#command-groups"
+	argumentsInputSelectorConstant           = "#arguments-input"
+	commandPreviewSelectorConstant           = "#command-preview"
+	runCommandSelectorConstant               = "#run-command"
+	stdoutOutputSelectorConstant             = "#stdout-output"
+	stderrOutputSelectorConstant             = "#stderr-output"
+	auditCommandPathConstant                 = "gix audit"
+	branchCommandPathConstant                = "gix cd"
+	filesReplaceCommandPathConstant          = "gix files replace"
+	remoteCanonicalCommandPathConstant       = "gix remote update-to-canonical"
+	workflowCommandPathConstant              = "gix workflow"
+	versionCommandPathConstant               = "gix version"
+	refModeNamedConstant                     = "named"
+	pathModeRelativeConstant                 = "relative"
+	fileTaskModeReplaceConstant              = "replace"
+	repositoryReadmePathConstant             = "README.md"
+	replacementFindValueConstant             = "initial"
+	replacementTextValueConstant             = "updated"
+	remoteOwnerValueConstant                 = "mprlab"
+	workflowTargetValueConstant              = "configs/proprietary-licensing.yaml"
+	workflowVariableAssignmentConstant       = "license_year=2026"
+	workflowVariableFileConstant             = "./vars.yaml"
+	workflowWorkersValueConstant             = "3"
 )
 
 var browserExecutableCandidates = []string{
@@ -112,9 +122,8 @@ var browserExecutableCandidates = []string{
 	"/opt/google/chrome/chrome",
 }
 
-func TestWebInterfaceBrowserPrefillsBranchAndFileTasks(t *testing.T) {
+func TestWebInterfaceBrowserShowsWorkflowQueueByDefault(t *testing.T) {
 	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
-	createTestBranch(t, repositoryPath, "feature/demo")
 
 	httpServer, repositoryCatalog := newBrowserTestServer(t, repositoryPath)
 	defer httpServer.Close()
@@ -124,53 +133,25 @@ func TestWebInterfaceBrowserPrefillsBranchAndFileTasks(t *testing.T) {
 
 	require.NoError(t, chromedp.Run(browserContext,
 		chromedp.Navigate(httpServer.URL),
-		chromedp.WaitVisible(branchTaskButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(workflowPrimitiveSelectSelectorConstant, chromedp.ByQuery),
 	))
 	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
 
-	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(branchTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(switchTargetButtonSelectorConstant, chromedp.ByQuery),
-		setControlValue(targetRefModeSelectorConstant, refModeNamedConstant),
-		setControlValue(targetRefSelectSelectorConstant, "master"),
-		chromedp.Click(switchTargetButtonSelectorConstant, chromedp.ByQuery),
-	))
+	workflowRepoText, workflowRepoError := readTextContent(browserContext, workflowActionRepoSelectorConstant)
+	require.NoError(t, workflowRepoError)
+	assertTextContainsPath(t, workflowRepoText, repositoryPath)
 
-	assertSelectedCommand(t, browserContext, branchCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"cd",
-		"master",
-		"--roots",
-		expectedRepository.Path,
-	})
+	workflowPrimitiveValue, workflowPrimitiveValueError := readValue(browserContext, workflowPrimitiveSelectSelectorConstant)
+	require.NoError(t, workflowPrimitiveValueError)
+	require.NotEmpty(t, workflowPrimitiveValue)
 
-	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(filesTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(fileLoadButtonSelectorConstant, chromedp.ByQuery),
-		setControlValue(targetRefSelectSelectorConstant, "feature/demo"),
-		setControlValue(targetPathModeSelectorConstant, pathModeRelativeConstant),
-		setControlValue(targetPathValueSelectorConstant, repositoryReadmePathConstant),
-		setControlValue(fileTaskModeSelectorConstant, fileTaskModeReplaceConstant),
-		setControlValue(fileFindInputSelectorConstant, replacementFindValueConstant),
-		setControlValue(fileReplaceInputSelectorConstant, replacementTextValueConstant),
-		chromedp.Click(fileLoadButtonSelectorConstant, chromedp.ByQuery),
-	))
+	queueDisabled, queueDisabledError := readDisabledState(browserContext, workflowActionQueueSelectorConstant)
+	require.NoError(t, queueDisabledError)
+	require.False(t, queueDisabled)
 
-	assertSelectedCommand(t, browserContext, filesReplaceCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"files",
-		"replace",
-		"--roots",
-		expectedRepository.Path,
-		"--pattern",
-		repositoryReadmePathConstant,
-		"--branch",
-		"feature/demo",
-		"--find",
-		replacementFindValueConstant,
-		"--replace",
-		replacementTextValueConstant,
-	})
+	runCommandHidden, runCommandHiddenError := readHiddenState(browserContext, runCommandSelectorConstant)
+	require.NoError(t, runCommandHiddenError)
+	require.True(t, runCommandHidden)
 }
 
 func TestWebInterfaceBrowserInspectsAuditRootsAndDisplaysTable(t *testing.T) {
@@ -255,6 +236,216 @@ func TestWebInterfaceBrowserInspectsAuditRootsAndDisplaysTable(t *testing.T) {
 	})()`, &auditLayout)))
 	require.LessOrEqual(t, auditLayout.DocumentScrollWidth, auditLayout.DocumentClientWidth+2)
 	require.LessOrEqual(t, auditLayout.TableScrollWidth, auditLayout.TableClientWidth+2)
+}
+
+func TestWebInterfaceBrowserInspectsAuditRootsFromExplicitLaunchRoots(t *testing.T) {
+	rootPath := t.TempDir()
+	launchRootPath := filepath.Join(rootPath, "fleet", "workspace")
+	repositoryPath := createTestRepository(t, filepath.Join(launchRootPath, "example"))
+
+	httpServer, repositoryCatalog := newBrowserTestServerWithOptions(
+		t,
+		rootPath,
+		[]string{launchRootPath},
+		nil,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(request.Roots[0], "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            "yes",
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "main",
+						InSync:                 "yes",
+						RemoteProtocol:         "ssh",
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		nil,
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	auditSelectionSummary, auditSelectionSummaryError := readTextContent(browserContext, auditSelectionSummarySelectorConstant)
+	require.NoError(t, auditSelectionSummaryError)
+	assertTextContainsPath(t, auditSelectionSummary, launchRootPath)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
+	require.NoError(t, auditSummaryError)
+	require.Equal(t, "1 row", auditSummary)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, "canonical/example")
+	assertTextContainsPath(t, auditResultsText, repositoryPath)
+
+	runErrorText, runErrorError := readTextContent(browserContext, "#run-error")
+	require.NoError(t, runErrorError)
+	require.Empty(t, runErrorText)
+}
+
+func TestWebInterfaceBrowserInspectsAuditRootsFromMultipleExplicitLaunchRoots(t *testing.T) {
+	rootPath := t.TempDir()
+	firstLaunchRootPath := filepath.Join(rootPath, "fleet", "alpha")
+	secondLaunchRootPath := filepath.Join(rootPath, "fleet", "beta")
+	firstRepositoryPath := createTestRepository(t, filepath.Join(firstLaunchRootPath, "example"))
+	createTestRepository(t, filepath.Join(secondLaunchRootPath, "other"))
+
+	httpServer, repositoryCatalog := newBrowserTestServerWithOptions(
+		t,
+		rootPath,
+		[]string{firstLaunchRootPath, secondLaunchRootPath},
+		nil,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(request.Roots[0], "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            "yes",
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "main",
+						InSync:                 "yes",
+						RemoteProtocol:         "ssh",
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		nil,
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	auditSelectionSummary, auditSelectionSummaryError := readTextContent(browserContext, auditSelectionSummarySelectorConstant)
+	require.NoError(t, auditSelectionSummaryError)
+	assertTextContainsPath(t, auditSelectionSummary, firstLaunchRootPath)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
+	require.NoError(t, auditSummaryError)
+	require.Equal(t, "1 row", auditSummary)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, "canonical/example")
+	assertTextContainsPath(t, auditResultsText, firstRepositoryPath)
+
+	runErrorText, runErrorError := readTextContent(browserContext, "#run-error")
+	require.NoError(t, runErrorError)
+	require.Empty(t, runErrorText)
+}
+
+func TestWebInterfaceBrowserInspectsAuditRootsFromSelectedParentFolder(t *testing.T) {
+	rootPath := t.TempDir()
+	launchRootPath := filepath.Join(rootPath, "fleet", "workspace")
+	repositoryPath := createTestRepository(t, filepath.Join(launchRootPath, "example"))
+
+	httpServer, repositoryCatalog := newBrowserTestServerWithOptions(
+		t,
+		rootPath,
+		[]string{launchRootPath},
+		nil,
+		func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+			return web.AuditInspectionResponse{
+				Roots: request.Roots,
+				Rows: []web.AuditInspectionRow{
+					{
+						Path:                   filepath.Join(request.Roots[0], "workspace", "example"),
+						FolderName:             "example",
+						IsGitRepository:        true,
+						FinalGitHubRepository:  "canonical/example",
+						OriginRemoteStatus:     "configured",
+						NameMatches:            "yes",
+						RemoteDefaultBranch:    "main",
+						LocalBranch:            "main",
+						InSync:                 "yes",
+						RemoteProtocol:         "ssh",
+						OriginMatchesCanonical: "yes",
+						WorktreeDirty:          "no",
+						DirtyFiles:             "",
+					},
+				},
+			}
+		},
+		nil,
+	)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		clickRepositoryTreeTitle("fleet"),
+	))
+
+	auditSelectionSummary, auditSelectionSummaryError := readTextContent(browserContext, auditSelectionSummarySelectorConstant)
+	require.NoError(t, auditSelectionSummaryError)
+	assertTextContainsPath(t, auditSelectionSummary, filepath.Join(rootPath, "fleet"))
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
+	require.NoError(t, auditSummaryError)
+	require.Equal(t, "1 row", auditSummary)
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, "canonical/example")
+	assertTextContainsPath(t, auditResultsText, repositoryPath)
+
+	runErrorText, runErrorError := readTextContent(browserContext, "#run-error")
+	require.NoError(t, runErrorError)
+	require.Empty(t, runErrorText)
 }
 
 func TestWebInterfaceBrowserKeepsAuditActionButtonsLegible(t *testing.T) {
@@ -470,7 +661,7 @@ func TestWebInterfaceBrowserFiltersAuditRowsByColumnValue(t *testing.T) {
 	require.NotContains(t, auditResultsText, "alpha")
 }
 
-func TestWebInterfaceBrowserRunButtonUsesActionableAuditInspection(t *testing.T) {
+func TestWebInterfaceBrowserUsesInspectButtonWithoutCommandRunner(t *testing.T) {
 	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
 
 	httpServer, repositoryCatalog := newBrowserTestServerWithInspector(t, repositoryPath, func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
@@ -502,20 +693,23 @@ func TestWebInterfaceBrowserRunButtonUsesActionableAuditInspection(t *testing.T)
 
 	require.NoError(t, chromedp.Run(browserContext,
 		chromedp.Navigate(httpServer.URL),
-		chromedp.WaitVisible(runCommandSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
 	))
 	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
-	assertSelectedCommand(t, browserContext, auditCommandPathConstant)
 
 	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(runCommandSelectorConstant, chromedp.ByQuery),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
 		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
 		chromedp.WaitVisible(auditQueueRenameSelectorConstant, chromedp.ByQuery),
 	))
 
-	runButtonLabel, runButtonLabelError := readTextContent(browserContext, runCommandSelectorConstant)
-	require.NoError(t, runButtonLabelError)
-	require.Equal(t, "Inspect audit table", runButtonLabel)
+	inspectButtonLabel, inspectButtonLabelError := readTextContent(browserContext, auditRunButtonSelectorConstant)
+	require.NoError(t, inspectButtonLabelError)
+	require.Equal(t, "Inspect or refresh audit table", inspectButtonLabel)
+
+	runCommandHidden, runCommandHiddenError := readHiddenState(browserContext, runCommandSelectorConstant)
+	require.NoError(t, runCommandHiddenError)
+	require.True(t, runCommandHidden)
 }
 
 func TestWebInterfaceBrowserInspectionIgnoresEditedAuditRootArguments(t *testing.T) {
@@ -657,9 +851,11 @@ func TestWebInterfaceBrowserQueuesRenameChangeAndAppliesIt(t *testing.T) {
 		return summaryText == "0 pending changes"
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 
-	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
-	require.NoError(t, auditResultsError)
-	require.Contains(t, auditResultsText, "yes")
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+
+	waitForAuditResultsBody(t, browserContext, []string{"yes"}, nil)
 }
 
 func TestWebInterfaceBrowserAppliesQueueUsingLastInspectedScope(t *testing.T) {
@@ -768,11 +964,19 @@ func TestWebInterfaceBrowserAppliesQueueUsingLastInspectedScope(t *testing.T) {
 		return summaryText == "0 pending changes"
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 
-	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
-	require.NoError(t, auditResultsError)
-	require.Contains(t, auditResultsText, workspacePath)
-	require.Contains(t, auditResultsText, "yes")
-	require.NotContains(t, auditResultsText, alternateRoot)
+	require.Eventually(t, func() bool {
+		stdoutOutput, stdoutError := readTextContent(browserContext, stdoutOutputSelectorConstant)
+		if stdoutError != nil {
+			return false
+		}
+		return strings.Contains(stdoutOutput, workspaceRepositoryPath) && strings.Contains(stdoutOutput, "rename applied")
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+
+	waitForAuditResultsBody(t, browserContext, []string{alternateRoot, "other"}, []string{workspacePath})
 }
 
 func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing.T) {
@@ -882,9 +1086,11 @@ func TestWebInterfaceBrowserQueuesDeleteChangeAndRequiresConfirmation(t *testing
 		return summaryText == "0 pending changes"
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 
-	auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
-	require.NoError(t, auditSummaryError)
-	require.Equal(t, "0 rows", auditSummary)
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+
+	waitForAuditResultsSummary(t, browserContext, "0 rows")
 }
 
 func TestWebInterfaceBrowserQueuesProtocolAndSyncChangesWithEditableOptions(t *testing.T) {
@@ -1017,19 +1223,17 @@ func TestWebInterfaceBrowserQueuesProtocolAndSyncChangesWithEditableOptions(t *t
 		return summaryText == "0 pending changes"
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 
-	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
-	require.NoError(t, auditResultsError)
-	require.Contains(t, auditResultsText, "ssh")
-	require.Contains(t, auditResultsText, "yes")
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+
+	waitForAuditResultsBody(t, browserContext, []string{"ssh", "yes"}, nil)
 }
 
-func TestWebInterfaceBrowserPrefillsRemoteAndWorkflowTasksAcrossRepositoryScope(t *testing.T) {
+func TestWebInterfaceBrowserAuditScopeChangesDoNotChangeWorkflowActionTarget(t *testing.T) {
 	rootPath := t.TempDir()
 	firstRepositoryPath := createTestRepository(t, filepath.Join(rootPath, "alpha"))
-	secondRepositoryPath := createTestRepository(t, filepath.Join(rootPath, "nested", "beta"))
-	createTestBranch(t, secondRepositoryPath, "feature/demo")
-	firstCanonicalRepositoryPath := canonicalPath(t, firstRepositoryPath)
-	secondCanonicalRepositoryPath := canonicalPath(t, secondRepositoryPath)
+	createTestRepository(t, filepath.Join(rootPath, "nested", "beta"))
 
 	httpServer, repositoryCatalog := newBrowserTestServer(t, rootPath)
 	defer httpServer.Close()
@@ -1039,64 +1243,214 @@ func TestWebInterfaceBrowserPrefillsRemoteAndWorkflowTasksAcrossRepositoryScope(
 
 	require.NoError(t, chromedp.Run(browserContext,
 		chromedp.Navigate(httpServer.URL),
-		chromedp.WaitVisible(remotesTaskButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(workflowPrimitiveSelectSelectorConstant, chromedp.ByQuery),
 	))
 	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
 
 	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(scopeAllButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.Click(remotesTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
-		setControlValue(remoteOwnerInputSelectorConstant, remoteOwnerValueConstant),
-		chromedp.Click(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
+		clickRepositoryTreeTitle("alpha"),
 	))
 
-	assertSelectedCommand(t, browserContext, remoteCanonicalCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"remote",
-		"update-to-canonical",
-		"--owner",
-		remoteOwnerValueConstant,
-		"--roots",
-		firstCanonicalRepositoryPath,
-		"--roots",
-		secondCanonicalRepositoryPath,
-	})
+	require.Eventually(t, func() bool {
+		repositoryTitle, repositoryTitleError := readTextContent(browserContext, "#repo-title")
+		if repositoryTitleError != nil {
+			return false
+		}
+		return repositoryTitle == "alpha"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 
 	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(workflowsTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(workflowLoadButtonSelectorConstant, chromedp.ByQuery),
-		setControlValue(workflowTargetInputSelectorConstant, workflowTargetValueConstant),
-		setControlValue(workflowVarsInputSelectorConstant, workflowVariableAssignmentConstant),
-		setControlValue(workflowVarFilesInputSelectorConstant, workflowVariableFileConstant),
-		setControlValue(workflowWorkersInputSelectorConstant, workflowWorkersValueConstant),
-		setCheckboxValue(workflowRequireCleanSelectorConstant, true),
-		chromedp.Click(workflowLoadButtonSelectorConstant, chromedp.ByQuery),
+		clickRepositoryTreeExpander("nested"),
+	))
+	waitForRepositoryTreeState(t, browserContext, []string{"alpha", "nested", "beta"}, nil, "")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		clickRepositoryTreeCheckbox("beta"),
 	))
 
-	assertSelectedCommand(t, browserContext, workflowCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"workflow",
-		workflowTargetValueConstant,
-		"--require-clean",
-		"--var",
-		workflowVariableAssignmentConstant,
-		"--var-file",
-		workflowVariableFileConstant,
-		"--workflow-workers",
-		workflowWorkersValueConstant,
-		"--roots",
-		firstCanonicalRepositoryPath,
-		"--roots",
-		secondCanonicalRepositoryPath,
+	waitForAuditRoots(t, browserContext, []string{
+		firstRepositoryPath,
+		filepath.Join(rootPath, "nested", "beta"),
 	})
+
+	workflowRepoText, workflowRepoError := readTextContent(browserContext, workflowActionRepoSelectorConstant)
+	require.NoError(t, workflowRepoError)
+	assertTextContainsPath(t, workflowRepoText, firstRepositoryPath)
+}
+
+func TestWebInterfaceBrowserQueuesAndAppliesWorkflowPrimitiveActions(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	httpServer, repositoryCatalog := newBrowserTestServer(t, repositoryPath)
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(workflowPrimitiveSelectSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(workflowPrimitiveSelectSelectorConstant, webWorkflowPrimitiveFileReplaceConstant),
+		chromedp.WaitVisible(workflowPrimitiveFieldsSelectorConstant, chromedp.ByQuery),
+		setControlValue(workflowPatternsSelectorConstant, "README.md"),
+		setControlValue(workflowFindSelectorConstant, "initial"),
+		setControlValue(workflowReplaceSelectorConstant, "updated"),
+		chromedp.Click(workflowActionQueueSelectorConstant, chromedp.ByQuery),
+	))
+
+	queuedRepositoryText, queuedRepositoryError := readTextContent(browserContext, workflowActionRepoSelectorConstant)
+	require.NoError(t, queuedRepositoryError)
+	assertTextContainsPath(t, queuedRepositoryText, repositoryPath)
+
+	queuedSummary, queuedSummaryError := readTextContent(browserContext, workflowQueueSummarySelectorConstant)
+	require.NoError(t, queuedSummaryError)
+	require.Equal(t, "1 queued action", queuedSummary)
+
+	queuedListText, queuedListError := readTextContent(browserContext, workflowQueueListSelectorConstant)
+	require.NoError(t, queuedListError)
+	require.Contains(t, queuedListText, "Replace in files")
+	require.Contains(t, queuedListText, "README.md")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(workflowQueueApplySelectorConstant, chromedp.ByQuery),
+	))
+
+	require.Eventually(t, func() bool {
+		updatedContent, readError := os.ReadFile(filepath.Join(repositoryPath, "README.md"))
+		if readError != nil {
+			return false
+		}
+		return string(updatedContent) == "updated\n"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	stdoutOutput, stdoutError := readTextContent(browserContext, stdoutOutputSelectorConstant)
+	require.NoError(t, stdoutError)
+	require.Contains(t, stdoutOutput, "Replace in files")
+	require.Contains(t, stdoutOutput, "REPLACE-APPLY")
+
+	stderrOutput, stderrError := readTextContent(browserContext, stderrOutputSelectorConstant)
+	require.NoError(t, stderrError)
+	require.Empty(t, strings.TrimSpace(stderrOutput))
+}
+
+func TestWebInterfaceBrowserAuditTableListsWorkflowPrimitiveRowActions(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	httpServer, repositoryCatalog := newBrowserTestServerWithInspector(t, repositoryPath, func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+		return web.AuditInspectionResponse{
+			Roots: request.Roots,
+			Rows: []web.AuditInspectionRow{
+				{
+					Path:                   filepath.Join(request.Roots[0], "example"),
+					FolderName:             "example",
+					IsGitRepository:        true,
+					FinalGitHubRepository:  "canonical/example",
+					OriginRemoteStatus:     "configured",
+					NameMatches:            "yes",
+					RemoteDefaultBranch:    "main",
+					LocalBranch:            "main",
+					InSync:                 "yes",
+					RemoteProtocol:         "ssh",
+					OriginMatchesCanonical: "yes",
+					WorktreeDirty:          "no",
+					DirtyFiles:             "",
+				},
+			},
+		}
+	})
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(auditRunButtonSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+	))
+
+	auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+	require.NoError(t, auditResultsError)
+	require.Contains(t, auditResultsText, "Promote default branch")
+	require.Contains(t, auditResultsText, "Create release tag")
+	require.Contains(t, auditResultsText, "Retag releases")
+	require.Contains(t, auditResultsText, "Audit report")
+	require.Contains(t, auditResultsText, "Purge history")
+	require.Contains(t, auditResultsText, "Replace in files")
+	require.Contains(t, auditResultsText, "Rewrite namespace")
+}
+
+func TestWebInterfaceBrowserQueuesWorkflowPrimitiveFromAuditTableUsingCurrentDraft(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	httpServer, repositoryCatalog := newBrowserTestServerWithInspector(t, repositoryPath, func(_ context.Context, request web.AuditInspectionRequest) web.AuditInspectionResponse {
+		return web.AuditInspectionResponse{
+			Roots: request.Roots,
+			Rows: []web.AuditInspectionRow{
+				{
+					Path:                   filepath.Join(request.Roots[0], "example"),
+					FolderName:             "example",
+					IsGitRepository:        true,
+					FinalGitHubRepository:  "canonical/example",
+					OriginRemoteStatus:     "configured",
+					NameMatches:            "yes",
+					RemoteDefaultBranch:    "main",
+					LocalBranch:            "main",
+					InSync:                 "yes",
+					RemoteProtocol:         "ssh",
+					OriginMatchesCanonical: "yes",
+					WorktreeDirty:          "no",
+					DirtyFiles:             "",
+				},
+			},
+		}
+	})
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+	expectedRepository := selectedRepositoryDescriptor(t, repositoryCatalog)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(workflowPrimitiveSelectSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		setControlValue(workflowPrimitiveSelectSelectorConstant, webWorkflowPrimitiveFileReplaceConstant),
+		chromedp.WaitVisible(workflowPrimitiveFieldsSelectorConstant, chromedp.ByQuery),
+		setControlValue(workflowPatternsSelectorConstant, "README.md"),
+		setControlValue(workflowFindSelectorConstant, "initial"),
+		setControlValue(workflowReplaceSelectorConstant, "updated"),
+		chromedp.Click(auditRunButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(auditResultsPanelSelectorConstant, chromedp.ByQuery),
+		clickAuditActionButton("Queue Replace in files"),
+	))
+
+	workflowQueueSummary, workflowQueueSummaryError := readTextContent(browserContext, workflowQueueSummarySelectorConstant)
+	require.NoError(t, workflowQueueSummaryError)
+	require.Equal(t, "1 queued action", workflowQueueSummary)
+
+	workflowQueueText, workflowQueueTextError := readTextContent(browserContext, workflowQueueListSelectorConstant)
+	require.NoError(t, workflowQueueTextError)
+	require.Contains(t, workflowQueueText, "Replace in files")
+	require.Contains(t, workflowQueueText, "README.md")
+	assertTextContainsPath(t, workflowQueueText, repositoryPath)
 }
 
 func TestWebInterfaceBrowserRendersRepositoryTreeAndPreservesCheckedScopeAcrossFilter(t *testing.T) {
 	rootPath := t.TempDir()
-	firstRepositoryPath := createTestRepository(t, filepath.Join(rootPath, "alpha"))
-	secondRepositoryPath := createTestRepository(t, filepath.Join(rootPath, "nested", "beta"))
-	secondCanonicalRepositoryPath := canonicalPath(t, secondRepositoryPath)
+	createTestRepository(t, filepath.Join(rootPath, "alpha"))
+	createTestRepository(t, filepath.Join(rootPath, "nested", "beta"))
 
 	httpServer, repositoryCatalog := newBrowserTestServer(t, rootPath)
 	defer httpServer.Close()
@@ -1124,7 +1478,10 @@ func TestWebInterfaceBrowserRendersRepositoryTreeAndPreservesCheckedScopeAcrossF
 	waitForRepositoryTreeState(t, browserContext, []string{"alpha", "nested", "beta"}, nil, "nested")
 
 	require.NoError(t, chromedp.Run(browserContext,
+		clickRepositoryTreeCheckbox("alpha"),
+		clickRepositoryTreeCheckbox("beta"),
 		clickRepositoryTreeTitle("beta"),
+		setControlValue(repoFilterSelectorConstant, "alpha"),
 	))
 
 	require.Eventually(t, func() bool {
@@ -1135,36 +1492,18 @@ func TestWebInterfaceBrowserRendersRepositoryTreeAndPreservesCheckedScopeAcrossF
 		return repositoryTitle == "beta"
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 
-	require.NoError(t, chromedp.Run(browserContext,
-		clickRepositoryTreeCheckbox("alpha"),
-		clickRepositoryTreeCheckbox("beta"),
-		setControlValue(repoFilterSelectorConstant, "alpha"),
-	))
-
-	filteredTreeText, filteredTreeTextError := readTextContent(browserContext, repoTreeSelectorConstant)
-	require.NoError(t, filteredTreeTextError)
-	require.Contains(t, filteredTreeText, "alpha")
-	require.NotContains(t, filteredTreeText, "beta")
+	visibleTreeTitles, visibleTreeTitlesError := readVisibleRepositoryTreeTitles(browserContext)
+	require.NoError(t, visibleTreeTitlesError)
+	require.Contains(t, visibleTreeTitles, "alpha")
 
 	require.NoError(t, chromedp.Run(browserContext,
 		setControlValue(repoFilterSelectorConstant, ""),
-		chromedp.Click(scopeCheckedButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.Click(remotesTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
-		setControlValue(remoteOwnerInputSelectorConstant, remoteOwnerValueConstant),
-		chromedp.Click(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
 	))
 
-	assertSelectedCommand(t, browserContext, remoteCanonicalCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"remote",
-		"update-to-canonical",
-		"--owner",
-		remoteOwnerValueConstant,
-		"--roots",
-		secondCanonicalRepositoryPath,
+	waitForAuditRoots(t, browserContext, []string{
+		filepath.Join(rootPath, "alpha"),
+		filepath.Join(rootPath, "nested", "beta"),
 	})
-	require.NotEqual(t, canonicalPath(t, firstRepositoryPath), secondCanonicalRepositoryPath)
 }
 
 func TestWebInterfaceBrowserDisplaysRepositoryTreeInLeftSidebar(t *testing.T) {
@@ -1380,32 +1719,66 @@ func TestWebInterfaceBrowserTraversesFolderTreeScenarios(t *testing.T) {
 				createTestRepository(testingInstance, filepath.Join(launchRootPath, "nested", "other"))
 				return newBrowserTestServerWithLaunchRoots(testingInstance, rootPath, []string{launchRootPath})
 			},
-			initialContains:    []string{"workspace", "example", "nested"},
-			initialExcludes:    []string{rootNameConfiguredRoot, "fleet", "other"},
+			initialContains:    []string{"fleet", "workspace", "example", "nested"},
+			initialExcludes:    []string{rootNameConfiguredRoot, "other"},
 			initialActiveRow:   "workspace",
 			initialAuditRoot:   filepath.Join(rootNameConfiguredRoot, "fleet", "workspace"),
 			expectedRepository: "",
 			steps: []traversalStep{
 				{
 					clickTitle:        "nested",
-					expectedContains:  []string{"workspace", "nested", "other", "example"},
-					expectedExcludes:  []string{rootNameConfiguredRoot, "fleet"},
+					expectedContains:  []string{"fleet", "workspace", "nested", "other", "example"},
+					expectedExcludes:  []string{rootNameConfiguredRoot},
 					expectedActiveRow: "nested",
 					expectedAuditRoot: filepath.Join(rootNameConfiguredRoot, "fleet", "workspace", "nested"),
 				},
 				{
 					clickTitle:        "nested",
-					expectedContains:  []string{"workspace", "nested", "example"},
+					expectedContains:  []string{"fleet", "workspace", "nested", "example"},
 					expectedExcludes:  []string{"other"},
 					expectedActiveRow: "nested",
 					expectedAuditRoot: filepath.Join(rootNameConfiguredRoot, "fleet", "workspace", "nested"),
 				},
 				{
 					clickTitle:        "example",
-					expectedContains:  []string{"workspace", "nested", "example"},
+					expectedContains:  []string{"fleet", "workspace", "nested", "example"},
 					expectedExcludes:  []string{"other"},
 					expectedActiveRow: "example",
 					expectedAuditRoot: filepath.Join(rootNameConfiguredRoot, "fleet", "workspace", "example"),
+				},
+			},
+		},
+		{
+			name: "single explicit root selection browses upward across repository-bearing branches only",
+			setup: func(testingInstance *testing.T) (*httptest.Server, web.RepositoryCatalog) {
+				rootPath := testingInstance.TempDir()
+				profilePath := filepath.Join(rootPath, "profile")
+				developmentPath := filepath.Join(profilePath, "Development")
+				launchRootPath := filepath.Join(developmentPath, "tyemirov")
+				createTestRepository(testingInstance, filepath.Join(launchRootPath, "gix"))
+				createTestRepository(testingInstance, filepath.Join(profilePath, "Documents", "notes"))
+				require.NoError(testingInstance, os.MkdirAll(filepath.Join(developmentPath, "shared"), 0o755))
+				return newBrowserTestServerWithLaunchRoots(testingInstance, rootPath, []string{launchRootPath})
+			},
+			initialContains:    []string{"Development", "tyemirov", "gix"},
+			initialExcludes:    []string{"shared", "Documents", "notes"},
+			initialActiveRow:   "tyemirov",
+			initialAuditRoot:   filepath.Join("profile", "Development", "tyemirov"),
+			expectedRepository: "",
+			steps: []traversalStep{
+				{
+					clickTitle:        "Development",
+					expectedContains:  []string{"profile", "Development", "Documents", "tyemirov", "gix"},
+					expectedExcludes:  []string{"shared"},
+					expectedActiveRow: "Development",
+					expectedAuditRoot: filepath.Join("profile", "Development"),
+				},
+				{
+					clickTitle:        "Documents",
+					expectedContains:  []string{"profile", "Development", "Documents", "notes"},
+					expectedExcludes:  []string{"shared"},
+					expectedActiveRow: "Documents",
+					expectedAuditRoot: filepath.Join("profile", "Documents"),
 				},
 			},
 		},
@@ -1440,14 +1813,61 @@ func TestWebInterfaceBrowserTraversesFolderTreeScenarios(t *testing.T) {
 	}
 }
 
+func TestWebInterfaceBrowserDiscoversRepositoryOutsideInitialLaunchCatalog(t *testing.T) {
+	rootPath := t.TempDir()
+	profilePath := filepath.Join(rootPath, "profile")
+	launchRootPath := filepath.Join(profilePath, "Development", "tyemirov")
+	createTestRepository(t, filepath.Join(launchRootPath, "gix"))
+	discoveredRepositoryPath := createTestRepository(t, filepath.Join(profilePath, "Documents", "notes"))
+	createTestBranch(t, discoveredRepositoryPath, "feature/dynamic")
+	require.NoError(t, os.MkdirAll(filepath.Join(profilePath, "Development", "shared"), 0o755))
+
+	httpServer, repositoryCatalog := newBrowserTestServerWithLaunchRoots(t, rootPath, []string{launchRootPath})
+	defer httpServer.Close()
+
+	browserContext := newBrowserTestContext(t)
+
+	require.NoError(t, chromedp.Run(browserContext,
+		chromedp.Navigate(httpServer.URL),
+		chromedp.WaitVisible(repoTreeSelectorConstant, chromedp.ByQuery),
+	))
+	waitForControlSurfaceReady(t, browserContext, "")
+	waitForRepositoryTreeState(t, browserContext, []string{"Development", "tyemirov", "gix"}, []string{"shared", "Documents", "notes"}, "tyemirov")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		clickRepositoryTreeTitle("Development"),
+	))
+	waitForRepositoryTreeState(t, browserContext, []string{"profile", "Development", "Documents", "tyemirov", "gix"}, []string{"shared"}, "Development")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		clickRepositoryTreeTitle("Documents"),
+	))
+	waitForRepositoryTreeState(t, browserContext, []string{"profile", "Development", "Documents", "notes"}, []string{"shared"}, "Documents")
+
+	require.NoError(t, chromedp.Run(browserContext,
+		clickRepositoryTreeTitle("notes"),
+	))
+
+	require.Eventually(t, func() bool {
+		repositoryTitle, repositoryTitleError := readTextContent(browserContext, "#repo-title")
+		if repositoryTitleError != nil {
+			return false
+		}
+		return repositoryTitle == "notes"
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+
+	workflowRepoText, workflowRepoError := readTextContent(browserContext, workflowActionRepoSelectorConstant)
+	require.NoError(t, workflowRepoError)
+	assertTextContainsPath(t, workflowRepoText, discoveredRepositoryPath)
+
+	require.NotEmpty(t, repositoryCatalog.Repositories)
+}
+
 func TestWebInterfaceBrowserRepositoryTreeShowsNestedRepositoriesAsFolderNodes(t *testing.T) {
 	rootPath := t.TempDir()
 	topLevelRepositoryPath := createTestRepository(t, filepath.Join(rootPath, "alpha"))
-	nestedRepositoryPath := createTestRepository(t, filepath.Join(topLevelRepositoryPath, "plugins", "child"))
-	siblingRepositoryPath := createTestRepository(t, filepath.Join(rootPath, "gamma"))
-	topLevelCanonicalRepositoryPath := canonicalPath(t, topLevelRepositoryPath)
-	nestedCanonicalRepositoryPath := canonicalPath(t, nestedRepositoryPath)
-	siblingCanonicalRepositoryPath := canonicalPath(t, siblingRepositoryPath)
+	createTestRepository(t, filepath.Join(topLevelRepositoryPath, "plugins", "child"))
+	createTestRepository(t, filepath.Join(rootPath, "gamma"))
 
 	httpServer, repositoryCatalog := newBrowserTestServer(t, rootPath)
 	defer httpServer.Close()
@@ -1476,28 +1896,6 @@ func TestWebInterfaceBrowserRepositoryTreeShowsNestedRepositoriesAsFolderNodes(t
 	))
 
 	waitForRepositoryTreeState(t, browserContext, []string{"alpha", "plugins", "child", "gamma"}, nil, "plugins")
-
-	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(scopeAllButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.Click(remotesTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
-		setControlValue(remoteOwnerInputSelectorConstant, remoteOwnerValueConstant),
-		chromedp.Click(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
-	))
-
-	assertSelectedCommand(t, browserContext, remoteCanonicalCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"remote",
-		"update-to-canonical",
-		"--owner",
-		remoteOwnerValueConstant,
-		"--roots",
-		topLevelCanonicalRepositoryPath,
-		"--roots",
-		nestedCanonicalRepositoryPath,
-		"--roots",
-		siblingCanonicalRepositoryPath,
-	})
 }
 
 func TestWebInterfaceBrowserRepositoryTreeOrdersSiblingsAlphabeticallyWithSharedIndent(t *testing.T) {
@@ -1549,8 +1947,8 @@ func TestWebInterfaceBrowserRepositoryTreeHonorsLaunchRoots(t *testing.T) {
 	rootPath := t.TempDir()
 	firstRootPath := filepath.Join(rootPath, "fleet", "alpha")
 	secondRootPath := filepath.Join(rootPath, "fleet", "beta")
-	firstRepositoryPath := createTestRepository(t, filepath.Join(firstRootPath, "example"))
-	secondRepositoryPath := createTestRepository(t, filepath.Join(secondRootPath, "other"))
+	createTestRepository(t, filepath.Join(firstRootPath, "example"))
+	createTestRepository(t, filepath.Join(secondRootPath, "other"))
 	createTestRepository(t, filepath.Join(rootPath, "ignored", "skip"))
 
 	httpServer, repositoryCatalog := newBrowserTestServerWithLaunchRoots(t, rootPath, []string{firstRootPath, secondRootPath})
@@ -1568,7 +1966,11 @@ func TestWebInterfaceBrowserRepositoryTreeHonorsLaunchRoots(t *testing.T) {
 	repoLaunchSummary, repoLaunchSummaryError := readTextContent(browserContext, repoLaunchSummarySelectorConstant)
 	require.NoError(t, repoLaunchSummaryError)
 	require.Contains(t, repoLaunchSummary, "Explicit roots mode")
-	require.Contains(t, repoLaunchSummary, canonicalPath(t, filepath.Join(rootPath, "fleet")))
+	require.True(
+		t,
+		strings.Contains(repoLaunchSummary, filepath.Join(rootPath, "fleet")) ||
+			strings.Contains(repoLaunchSummary, canonicalPath(t, filepath.Join(rootPath, "fleet"))),
+	)
 
 	repoCountText, repoCountError := readTextContent(browserContext, "#repo-count")
 	require.NoError(t, repoCountError)
@@ -1580,41 +1982,27 @@ func TestWebInterfaceBrowserRepositoryTreeHonorsLaunchRoots(t *testing.T) {
 
 	auditSelectionSummary, auditSelectionSummaryError := readTextContent(browserContext, auditSelectionSummarySelectorConstant)
 	require.NoError(t, auditSelectionSummaryError)
-	require.Contains(t, auditSelectionSummary, canonicalPath(t, firstRootPath))
-	require.NotContains(t, auditSelectionSummary, canonicalPath(t, secondRootPath))
+	assertTextContainsPath(t, auditSelectionSummary, firstRootPath)
+	require.False(
+		t,
+		strings.Contains(auditSelectionSummary, secondRootPath) ||
+			strings.Contains(auditSelectionSummary, canonicalPath(t, secondRootPath)),
+	)
 
 	auditRootsValue, auditRootsError := readValue(browserContext, auditRootsInputSelectorConstant)
 	require.NoError(t, auditRootsError)
-	require.Equal(t, canonicalPath(t, firstRootPath), strings.TrimSpace(auditRootsValue))
+	assertCanonicalPathEqual(t, firstRootPath, auditRootsValue)
 
 	treeText, treeTextError := readTextContent(browserContext, repoTreeSelectorConstant)
 	require.NoError(t, treeTextError)
+	require.Contains(t, treeText, "fleet")
 	require.Contains(t, treeText, filepath.Base(firstRootPath))
 	require.Contains(t, treeText, filepath.Base(secondRootPath))
 	require.NotContains(t, treeText, "skip")
 
-	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(scopeAllButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.Click(remotesTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
-		setControlValue(remoteOwnerInputSelectorConstant, remoteOwnerValueConstant),
-		chromedp.Click(remoteLoadButtonSelectorConstant, chromedp.ByQuery),
-	))
-
-	assertSelectedCommand(t, browserContext, remoteCanonicalCommandPathConstant)
-	assertRunnerArguments(t, browserContext, []string{
-		"remote",
-		"update-to-canonical",
-		"--owner",
-		remoteOwnerValueConstant,
-		"--roots",
-		canonicalPath(t, firstRepositoryPath),
-		"--roots",
-		canonicalPath(t, secondRepositoryPath),
-	})
 }
 
-func TestWebInterfaceBrowserSingleLaunchRootShowsConfiguredRootFolder(t *testing.T) {
+func TestWebInterfaceBrowserSingleLaunchRootShowsConfiguredRootUnderParentFolder(t *testing.T) {
 	rootPath := t.TempDir()
 	launchRootPath := filepath.Join(rootPath, "fleet")
 	createTestRepository(t, filepath.Join(launchRootPath, "workspace", "example"))
@@ -1633,9 +2021,9 @@ func TestWebInterfaceBrowserSingleLaunchRootShowsConfiguredRootFolder(t *testing
 
 	treeText, treeTextError := readTextContent(browserContext, repoTreeSelectorConstant)
 	require.NoError(t, treeTextError)
+	require.Contains(t, treeText, filepath.Base(rootPath))
 	require.Contains(t, treeText, filepath.Base(launchRootPath))
 	require.Contains(t, treeText, "workspace")
-	require.NotContains(t, treeText, filepath.Base(rootPath))
 
 	require.Eventually(t, func() bool {
 		activeTitle, activeTitleError := readActiveRepositoryTreeTitle(browserContext)
@@ -1651,21 +2039,25 @@ func TestWebInterfaceBrowserSingleLaunchRootShowsConfiguredRootFolder(t *testing
 
 	auditSelectionSummary, auditSelectionSummaryError := readTextContent(browserContext, auditSelectionSummarySelectorConstant)
 	require.NoError(t, auditSelectionSummaryError)
-	require.Contains(t, auditSelectionSummary, canonicalPath(t, launchRootPath))
+	require.True(
+		t,
+		strings.Contains(auditSelectionSummary, launchRootPath) ||
+			strings.Contains(auditSelectionSummary, canonicalPath(t, launchRootPath)),
+	)
 
 	auditRootsValue, auditRootsError := readValue(browserContext, auditRootsInputSelectorConstant)
 	require.NoError(t, auditRootsError)
-	require.Equal(t, canonicalPath(t, launchRootPath), strings.TrimSpace(auditRootsValue))
+	assertCanonicalPathEqual(t, launchRootPath, auditRootsValue)
 
 	require.NoError(t, chromedp.Run(browserContext,
 		clickRepositoryTreeTitle("workspace"),
 	))
 
-	waitForRepositoryTreeState(t, browserContext, []string{filepath.Base(launchRootPath), "workspace", "example"}, []string{filepath.Base(rootPath)}, "workspace")
+	waitForRepositoryTreeState(t, browserContext, []string{filepath.Base(rootPath), filepath.Base(launchRootPath), "workspace", "example"}, nil, "workspace")
 
 	auditRootsValue, auditRootsError = readValue(browserContext, auditRootsInputSelectorConstant)
 	require.NoError(t, auditRootsError)
-	require.Equal(t, canonicalPath(t, filepath.Join(launchRootPath, "workspace")), strings.TrimSpace(auditRootsValue))
+	assertCanonicalPathEqual(t, filepath.Join(launchRootPath, "workspace"), auditRootsValue)
 }
 
 func TestWebInterfaceBrowserFolderClickSetsAuditRoot(t *testing.T) {
@@ -1692,7 +2084,7 @@ func TestWebInterfaceBrowserFolderClickSetsAuditRoot(t *testing.T) {
 
 	auditRootsValue, auditRootsError := readValue(browserContext, auditRootsInputSelectorConstant)
 	require.NoError(t, auditRootsError)
-	require.Equal(t, canonicalPath(t, firstFolderPath), strings.TrimSpace(auditRootsValue))
+	assertCanonicalPathEqual(t, firstFolderPath, auditRootsValue)
 
 	assertRunnerArguments(t, browserContext, []string{
 		"audit",
@@ -1727,7 +2119,7 @@ func TestWebInterfaceBrowserLatestFolderClickReplacesAuditRoot(t *testing.T) {
 
 	auditRootsValue, auditRootsError := readValue(browserContext, auditRootsInputSelectorConstant)
 	require.NoError(t, auditRootsError)
-	require.Equal(t, canonicalPath(t, secondFolderPath), strings.TrimSpace(auditRootsValue))
+	assertCanonicalPathEqual(t, secondFolderPath, auditRootsValue)
 
 	assertRunnerArguments(t, browserContext, []string{
 		"audit",
@@ -1747,7 +2139,7 @@ func TestBrowserStartupErrorSkippable(t *testing.T) {
 	require.False(t, browserStartupErrorSkippable(nil))
 }
 
-func TestWebInterfaceBrowserAdvancedHidesTaskOwnedCommands(t *testing.T) {
+func TestWebInterfaceBrowserHidesCommandOrientedControls(t *testing.T) {
 	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
 
 	httpServer, repositoryCatalog := newBrowserTestServer(t, repositoryPath)
@@ -1758,31 +2150,39 @@ func TestWebInterfaceBrowserAdvancedHidesTaskOwnedCommands(t *testing.T) {
 
 	require.NoError(t, chromedp.Run(browserContext,
 		chromedp.Navigate(httpServer.URL),
-		chromedp.WaitVisible(workflowsTaskButtonSelectorConstant, chromedp.ByQuery),
+		chromedp.WaitVisible(workflowPrimitiveSelectSelectorConstant, chromedp.ByQuery),
 	))
 	waitForControlSurfaceReady(t, browserContext, expectedRepository.Name)
 
-	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(workflowsTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(workflowLoadButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.Click(workflowLoadButtonSelectorConstant, chromedp.ByQuery),
-	))
-	assertSelectedCommand(t, browserContext, workflowCommandPathConstant)
+	hiddenSelectors := []string{
+		commandGroupsSelectorConstant,
+		runCommandSelectorConstant,
+		repoFocusSelectorConstant,
+		repoScopeSelectorConstant,
+		repoLaunchSummarySelectorConstant,
+		queueIntroPanelSelectorConstant,
+	}
+	for _, selector := range hiddenSelectors {
+		hiddenState, hiddenStateError := readHiddenState(browserContext, selector)
+		require.NoError(t, hiddenStateError)
+		require.True(t, hiddenState, selector)
+	}
 
-	require.NoError(t, chromedp.Run(browserContext,
-		chromedp.Click(advancedTaskButtonSelectorConstant, chromedp.ByQuery),
-		chromedp.WaitVisible(commandGroupsSelectorConstant, chromedp.ByQuery),
-	))
-	assertSelectedCommand(t, browserContext, versionCommandPathConstant)
+	missingSelectors := []string{
+		"#target-ref-mode",
+		"#target-ref-select",
+		"#target-path-mode",
+		"#target-path-value",
+	}
+	for _, selector := range missingSelectors {
+		selectorExists, selectorExistsError := readSelectorExists(browserContext, selector)
+		require.NoError(t, selectorExistsError)
+		require.False(t, selectorExists, selector)
+	}
 
-	commandGroupsText, commandGroupsError := readTextContent(browserContext, commandGroupsSelectorConstant)
-	require.NoError(t, commandGroupsError)
-	assert.Contains(t, commandGroupsText, versionCommandPathConstant)
-	assert.NotContains(t, commandGroupsText, auditCommandPathConstant)
-	assert.NotContains(t, commandGroupsText, branchCommandPathConstant)
-	assert.NotContains(t, commandGroupsText, filesReplaceCommandPathConstant)
-	assert.NotContains(t, commandGroupsText, remoteCanonicalCommandPathConstant)
-	assert.NotContains(t, commandGroupsText, workflowCommandPathConstant)
+	workflowSummaryText, workflowSummaryError := readTextContent(browserContext, workflowPrimitiveSummarySelectorConstant)
+	require.NoError(t, workflowSummaryError)
+	require.NotEmpty(t, workflowSummaryText)
 }
 
 func newBrowserTestServer(testingInstance *testing.T, workingDirectory string) (*httptest.Server, web.RepositoryCatalog) {
@@ -1840,14 +2240,16 @@ func newBrowserTestServerWithOptions(
 		}
 
 		server, serverError := web.NewServer(web.ServerOptions{
-			Address:           testServerAddressConstant,
-			Repositories:      repositoryCatalog,
-			Catalog:           application.commandCatalog(),
-			LoadBranches:      application.loadRepositoryBranches,
-			BrowseDirectories: application.newWebDirectoryBrowser(),
-			Execute:           commandExecutor,
-			InspectAudit:      auditInspector,
-			ApplyAuditChanges: auditChangeExecutor,
+			Address:                testServerAddressConstant,
+			Repositories:           repositoryCatalog,
+			Catalog:                application.commandCatalog(),
+			LoadBranches:           application.loadRepositoryBranches,
+			BrowseDirectories:      application.newWebDirectoryBrowser(),
+			Execute:                commandExecutor,
+			InspectAudit:           auditInspector,
+			ApplyAuditChanges:      auditChangeExecutor,
+			LoadWorkflowPrimitives: application.newWebWorkflowPrimitiveCatalogLoader(),
+			ApplyWorkflowActions:   application.newWebWorkflowPrimitiveExecutor(),
 		})
 		require.NoError(testingInstance, serverError)
 
@@ -2042,6 +2444,40 @@ func waitForRepositoryTreeState(testingInstance *testing.T, browserContext conte
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 }
 
+func waitForAuditResultsBody(testingInstance *testing.T, browserContext context.Context, expectedContains []string, expectedExcludes []string) {
+	testingInstance.Helper()
+
+	require.Eventually(testingInstance, func() bool {
+		auditResultsText, auditResultsError := readTextContent(browserContext, auditResultsBodySelectorConstant)
+		if auditResultsError != nil {
+			return false
+		}
+		for _, expectedFragment := range expectedContains {
+			if !strings.Contains(auditResultsText, expectedFragment) {
+				return false
+			}
+		}
+		for _, excludedFragment := range expectedExcludes {
+			if strings.Contains(auditResultsText, excludedFragment) {
+				return false
+			}
+		}
+		return true
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+}
+
+func waitForAuditResultsSummary(testingInstance *testing.T, browserContext context.Context, expectedSummary string) {
+	testingInstance.Helper()
+
+	require.Eventually(testingInstance, func() bool {
+		auditSummary, auditSummaryError := readTextContent(browserContext, auditResultsSummarySelectorConstant)
+		if auditSummaryError != nil {
+			return false
+		}
+		return auditSummary == expectedSummary
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+}
+
 func readVisibleRepositoryTreeTitles(browserContext context.Context) ([]string, error) {
 	var titles []string
 	readError := chromedp.Run(browserContext, chromedp.Evaluate(fmt.Sprintf(`(() => {
@@ -2071,6 +2507,48 @@ func waitForAuditRootSuffix(testingInstance *testing.T, browserContext context.C
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 }
 
+func waitForAuditRoots(testingInstance *testing.T, browserContext context.Context, expectedPaths []string) {
+	testingInstance.Helper()
+
+	normalizedExpectedPaths := canonicalizeArgumentPaths(testingInstance, expectedPaths)
+	lastObservedPaths := []string(nil)
+	rootsMatched := assert.Eventually(testingInstance, func() bool {
+		auditRootsValue, auditRootsError := readValue(browserContext, auditRootsInputSelectorConstant)
+		if auditRootsError != nil {
+			return false
+		}
+
+		lastObservedPaths = canonicalizeArgumentPaths(testingInstance, splitAuditRootsValue(auditRootsValue))
+		if len(lastObservedPaths) != len(normalizedExpectedPaths) {
+			return false
+		}
+
+		for _, expectedPath := range normalizedExpectedPaths {
+			foundMatch := false
+			for _, observedPath := range lastObservedPaths {
+				if observedPath == expectedPath {
+					foundMatch = true
+					break
+				}
+			}
+			if !foundMatch {
+				return false
+			}
+		}
+
+		return true
+	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
+	if !rootsMatched {
+		require.Equal(testingInstance, normalizedExpectedPaths, lastObservedPaths)
+	}
+}
+
+func splitAuditRootsValue(auditRootsValue string) []string {
+	return strings.FieldsFunc(strings.TrimSpace(auditRootsValue), func(r rune) bool {
+		return r == ','
+	})
+}
+
 func assertSelectedCommand(testingInstance *testing.T, browserContext context.Context, expectedCommandPath string) {
 	testingInstance.Helper()
 
@@ -2086,22 +2564,25 @@ func assertSelectedCommand(testingInstance *testing.T, browserContext context.Co
 func assertRunnerArguments(testingInstance *testing.T, browserContext context.Context, expectedArguments []string) {
 	testingInstance.Helper()
 
+	normalizedExpectedArguments := canonicalizeArgumentPaths(testingInstance, expectedArguments)
 	lastObservedArguments := []string(nil)
+	lastNormalizedObservedArguments := []string(nil)
 	argumentsMatched := assert.Eventually(testingInstance, func() bool {
 		argumentsValue, argumentsError := readValue(browserContext, argumentsInputSelectorConstant)
 		if argumentsError != nil {
 			return false
 		}
 		lastObservedArguments = splitArgumentLines(argumentsValue)
-		return strings.Join(lastObservedArguments, "\n") == strings.Join(expectedArguments, "\n")
+		lastNormalizedObservedArguments = canonicalizeArgumentPaths(testingInstance, lastObservedArguments)
+		return strings.Join(lastNormalizedObservedArguments, "\n") == strings.Join(normalizedExpectedArguments, "\n")
 	}, browserReadyTimeoutConstant, browserReadyPollIntervalConstant)
 	if !argumentsMatched {
-		require.Equal(testingInstance, expectedArguments, lastObservedArguments)
+		require.Equal(testingInstance, normalizedExpectedArguments, lastNormalizedObservedArguments)
 	}
 
 	argumentsValue, argumentsError := readValue(browserContext, argumentsInputSelectorConstant)
 	require.NoError(testingInstance, argumentsError)
-	require.Equal(testingInstance, expectedArguments, splitArgumentLines(argumentsValue))
+	require.Equal(testingInstance, normalizedExpectedArguments, canonicalizeArgumentPaths(testingInstance, splitArgumentLines(argumentsValue)))
 }
 
 func splitArgumentLines(argumentsValue string) []string {
@@ -2111,6 +2592,22 @@ func splitArgumentLines(argumentsValue string) []string {
 	}
 
 	return strings.Split(trimmedArguments, "\n")
+}
+
+func canonicalizeArgumentPaths(testingInstance *testing.T, arguments []string) []string {
+	testingInstance.Helper()
+
+	normalizedArguments := make([]string, 0, len(arguments))
+	for _, argument := range arguments {
+		trimmedArgument := strings.TrimSpace(argument)
+		if filepath.IsAbs(trimmedArgument) {
+			normalizedArguments = append(normalizedArguments, canonicalPath(testingInstance, trimmedArgument))
+			continue
+		}
+		normalizedArguments = append(normalizedArguments, trimmedArgument)
+	}
+
+	return normalizedArguments
 }
 
 func readTextContent(browserContext context.Context, selector string) (string, error) {
@@ -2139,6 +2636,21 @@ func readValue(browserContext context.Context, selector string) (string, error) 
 	return controlValue, actionError
 }
 
+func assertCanonicalPathEqual(testingInstance *testing.T, expectedPath string, actualPath string) {
+	testingInstance.Helper()
+	require.Equal(testingInstance, canonicalPath(testingInstance, expectedPath), canonicalPath(testingInstance, strings.TrimSpace(actualPath)))
+}
+
+func assertTextContainsPath(testingInstance *testing.T, text string, expectedPath string) {
+	testingInstance.Helper()
+	trimmedExpectedPath := strings.TrimSpace(expectedPath)
+	require.True(
+		testingInstance,
+		strings.Contains(text, trimmedExpectedPath) ||
+			strings.Contains(text, canonicalPath(testingInstance, trimmedExpectedPath)),
+	)
+}
+
 func readDisabledState(browserContext context.Context, selector string) (bool, error) {
 	var disabled bool
 	script := fmt.Sprintf(`(() => {
@@ -2147,6 +2659,26 @@ func readDisabledState(browserContext context.Context, selector string) (bool, e
 	})()`, selector)
 	actionError := chromedp.Run(browserContext, chromedp.Evaluate(script, &disabled))
 	return disabled, actionError
+}
+
+func readHiddenState(browserContext context.Context, selector string) (bool, error) {
+	var hidden bool
+	script := fmt.Sprintf(`(() => {
+		const element = document.querySelector(%q);
+		if (!(element instanceof HTMLElement)) {
+			return false;
+		}
+		return Boolean(element.hidden || element.closest("[hidden]") || getComputedStyle(element).display === "none");
+	})()`, selector)
+	actionError := chromedp.Run(browserContext, chromedp.Evaluate(script, &hidden))
+	return hidden, actionError
+}
+
+func readSelectorExists(browserContext context.Context, selector string) (bool, error) {
+	var selectorExists bool
+	script := fmt.Sprintf(`(() => Boolean(document.querySelector(%q)))()`, selector)
+	actionError := chromedp.Run(browserContext, chromedp.Evaluate(script, &selectorExists))
+	return selectorExists, actionError
 }
 
 func setControlValue(selector string, value string) chromedp.Action {
@@ -2192,6 +2724,24 @@ func clickRepositoryTreeTitle(title string) chromedp.Action {
 	})()`, repoTreeSelectorConstant, title), nil)
 }
 
+func clickRepositoryTreeExpander(title string) chromedp.Action {
+	return chromedp.Evaluate(fmt.Sprintf(`(() => {
+		const rows = Array.from(document.querySelectorAll(%q + " .wb-row"));
+		const match = rows.find((row) => {
+			const titleElement = row.querySelector(".wb-title");
+			return titleElement && (titleElement.textContent || "").trim() === %q;
+		});
+		if (!match) {
+			throw new Error("missing tree node title");
+		}
+		const expanderElement = match.querySelector(".wb-expander");
+		if (!expanderElement) {
+			throw new Error("missing tree expander");
+		}
+		expanderElement.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+	})()`, repoTreeSelectorConstant, title), nil)
+}
+
 func clickRepositoryTreeCheckbox(title string) chromedp.Action {
 	return chromedp.Evaluate(fmt.Sprintf(`(() => {
 		const rows = Array.from(document.querySelectorAll(%q + " .wb-row"));
@@ -2208,4 +2758,15 @@ func clickRepositoryTreeCheckbox(title string) chromedp.Action {
 		}
 		checkboxElement.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 	})()`, repoTreeSelectorConstant, title), nil)
+}
+
+func clickAuditActionButton(label string) chromedp.Action {
+	return chromedp.Evaluate(fmt.Sprintf(`(() => {
+		const buttons = Array.from(document.querySelectorAll(%q + " button"));
+		const match = buttons.find((button) => (button.textContent || "").trim() === %q);
+		if (!match) {
+			throw new Error("missing audit action button");
+		}
+		match.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+	})()`, auditResultsBodySelectorConstant, label), nil)
 }

--- a/cmd/cli/application_web_test.go
+++ b/cmd/cli/application_web_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -371,6 +372,81 @@ func TestRepositoryCatalogUsesExplicitLaunchRoots(t *testing.T) {
 	})
 }
 
+func TestWebDirectoryBrowserShowsOnlyRepositoryBranches(t *testing.T) {
+	rootPath := t.TempDir()
+	containerPath := filepath.Join(rootPath, "Folder C")
+	require.NoError(t, os.MkdirAll(filepath.Join(containerPath, "Folder A"), 0o755))
+	repositoryPath := createTestRepository(t, filepath.Join(containerPath, "Folder B"))
+	createTestBranch(t, repositoryPath, "feature/demo")
+
+	application := NewApplication()
+	directoryBrowser := application.newWebDirectoryBrowser()
+
+	type expectedFolder struct {
+		name           string
+		path           string
+		repositoryPath string
+		currentBranch  string
+	}
+
+	testCases := []struct {
+		name            string
+		browsePath      string
+		expectedFolders []expectedFolder
+	}{
+		{
+			name:       "ancestor folder remains visible when it contains a repository descendant",
+			browsePath: rootPath,
+			expectedFolders: []expectedFolder{
+				{
+					name: "Folder C",
+					path: containerPath,
+				},
+			},
+		},
+		{
+			name:       "non repository siblings stay hidden beneath visible ancestor folder",
+			browsePath: containerPath,
+			expectedFolders: []expectedFolder{
+				{
+					name:           "Folder B",
+					path:           repositoryPath,
+					repositoryPath: repositoryPath,
+					currentBranch:  "feature/demo",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			listing := directoryBrowser(context.Background(), testCase.browsePath)
+
+			require.Empty(t, listing.Error)
+			require.Equal(t, canonicalPath(t, testCase.browsePath), canonicalPath(t, listing.Path))
+			require.Len(t, listing.Folders, len(testCase.expectedFolders))
+
+			for folderIndex, expectedFolder := range testCase.expectedFolders {
+				actualFolder := listing.Folders[folderIndex]
+				require.Equal(t, expectedFolder.name, actualFolder.Name)
+				require.Equal(t, canonicalPath(t, expectedFolder.path), canonicalPath(t, actualFolder.Path))
+
+				if len(expectedFolder.repositoryPath) == 0 {
+					require.Nil(t, actualFolder.Repository)
+					continue
+				}
+
+				require.NotNil(t, actualFolder.Repository)
+				require.Equal(t, dynamicWebRepositoryID(expectedFolder.repositoryPath), actualFolder.Repository.ID)
+				require.Equal(t, expectedFolder.name, actualFolder.Repository.Name)
+				require.Equal(t, canonicalPath(t, expectedFolder.repositoryPath), canonicalPath(t, actualFolder.Repository.Path))
+				require.Equal(t, expectedFolder.currentBranch, actualFolder.Repository.CurrentBranch)
+				require.False(t, actualFolder.Repository.ContextCurrent)
+			}
+		})
+	}
+}
+
 func TestLoadRepositoryBranchesReturnsLocalBranches(t *testing.T) {
 	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
 	createTestBranch(t, repositoryPath, "feature/demo")
@@ -384,6 +460,61 @@ func TestLoadRepositoryBranchesReturnsLocalBranches(t *testing.T) {
 	require.Empty(t, branchCatalog.Error)
 	require.Equal(t, "repo-001", branchCatalog.RepositoryID)
 	require.Equal(t, repositoryPath, branchCatalog.RepositoryPath)
+	require.Len(t, branchCatalog.Branches, 2)
+	require.Equal(t, "feature/demo", branchCatalog.Branches[0].Name)
+	require.True(t, branchCatalog.Branches[0].Current)
+	require.Equal(t, "master", branchCatalog.Branches[1].Name)
+}
+
+func TestWebServerLoadsBranchesForDynamicallyDiscoveredRepository(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+	createTestBranch(t, repositoryPath, "feature/demo")
+
+	application := NewApplication()
+	server, serverError := web.NewServer(web.ServerOptions{
+		Address:           "127.0.0.1:8080",
+		Repositories:      web.RepositoryCatalog{},
+		Catalog:           application.commandCatalog(),
+		LoadBranches:      application.loadRepositoryBranches,
+		BrowseDirectories: application.newWebDirectoryBrowser(),
+		Execute:           application.newWebCommandExecutor(),
+		InspectAudit: func(_ context.Context, _ web.AuditInspectionRequest) web.AuditInspectionResponse {
+			return web.AuditInspectionResponse{}
+		},
+		ApplyAuditChanges: func(_ context.Context, _ web.AuditChangeApplyRequest) web.AuditChangeApplyResponse {
+			return web.AuditChangeApplyResponse{}
+		},
+		LoadWorkflowPrimitives: application.newWebWorkflowPrimitiveCatalogLoader(),
+		ApplyWorkflowActions: func(_ context.Context, request web.WorkflowPrimitiveApplyRequest) web.WorkflowPrimitiveApplyResponse {
+			return web.WorkflowPrimitiveApplyResponse{
+				Results: []web.WorkflowPrimitiveApplyResult{
+					{
+						ID:             request.Actions[0].ID,
+						RepositoryPath: request.Actions[0].RepositoryPath,
+						PrimitiveID:    request.Actions[0].PrimitiveID,
+						Status:         webAuditChangeStatusSucceededConstant,
+						Message:        "Applied Replace in files",
+					},
+				},
+			}
+		},
+	})
+	require.NoError(t, serverError)
+
+	httpServer := httptest.NewServer(server.Handler())
+	defer httpServer.Close()
+
+	repositoryID := dynamicWebRepositoryID(repositoryPath)
+	branchesResponse, branchesError := http.Get(httpServer.URL + "/api/repos/" + url.PathEscape(repositoryID) + "/branches?path=" + url.QueryEscape(repositoryPath))
+	require.NoError(t, branchesError)
+	defer branchesResponse.Body.Close()
+	require.Equal(t, http.StatusOK, branchesResponse.StatusCode)
+
+	var branchCatalog web.BranchCatalog
+	require.NoError(t, json.NewDecoder(branchesResponse.Body).Decode(&branchCatalog))
+	require.Empty(t, branchCatalog.Error)
+	require.Equal(t, repositoryID, branchCatalog.RepositoryID)
+	require.Equal(t, canonicalPath(t, repositoryPath), canonicalPath(t, branchCatalog.RepositoryPath))
 	require.Len(t, branchCatalog.Branches, 2)
 	require.Equal(t, "feature/demo", branchCatalog.Branches[0].Name)
 	require.True(t, branchCatalog.Branches[0].Current)
@@ -463,6 +594,8 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 				},
 			}
 		},
+		LoadWorkflowPrimitives: application.newWebWorkflowPrimitiveCatalogLoader(),
+		ApplyWorkflowActions:   application.newWebWorkflowPrimitiveExecutor(),
 	})
 	require.NoError(t, serverError)
 
@@ -485,18 +618,20 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 	require.Contains(t, indexDocument.String(), "<h2>Repos</h2>")
 	require.Contains(t, indexDocument.String(), "cdn.jsdelivr.net/npm/wunderbaum@0/dist/wunderbaum.min.css")
 	require.Contains(t, indexDocument.String(), "<h3>Scope</h3>")
-	require.Contains(t, indexDocument.String(), "<h3>Paths</h3>")
-	require.Contains(t, indexDocument.String(), "<h3>Follow-up Tasks</h3>")
-	require.Contains(t, indexDocument.String(), "id=\"target-ref-select\"")
+	require.Contains(t, indexDocument.String(), "<h3>Workflow Actions</h3>")
+	require.NotContains(t, indexDocument.String(), "<h3>Refs</h3>")
+	require.NotContains(t, indexDocument.String(), "<h3>Paths</h3>")
+	require.NotContains(t, indexDocument.String(), "id=\"target-ref-select\"")
+	require.NotContains(t, indexDocument.String(), "id=\"target-path-value\"")
 	require.Contains(t, indexDocument.String(), "id=\"repo-tree\"")
 	require.Contains(t, indexDocument.String(), "id=\"audit-selection-summary\"")
 	require.Contains(t, indexDocument.String(), "id=\"audit-roots-input\"")
-	require.Contains(t, indexDocument.String(), "Inspect audit table")
+	require.Contains(t, indexDocument.String(), "Inspect or refresh audit table")
 	require.Contains(t, indexDocument.String(), "id=\"audit-results-panel\"")
 	require.Contains(t, indexDocument.String(), "id=\"audit-queue-panel\"")
 	require.Contains(t, indexDocument.String(), "Pending Changes")
-	require.Contains(t, indexDocument.String(), "Run remote normalization command")
-	require.Contains(t, indexDocument.String(), "Run workflow command")
+	require.Contains(t, indexDocument.String(), "Queue workflow action")
+	require.Contains(t, indexDocument.String(), "Apply queued workflow actions")
 
 	applicationScriptResponse, applicationScriptError := http.Get(httpServer.URL + "/assets/app.js")
 	require.NoError(t, applicationScriptError)
@@ -568,6 +703,28 @@ func TestWebServerExecutesVersionCommand(t *testing.T) {
 	require.Len(t, applyInspection.Results, 1)
 	require.Equal(t, "chg-001", applyInspection.Results[0].ID)
 	require.Equal(t, "succeeded", applyInspection.Results[0].Status)
+
+	workflowCatalogResponse, workflowCatalogError := http.Get(httpServer.URL + "/api/workflow/primitives")
+	require.NoError(t, workflowCatalogError)
+	defer workflowCatalogResponse.Body.Close()
+	require.Equal(t, http.StatusOK, workflowCatalogResponse.StatusCode)
+
+	var workflowCatalog web.WorkflowPrimitiveCatalog
+	require.NoError(t, json.NewDecoder(workflowCatalogResponse.Body).Decode(&workflowCatalog))
+	require.NotEmpty(t, workflowCatalog.Primitives)
+	require.Equal(t, webWorkflowPrimitiveCanonicalRemoteConstant, workflowCatalog.Primitives[0].ID)
+
+	workflowApplyBody := strings.NewReader(`{"actions":[{"id":"wf-001","repository_path":"/tmp/example","primitive_id":"repo.files.replace","parameters":{"patterns":"README.md","find":"initial","replace":"updated"}}]}`)
+	workflowApplyResponse, workflowApplyError := http.Post(httpServer.URL+"/api/workflow/apply", "application/json", workflowApplyBody)
+	require.NoError(t, workflowApplyError)
+	defer workflowApplyResponse.Body.Close()
+	require.Equal(t, http.StatusOK, workflowApplyResponse.StatusCode)
+
+	var workflowApplyInspection web.WorkflowPrimitiveApplyResponse
+	require.NoError(t, json.NewDecoder(workflowApplyResponse.Body).Decode(&workflowApplyInspection))
+	require.Len(t, workflowApplyInspection.Results, 1)
+	require.Equal(t, "wf-001", workflowApplyInspection.Results[0].ID)
+	require.Equal(t, webAuditChangeStatusSucceededConstant, workflowApplyInspection.Results[0].Status)
 
 	runBody := strings.NewReader(`{"arguments":["version"]}`)
 	runResponse, runError := http.Post(httpServer.URL+"/api/runs", "application/json", runBody)

--- a/cmd/cli/application_web_workflow_primitives.go
+++ b/cmd/cli/application_web_workflow_primitives.go
@@ -1,0 +1,1038 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/tyemirov/gix/internal/audit"
+	"github.com/tyemirov/gix/internal/repos/shared"
+	"github.com/tyemirov/gix/internal/web"
+	"github.com/tyemirov/gix/internal/workflow"
+)
+
+const (
+	webWorkflowPrimitiveCanonicalRemoteConstant    = "repo.remote.update"
+	webWorkflowPrimitiveProtocolConversionConstant = "repo.remote.convert-protocol"
+	webWorkflowPrimitiveRenameFolderConstant       = "repo.folder.rename"
+	webWorkflowPrimitiveDefaultBranchConstant      = "branch.default"
+	webWorkflowPrimitiveReleaseTagConstant         = "repo.release.tag"
+	webWorkflowPrimitiveReleaseRetagConstant       = "repo.release.retag"
+	webWorkflowPrimitiveAuditReportConstant        = "audit.report"
+	webWorkflowPrimitiveHistoryPurgeConstant       = "repo.history.purge"
+	webWorkflowPrimitiveFileReplaceConstant        = "repo.files.replace"
+	webWorkflowPrimitiveNamespaceRewriteConstant   = "repo.namespace.rewrite"
+
+	webWorkflowPrimitiveQueuedActionsRequiredConstant       = "at least one queued workflow action is required"
+	webWorkflowPrimitiveRepositoryPathRequiredConstant      = "workflow action repository path is required"
+	webWorkflowPrimitiveRepositoryPathAbsoluteRequiredConst = "workflow action repository path must be absolute"
+	webWorkflowPrimitiveIdentifierRequiredConstant          = "workflow primitive id is required"
+	webWorkflowPrimitiveUnsupportedTemplateConstant         = "unsupported workflow primitive %q"
+	webWorkflowPrimitiveParameterRequiredTemplateConstant   = "workflow primitive %s requires %q"
+	webWorkflowPrimitiveParameterTypeTemplateConstant       = "workflow primitive %s requires %q to be %s"
+	webWorkflowPrimitiveParameterValueTemplateConstant      = "workflow primitive %s does not allow %q for %q"
+	webWorkflowPrimitiveRetagMappingsFormatConstant         = "workflow primitive repo.release.retag requires CSV lines: tag,target[,message]"
+	webWorkflowPrimitiveAppliedTemplateConstant             = "Applied %s"
+	webWorkflowPrimitiveSkippedTemplateConstant             = "Skipped %s"
+
+	webWorkflowPrimitiveParameterTypeStringConstant   = "a string"
+	webWorkflowPrimitiveParameterTypeBooleanConstant  = "a boolean"
+	webWorkflowPrimitiveProtocolPlaceholderConstant   = "ssh"
+	webWorkflowPrimitiveOwnerPlaceholderConstant      = "owner"
+	webWorkflowPrimitiveBranchPlaceholderConstant     = "master"
+	webWorkflowPrimitiveRemotePlaceholderConstant     = "origin"
+	webWorkflowPrimitiveTagPlaceholderConstant        = "v1.2.3"
+	webWorkflowPrimitiveOutputPlaceholderConstant     = "./audit-report.csv"
+	webWorkflowPrimitivePathsPlaceholderConstant      = "path/one\npath/two"
+	webWorkflowPrimitivePatternPlaceholderConstant    = "README.md\n**/*.go"
+	webWorkflowPrimitiveFindPlaceholderConstant       = "TEXT_TO_FIND"
+	webWorkflowPrimitiveReplacePlaceholderConstant    = "TEXT_TO_REPLACE"
+	webWorkflowPrimitiveCommandPlaceholderConstant    = "go test ./..."
+	webWorkflowPrimitiveNamespaceOldPlaceholderConst  = "github.com/old/module"
+	webWorkflowPrimitiveNamespaceNewPlaceholderConst  = "github.com/new/module"
+	webWorkflowPrimitiveBranchPrefixPlaceholderConst  = "rewrite/namespace"
+	webWorkflowPrimitiveCommitMessagePlaceholderConst = "Rewrite module namespace"
+	webWorkflowPrimitiveMappingsPlaceholderConstant   = "v1.2.3,main,Retag v1.2.3"
+
+	webWorkflowPrimitiveParameterOwnerConstant              = "owner"
+	webWorkflowPrimitiveParameterFromConstant               = "from"
+	webWorkflowPrimitiveParameterToConstant                 = "to"
+	webWorkflowPrimitiveParameterIncludeOwnerConstant       = "include_owner"
+	webWorkflowPrimitiveParameterRequireCleanConstant       = "require_clean"
+	webWorkflowPrimitiveParameterSourceConstant             = "source"
+	webWorkflowPrimitiveParameterTargetConstant             = "target"
+	webWorkflowPrimitiveParameterRemoteConstant             = "remote"
+	webWorkflowPrimitiveParameterPushConstant               = "push"
+	webWorkflowPrimitiveParameterDeleteSourceBranchConstant = "delete_source_branch"
+	webWorkflowPrimitiveParameterTagConstant                = "tag"
+	webWorkflowPrimitiveParameterMessageConstant            = "message"
+	webWorkflowPrimitiveParameterMappingsConstant           = "mappings"
+	webWorkflowPrimitiveParameterIncludeAllConstant         = "include_all"
+	webWorkflowPrimitiveParameterDebugConstant              = "debug"
+	webWorkflowPrimitiveParameterDepthConstant              = "depth"
+	webWorkflowPrimitiveParameterOutputConstant             = "output"
+	webWorkflowPrimitiveParameterPathsConstant              = "paths"
+	webWorkflowPrimitiveParameterRestoreConstant            = "restore"
+	webWorkflowPrimitiveParameterPushMissingConstant        = "push_missing"
+	webWorkflowPrimitiveParameterPatternsConstant           = "patterns"
+	webWorkflowPrimitiveParameterFindConstant               = "find"
+	webWorkflowPrimitiveParameterReplaceConstant            = "replace"
+	webWorkflowPrimitiveParameterCommandConstant            = "command"
+	webWorkflowPrimitiveParameterOldConstant                = "old"
+	webWorkflowPrimitiveParameterNewConstant                = "new"
+	webWorkflowPrimitiveParameterBranchPrefixConstant       = "branch_prefix"
+	webWorkflowPrimitiveParameterCommitMessageConstant      = "commit_message"
+
+	webWorkflowPrimitiveProtocolSSHConstant   = string(shared.RemoteProtocolSSH)
+	webWorkflowPrimitiveProtocolHTTPSConstant = string(shared.RemoteProtocolHTTPS)
+	webWorkflowPrimitiveAuditDepthFullConst   = string(audit.InspectionDepthFull)
+	webWorkflowPrimitiveAuditDepthMinConst    = string(audit.InspectionDepthMinimal)
+)
+
+type webWorkflowPrimitiveDefinition struct {
+	descriptor   web.WorkflowPrimitiveDescriptor
+	buildOptions func(map[string]any) (map[string]any, error)
+}
+
+func (application *Application) newWebWorkflowPrimitiveCatalogLoader() web.WorkflowPrimitiveCatalogLoader {
+	definitions := application.webWorkflowPrimitiveDefinitions()
+	descriptors := make([]web.WorkflowPrimitiveDescriptor, 0, len(definitions))
+	for _, definition := range definitions {
+		descriptors = append(descriptors, definition.descriptor)
+	}
+
+	return func(context.Context) web.WorkflowPrimitiveCatalog {
+		return web.WorkflowPrimitiveCatalog{Primitives: append([]web.WorkflowPrimitiveDescriptor(nil), descriptors...)}
+	}
+}
+
+func (application *Application) newWebWorkflowPrimitiveExecutor() web.WorkflowPrimitiveExecutor {
+	definitions := application.webWorkflowPrimitiveDefinitions()
+	definitionIndex := make(map[string]webWorkflowPrimitiveDefinition, len(definitions))
+	for _, definition := range definitions {
+		definitionIndex[definition.descriptor.ID] = definition
+	}
+
+	return func(executionContext context.Context, request web.WorkflowPrimitiveApplyRequest) web.WorkflowPrimitiveApplyResponse {
+		if len(request.Actions) == 0 {
+			return web.WorkflowPrimitiveApplyResponse{Error: webWorkflowPrimitiveQueuedActionsRequiredConstant}
+		}
+
+		results := make([]web.WorkflowPrimitiveApplyResult, 0, len(request.Actions))
+		for _, action := range request.Actions {
+			results = append(results, application.applyWebWorkflowPrimitive(executionContext, definitionIndex, action))
+		}
+		return web.WorkflowPrimitiveApplyResponse{Results: results}
+	}
+}
+
+func (application *Application) applyWebWorkflowPrimitive(
+	executionContext context.Context,
+	definitionIndex map[string]webWorkflowPrimitiveDefinition,
+	action web.WorkflowPrimitiveQueuedAction,
+) web.WorkflowPrimitiveApplyResult {
+	primitiveID := strings.ToLower(strings.TrimSpace(action.PrimitiveID))
+	normalizedPath, pathError := normalizeWebAbsolutePath(
+		action.RepositoryPath,
+		webWorkflowPrimitiveRepositoryPathRequiredConstant,
+		webWorkflowPrimitiveRepositoryPathAbsoluteRequiredConst,
+	)
+	result := web.WorkflowPrimitiveApplyResult{
+		ID:             action.ID,
+		RepositoryPath: normalizedPath,
+		PrimitiveID:    primitiveID,
+	}
+	if pathError != nil {
+		result.Status = webAuditChangeStatusFailedConstant
+		result.Error = pathError.Error()
+		return result
+	}
+	if len(primitiveID) == 0 {
+		result.Status = webAuditChangeStatusFailedConstant
+		result.Error = webWorkflowPrimitiveIdentifierRequiredConstant
+		return result
+	}
+
+	definition, exists := definitionIndex[primitiveID]
+	if !exists {
+		result.Status = webAuditChangeStatusFailedConstant
+		result.Error = fmt.Sprintf(webWorkflowPrimitiveUnsupportedTemplateConstant, primitiveID)
+		return result
+	}
+
+	options, optionsError := definition.buildOptions(action.Parameters)
+	if optionsError != nil {
+		result.Status = webAuditChangeStatusFailedConstant
+		result.Error = optionsError.Error()
+		return result
+	}
+
+	outputBuffer := &bytes.Buffer{}
+	errorBuffer := &bytes.Buffer{}
+
+	dependencies, dependencyError := application.webTaskRunnerDependencies(outputBuffer, errorBuffer)
+	if dependencyError != nil {
+		result.Status = webAuditChangeStatusFailedConstant
+		result.Error = dependencyError.Error()
+		return result
+	}
+
+	taskDefinition := workflow.TaskDefinition{
+		Name:  definition.descriptor.Label,
+		Steps: []workflow.TaskExecutionStep{workflow.TaskExecutionStepCustomActions},
+		Actions: []workflow.TaskActionDefinition{
+			{
+				Type:    primitiveID,
+				Options: options,
+			},
+		},
+	}
+
+	executionOutcome, executionError := executeWebAuditTasks(
+		executionContext,
+		dependencies.Workflow,
+		normalizedPath,
+		[]workflow.TaskDefinition{taskDefinition},
+	)
+	result.Stdout = outputBuffer.String()
+	result.Stderr = errorBuffer.String()
+	result.Status = webWorkflowPrimitiveResultStatus(executionOutcome, executionError)
+	if result.Status == webAuditChangeStatusFailedConstant {
+		result.Error = executionError.Error()
+		return result
+	}
+	if result.Status == webAuditChangeStatusSkippedConstant {
+		result.Message = fmt.Sprintf(webWorkflowPrimitiveSkippedTemplateConstant, definition.descriptor.Label)
+		return result
+	}
+
+	result.Message = fmt.Sprintf(webWorkflowPrimitiveAppliedTemplateConstant, definition.descriptor.Label)
+	return result
+}
+
+func webWorkflowPrimitiveResultStatus(executionOutcome workflow.ExecutionOutcome, executionError error) string {
+	if executionError != nil {
+		return webAuditChangeStatusFailedConstant
+	}
+	if webAuditExecutionOutcomeContainsStepOutcome(executionOutcome, webAuditChangeStatusSkippedConstant) {
+		return webAuditChangeStatusSkippedConstant
+	}
+	return webAuditChangeStatusSucceededConstant
+}
+
+func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowPrimitiveDefinition {
+	return []webWorkflowPrimitiveDefinition{
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveCanonicalRemoteConstant,
+				Label:       "Fix canonical remote",
+				Description: "Update the origin remote to the canonical GitHub repository for the selected repo.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterOwnerConstant,
+						"Owner constraint",
+						"Restrict canonical remotes to one GitHub owner when needed.",
+						false,
+						"",
+						webWorkflowPrimitiveOwnerPlaceholderConstant,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				owner, ownerError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveCanonicalRemoteConstant, webWorkflowPrimitiveParameterOwnerConstant, false, "")
+				if ownerError != nil {
+					return nil, ownerError
+				}
+				return workflowPrimitiveOptions(map[string]string{
+					webWorkflowPrimitiveParameterOwnerConstant: owner,
+				}), nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveProtocolConversionConstant,
+				Label:       "Convert remote protocol",
+				Description: "Switch the origin remote between SSH and HTTPS for the selected repo.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					selectWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterFromConstant,
+						"From protocol",
+						"Leave blank to use the repo's current remote protocol.",
+						false,
+						"",
+						protocolWorkflowPrimitiveOptions(),
+					),
+					selectWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterToConstant,
+						"To protocol",
+						"The destination protocol for the origin remote.",
+						true,
+						webWorkflowPrimitiveProtocolSSHConstant,
+						protocolWorkflowPrimitiveOptions(),
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				fromProtocol, fromError := readWebWorkflowSelectParameter(
+					parameters,
+					webWorkflowPrimitiveProtocolConversionConstant,
+					webWorkflowPrimitiveParameterFromConstant,
+					false,
+					"",
+					allowedProtocolValues(),
+				)
+				if fromError != nil {
+					return nil, fromError
+				}
+				toProtocol, toError := readWebWorkflowSelectParameter(
+					parameters,
+					webWorkflowPrimitiveProtocolConversionConstant,
+					webWorkflowPrimitiveParameterToConstant,
+					true,
+					webWorkflowPrimitiveProtocolSSHConstant,
+					allowedProtocolValues(),
+				)
+				if toError != nil {
+					return nil, toError
+				}
+				return workflowPrimitiveOptions(map[string]string{
+					webWorkflowPrimitiveParameterFromConstant: fromProtocol,
+					webWorkflowPrimitiveParameterToConstant:   toProtocol,
+				}), nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveRenameFolderConstant,
+				Label:       "Rename folder",
+				Description: "Rename the selected repository folder to match its desired GitHub repository name.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterIncludeOwnerConstant,
+						"Include owner",
+						"Prefix the folder name with the GitHub owner.",
+						false,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterRequireCleanConstant,
+						"Require clean worktree",
+						"Block the rename when the worktree is dirty.",
+						true,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				includeOwner, includeOwnerError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveRenameFolderConstant, webWorkflowPrimitiveParameterIncludeOwnerConstant, false)
+				if includeOwnerError != nil {
+					return nil, includeOwnerError
+				}
+				requireClean, requireCleanError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveRenameFolderConstant, webWorkflowPrimitiveParameterRequireCleanConstant, true)
+				if requireCleanError != nil {
+					return nil, requireCleanError
+				}
+				return map[string]any{
+					webWorkflowPrimitiveParameterIncludeOwnerConstant: includeOwner,
+					webWorkflowPrimitiveParameterRequireCleanConstant: requireClean,
+				}, nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveDefaultBranchConstant,
+				Label:       "Promote default branch",
+				Description: "Promote a source branch to the target default branch and optionally push or delete the source branch.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterSourceConstant,
+						"Source branch",
+						"Leave blank to detect the current default branch source automatically.",
+						false,
+						"",
+						"main",
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterTargetConstant,
+						"Target branch",
+						"The branch that should become the default.",
+						true,
+						webWorkflowPrimitiveBranchPlaceholderConstant,
+						webWorkflowPrimitiveBranchPlaceholderConstant,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterRemoteConstant,
+						"Remote name",
+						"The remote that receives the promoted default branch.",
+						false,
+						webWorkflowPrimitiveRemotePlaceholderConstant,
+						webWorkflowPrimitiveRemotePlaceholderConstant,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterPushConstant,
+						"Push to remote",
+						"Push the promoted default branch to the remote.",
+						true,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterDeleteSourceBranchConstant,
+						"Delete source branch",
+						"Delete the remote source branch after promotion.",
+						false,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				sourceBranch, sourceError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveDefaultBranchConstant, webWorkflowPrimitiveParameterSourceConstant, false, "")
+				if sourceError != nil {
+					return nil, sourceError
+				}
+				targetBranch, targetError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveDefaultBranchConstant, webWorkflowPrimitiveParameterTargetConstant, true, webWorkflowPrimitiveBranchPlaceholderConstant)
+				if targetError != nil {
+					return nil, targetError
+				}
+				remoteName, remoteError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveDefaultBranchConstant, webWorkflowPrimitiveParameterRemoteConstant, false, webWorkflowPrimitiveRemotePlaceholderConstant)
+				if remoteError != nil {
+					return nil, remoteError
+				}
+				pushToRemote, pushError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveDefaultBranchConstant, webWorkflowPrimitiveParameterPushConstant, true)
+				if pushError != nil {
+					return nil, pushError
+				}
+				deleteSourceBranch, deleteError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveDefaultBranchConstant, webWorkflowPrimitiveParameterDeleteSourceBranchConstant, false)
+				if deleteError != nil {
+					return nil, deleteError
+				}
+				return map[string]any{
+					webWorkflowPrimitiveParameterSourceConstant:             sourceBranch,
+					webWorkflowPrimitiveParameterTargetConstant:             targetBranch,
+					webWorkflowPrimitiveParameterRemoteConstant:             remoteName,
+					webWorkflowPrimitiveParameterPushConstant:               pushToRemote,
+					webWorkflowPrimitiveParameterDeleteSourceBranchConstant: deleteSourceBranch,
+				}, nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveReleaseTagConstant,
+				Label:       "Create release tag",
+				Description: "Create and optionally push one annotated Git tag for the selected repo.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterTagConstant,
+						"Tag name",
+						"The Git tag to create.",
+						true,
+						"",
+						webWorkflowPrimitiveTagPlaceholderConstant,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterMessageConstant,
+						"Tag message",
+						"Optional annotation message for the created tag.",
+						false,
+						"",
+						"Release message",
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterRemoteConstant,
+						"Remote name",
+						"Push the tag to this remote when provided.",
+						false,
+						"",
+						webWorkflowPrimitiveRemotePlaceholderConstant,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				tagName, tagError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveReleaseTagConstant, webWorkflowPrimitiveParameterTagConstant, true, "")
+				if tagError != nil {
+					return nil, tagError
+				}
+				message, messageError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveReleaseTagConstant, webWorkflowPrimitiveParameterMessageConstant, false, "")
+				if messageError != nil {
+					return nil, messageError
+				}
+				remoteName, remoteError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveReleaseTagConstant, webWorkflowPrimitiveParameterRemoteConstant, false, "")
+				if remoteError != nil {
+					return nil, remoteError
+				}
+				return workflowPrimitiveOptions(map[string]string{
+					webWorkflowPrimitiveParameterTagConstant:     tagName,
+					webWorkflowPrimitiveParameterMessageConstant: message,
+					webWorkflowPrimitiveParameterRemoteConstant:  remoteName,
+				}), nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveReleaseRetagConstant,
+				Label:       "Retag releases",
+				Description: "Move existing tags to new targets for the selected repo.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterRemoteConstant,
+						"Remote name",
+						"Push retagged refs to this remote when provided.",
+						false,
+						"",
+						webWorkflowPrimitiveRemotePlaceholderConstant,
+					),
+					textareaWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterMappingsConstant,
+						"Mappings",
+						"Use CSV lines in the form tag,target[,message].",
+						true,
+						"",
+						webWorkflowPrimitiveMappingsPlaceholderConstant,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				remoteName, remoteError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveReleaseRetagConstant, webWorkflowPrimitiveParameterRemoteConstant, false, "")
+				if remoteError != nil {
+					return nil, remoteError
+				}
+				mappings, mappingsError := readWebWorkflowRetagMappingsParameter(parameters)
+				if mappingsError != nil {
+					return nil, mappingsError
+				}
+				options := map[string]any{
+					webWorkflowPrimitiveParameterMappingsConstant: mappings,
+				}
+				if len(remoteName) > 0 {
+					options[webWorkflowPrimitiveParameterRemoteConstant] = remoteName
+				}
+				return options, nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveAuditReportConstant,
+				Label:       "Audit report",
+				Description: "Run the audit report action against the selected repository scope.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterIncludeAllConstant,
+						"Include non-Git folders",
+						"Include non-repository folders under the selected root.",
+						false,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterDebugConstant,
+						"Debug output",
+						"Enable verbose audit discovery output.",
+						false,
+					),
+					selectWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterDepthConstant,
+						"Inspection depth",
+						"Choose between full and minimal audit inspection.",
+						true,
+						webWorkflowPrimitiveAuditDepthFullConst,
+						[]web.WorkflowPrimitiveParameterOption{
+							{Value: webWorkflowPrimitiveAuditDepthFullConst, Label: "Full"},
+							{Value: webWorkflowPrimitiveAuditDepthMinConst, Label: "Minimal"},
+						},
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterOutputConstant,
+						"Output file",
+						"Write the audit report to a CSV file when provided.",
+						false,
+						"",
+						webWorkflowPrimitiveOutputPlaceholderConstant,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				includeAll, includeAllError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveAuditReportConstant, webWorkflowPrimitiveParameterIncludeAllConstant, false)
+				if includeAllError != nil {
+					return nil, includeAllError
+				}
+				debugOutput, debugError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveAuditReportConstant, webWorkflowPrimitiveParameterDebugConstant, false)
+				if debugError != nil {
+					return nil, debugError
+				}
+				inspectionDepth, depthError := readWebWorkflowSelectParameter(
+					parameters,
+					webWorkflowPrimitiveAuditReportConstant,
+					webWorkflowPrimitiveParameterDepthConstant,
+					true,
+					webWorkflowPrimitiveAuditDepthFullConst,
+					map[string]struct{}{
+						webWorkflowPrimitiveAuditDepthFullConst: {},
+						webWorkflowPrimitiveAuditDepthMinConst:  {},
+					},
+				)
+				if depthError != nil {
+					return nil, depthError
+				}
+				outputPath, outputError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveAuditReportConstant, webWorkflowPrimitiveParameterOutputConstant, false, "")
+				if outputError != nil {
+					return nil, outputError
+				}
+				return workflowPrimitiveOptions(map[string]string{
+					webWorkflowPrimitiveParameterDepthConstant:  inspectionDepth,
+					webWorkflowPrimitiveParameterOutputConstant: outputPath,
+				}, map[string]bool{
+					webWorkflowPrimitiveParameterIncludeAllConstant: includeAll,
+					webWorkflowPrimitiveParameterDebugConstant:      debugOutput,
+				}), nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveHistoryPurgeConstant,
+				Label:       "Purge history",
+				Description: "Rewrite repository history to remove selected paths.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					textareaWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterPathsConstant,
+						"Paths",
+						"Enter one repository-relative path per line.",
+						true,
+						"",
+						webWorkflowPrimitivePathsPlaceholderConstant,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterRemoteConstant,
+						"Remote name",
+						"Push rewritten history to this remote when provided.",
+						false,
+						"",
+						webWorkflowPrimitiveRemotePlaceholderConstant,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterPushConstant,
+						"Push rewritten history",
+						"Push updated refs after the rewrite.",
+						true,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterRestoreConstant,
+						"Restore worktree",
+						"Restore the working tree after rewriting history.",
+						true,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterPushMissingConstant,
+						"Push missing refs",
+						"Push refs that do not already exist on the remote.",
+						false,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				paths, pathsError := readWebWorkflowStringListParameter(parameters, webWorkflowPrimitiveHistoryPurgeConstant, webWorkflowPrimitiveParameterPathsConstant, true)
+				if pathsError != nil {
+					return nil, pathsError
+				}
+				remoteName, remoteError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveHistoryPurgeConstant, webWorkflowPrimitiveParameterRemoteConstant, false, "")
+				if remoteError != nil {
+					return nil, remoteError
+				}
+				pushEnabled, pushError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveHistoryPurgeConstant, webWorkflowPrimitiveParameterPushConstant, true)
+				if pushError != nil {
+					return nil, pushError
+				}
+				restoreEnabled, restoreError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveHistoryPurgeConstant, webWorkflowPrimitiveParameterRestoreConstant, true)
+				if restoreError != nil {
+					return nil, restoreError
+				}
+				pushMissing, pushMissingError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveHistoryPurgeConstant, webWorkflowPrimitiveParameterPushMissingConstant, false)
+				if pushMissingError != nil {
+					return nil, pushMissingError
+				}
+				options := map[string]any{
+					webWorkflowPrimitiveParameterPathsConstant:       paths,
+					webWorkflowPrimitiveParameterPushConstant:        pushEnabled,
+					webWorkflowPrimitiveParameterRestoreConstant:     restoreEnabled,
+					webWorkflowPrimitiveParameterPushMissingConstant: pushMissing,
+				}
+				if len(remoteName) > 0 {
+					options[webWorkflowPrimitiveParameterRemoteConstant] = remoteName
+				}
+				return options, nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveFileReplaceConstant,
+				Label:       "Replace in files",
+				Description: "Run text replacements across matching files in the selected repository.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					textareaWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterPatternsConstant,
+						"Patterns",
+						"Use one glob pattern per line.",
+						true,
+						"",
+						webWorkflowPrimitivePatternPlaceholderConstant,
+					),
+					textareaWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterFindConstant,
+						"Find",
+						"Text to search for in matching files.",
+						true,
+						"",
+						webWorkflowPrimitiveFindPlaceholderConstant,
+					),
+					textareaWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterReplaceConstant,
+						"Replace with",
+						"Replacement text written into matching files.",
+						false,
+						"",
+						webWorkflowPrimitiveReplacePlaceholderConstant,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterCommandConstant,
+						"Post-replacement command",
+						"Optional shell command to run after files are updated.",
+						false,
+						"",
+						webWorkflowPrimitiveCommandPlaceholderConstant,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				patterns, patternsError := readWebWorkflowStringListParameter(parameters, webWorkflowPrimitiveFileReplaceConstant, webWorkflowPrimitiveParameterPatternsConstant, true)
+				if patternsError != nil {
+					return nil, patternsError
+				}
+				findValue, findError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveFileReplaceConstant, webWorkflowPrimitiveParameterFindConstant, true, "")
+				if findError != nil {
+					return nil, findError
+				}
+				replaceValue, replaceError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveFileReplaceConstant, webWorkflowPrimitiveParameterReplaceConstant, false, "")
+				if replaceError != nil {
+					return nil, replaceError
+				}
+				commandValue, commandError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveFileReplaceConstant, webWorkflowPrimitiveParameterCommandConstant, false, "")
+				if commandError != nil {
+					return nil, commandError
+				}
+				options := map[string]any{
+					webWorkflowPrimitiveParameterPatternsConstant: patterns,
+					webWorkflowPrimitiveParameterFindConstant:     findValue,
+					webWorkflowPrimitiveParameterReplaceConstant:  replaceValue,
+				}
+				if len(commandValue) > 0 {
+					options[webWorkflowPrimitiveParameterCommandConstant] = commandValue
+				}
+				return options, nil
+			},
+		},
+		{
+			descriptor: web.WorkflowPrimitiveDescriptor{
+				ID:          webWorkflowPrimitiveNamespaceRewriteConstant,
+				Label:       "Rewrite namespace",
+				Description: "Rewrite the Go module namespace across the selected repository.",
+				Parameters: []web.WorkflowPrimitiveParameterDescriptor{
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterOldConstant,
+						"Old namespace",
+						"The namespace prefix to replace.",
+						true,
+						"",
+						webWorkflowPrimitiveNamespaceOldPlaceholderConst,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterNewConstant,
+						"New namespace",
+						"The replacement namespace prefix.",
+						true,
+						"",
+						webWorkflowPrimitiveNamespaceNewPlaceholderConst,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterBranchPrefixConstant,
+						"Branch prefix",
+						"Optional prefix for the working branch name.",
+						false,
+						"",
+						webWorkflowPrimitiveBranchPrefixPlaceholderConst,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterCommitMessageConstant,
+						"Commit message",
+						"Optional commit message for the namespace rewrite.",
+						false,
+						"",
+						webWorkflowPrimitiveCommitMessagePlaceholderConst,
+					),
+					checkboxWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterPushConstant,
+						"Push rewrite branch",
+						"Push the rewrite branch to the remote.",
+						true,
+					),
+					textWorkflowPrimitiveParameter(
+						webWorkflowPrimitiveParameterRemoteConstant,
+						"Remote name",
+						"Remote used when pushing the rewrite branch.",
+						false,
+						"",
+						webWorkflowPrimitiveRemotePlaceholderConstant,
+					),
+				},
+			},
+			buildOptions: func(parameters map[string]any) (map[string]any, error) {
+				oldNamespace, oldError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveNamespaceRewriteConstant, webWorkflowPrimitiveParameterOldConstant, true, "")
+				if oldError != nil {
+					return nil, oldError
+				}
+				newNamespace, newError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveNamespaceRewriteConstant, webWorkflowPrimitiveParameterNewConstant, true, "")
+				if newError != nil {
+					return nil, newError
+				}
+				branchPrefix, branchPrefixError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveNamespaceRewriteConstant, webWorkflowPrimitiveParameterBranchPrefixConstant, false, "")
+				if branchPrefixError != nil {
+					return nil, branchPrefixError
+				}
+				commitMessage, commitMessageError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveNamespaceRewriteConstant, webWorkflowPrimitiveParameterCommitMessageConstant, false, "")
+				if commitMessageError != nil {
+					return nil, commitMessageError
+				}
+				pushEnabled, pushError := readWebWorkflowBooleanParameter(parameters, webWorkflowPrimitiveNamespaceRewriteConstant, webWorkflowPrimitiveParameterPushConstant, true)
+				if pushError != nil {
+					return nil, pushError
+				}
+				remoteName, remoteError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveNamespaceRewriteConstant, webWorkflowPrimitiveParameterRemoteConstant, false, "")
+				if remoteError != nil {
+					return nil, remoteError
+				}
+				return workflowPrimitiveOptions(map[string]string{
+					webWorkflowPrimitiveParameterOldConstant:           oldNamespace,
+					webWorkflowPrimitiveParameterNewConstant:           newNamespace,
+					webWorkflowPrimitiveParameterBranchPrefixConstant:  branchPrefix,
+					webWorkflowPrimitiveParameterCommitMessageConstant: commitMessage,
+					webWorkflowPrimitiveParameterRemoteConstant:        remoteName,
+				}, map[string]bool{
+					webWorkflowPrimitiveParameterPushConstant: pushEnabled,
+				}), nil
+			},
+		},
+	}
+}
+
+func workflowPrimitiveOptions(stringOptions map[string]string, booleanOptions ...map[string]bool) map[string]any {
+	options := map[string]any{}
+	for key, value := range stringOptions {
+		if len(strings.TrimSpace(value)) == 0 {
+			continue
+		}
+		options[key] = value
+	}
+	for _, booleanOptionSet := range booleanOptions {
+		for key, value := range booleanOptionSet {
+			options[key] = value
+		}
+	}
+	return options
+}
+
+func textWorkflowPrimitiveParameter(key string, label string, description string, required bool, defaultValue string, placeholder string) web.WorkflowPrimitiveParameterDescriptor {
+	return web.WorkflowPrimitiveParameterDescriptor{
+		Key:          key,
+		Label:        label,
+		Description:  description,
+		Control:      web.WorkflowPrimitiveParameterControlText,
+		Required:     required,
+		DefaultValue: defaultValue,
+		Placeholder:  placeholder,
+	}
+}
+
+func textareaWorkflowPrimitiveParameter(key string, label string, description string, required bool, defaultValue string, placeholder string) web.WorkflowPrimitiveParameterDescriptor {
+	return web.WorkflowPrimitiveParameterDescriptor{
+		Key:          key,
+		Label:        label,
+		Description:  description,
+		Control:      web.WorkflowPrimitiveParameterControlTextarea,
+		Required:     required,
+		DefaultValue: defaultValue,
+		Placeholder:  placeholder,
+	}
+}
+
+func checkboxWorkflowPrimitiveParameter(key string, label string, description string, defaultValue bool) web.WorkflowPrimitiveParameterDescriptor {
+	return web.WorkflowPrimitiveParameterDescriptor{
+		Key:         key,
+		Label:       label,
+		Description: description,
+		Control:     web.WorkflowPrimitiveParameterControlCheckbox,
+		DefaultBool: boolPointer(defaultValue),
+	}
+}
+
+func selectWorkflowPrimitiveParameter(key string, label string, description string, required bool, defaultValue string, options []web.WorkflowPrimitiveParameterOption) web.WorkflowPrimitiveParameterDescriptor {
+	return web.WorkflowPrimitiveParameterDescriptor{
+		Key:          key,
+		Label:        label,
+		Description:  description,
+		Control:      web.WorkflowPrimitiveParameterControlSelect,
+		Required:     required,
+		DefaultValue: defaultValue,
+		Options:      append([]web.WorkflowPrimitiveParameterOption(nil), options...),
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func protocolWorkflowPrimitiveOptions() []web.WorkflowPrimitiveParameterOption {
+	return []web.WorkflowPrimitiveParameterOption{
+		{Value: webWorkflowPrimitiveProtocolSSHConstant, Label: "SSH"},
+		{Value: webWorkflowPrimitiveProtocolHTTPSConstant, Label: "HTTPS"},
+	}
+}
+
+func allowedProtocolValues() map[string]struct{} {
+	return map[string]struct{}{
+		webWorkflowPrimitiveProtocolSSHConstant:   {},
+		webWorkflowPrimitiveProtocolHTTPSConstant: {},
+	}
+}
+
+func readWebWorkflowStringParameter(parameters map[string]any, primitiveID string, key string, required bool, defaultValue string) (string, error) {
+	rawValue, exists := parameters[key]
+	if !exists || rawValue == nil {
+		if required && len(strings.TrimSpace(defaultValue)) == 0 {
+			return "", fmt.Errorf(webWorkflowPrimitiveParameterRequiredTemplateConstant, primitiveID, key)
+		}
+		return strings.TrimSpace(defaultValue), nil
+	}
+
+	typedValue, ok := rawValue.(string)
+	if !ok {
+		return "", fmt.Errorf(webWorkflowPrimitiveParameterTypeTemplateConstant, primitiveID, key, webWorkflowPrimitiveParameterTypeStringConstant)
+	}
+
+	normalizedValue := strings.TrimSpace(typedValue)
+	if len(normalizedValue) == 0 {
+		if required && len(strings.TrimSpace(defaultValue)) == 0 {
+			return "", fmt.Errorf(webWorkflowPrimitiveParameterRequiredTemplateConstant, primitiveID, key)
+		}
+		if len(normalizedValue) == 0 {
+			return strings.TrimSpace(defaultValue), nil
+		}
+	}
+
+	if len(normalizedValue) == 0 && required {
+		return "", fmt.Errorf(webWorkflowPrimitiveParameterRequiredTemplateConstant, primitiveID, key)
+	}
+	return normalizedValue, nil
+}
+
+func readWebWorkflowBooleanParameter(parameters map[string]any, primitiveID string, key string, defaultValue bool) (bool, error) {
+	rawValue, exists := parameters[key]
+	if !exists || rawValue == nil {
+		return defaultValue, nil
+	}
+
+	typedValue, ok := rawValue.(bool)
+	if !ok {
+		return false, fmt.Errorf(webWorkflowPrimitiveParameterTypeTemplateConstant, primitiveID, key, webWorkflowPrimitiveParameterTypeBooleanConstant)
+	}
+
+	return typedValue, nil
+}
+
+func readWebWorkflowSelectParameter(
+	parameters map[string]any,
+	primitiveID string,
+	key string,
+	required bool,
+	defaultValue string,
+	allowedValues map[string]struct{},
+) (string, error) {
+	value, valueError := readWebWorkflowStringParameter(parameters, primitiveID, key, required, defaultValue)
+	if valueError != nil {
+		return "", valueError
+	}
+	if len(value) == 0 {
+		return "", nil
+	}
+	if _, exists := allowedValues[value]; !exists {
+		return "", fmt.Errorf(webWorkflowPrimitiveParameterValueTemplateConstant, primitiveID, value, key)
+	}
+	return value, nil
+}
+
+func readWebWorkflowStringListParameter(parameters map[string]any, primitiveID string, key string, required bool) ([]string, error) {
+	value, valueError := readWebWorkflowStringParameter(parameters, primitiveID, key, required, "")
+	if valueError != nil {
+		return nil, valueError
+	}
+
+	lines := strings.Split(value, "\n")
+	collected := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if len(trimmedLine) == 0 {
+			continue
+		}
+		collected = append(collected, trimmedLine)
+	}
+
+	if required && len(collected) == 0 {
+		return nil, fmt.Errorf(webWorkflowPrimitiveParameterRequiredTemplateConstant, primitiveID, key)
+	}
+
+	return collected, nil
+}
+
+func readWebWorkflowRetagMappingsParameter(parameters map[string]any) ([]map[string]any, error) {
+	rawMappings, mappingsError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveReleaseRetagConstant, webWorkflowPrimitiveParameterMappingsConstant, true, "")
+	if mappingsError != nil {
+		return nil, mappingsError
+	}
+
+	reader := csv.NewReader(strings.NewReader(rawMappings))
+	reader.FieldsPerRecord = -1
+	records, readError := reader.ReadAll()
+	if readError != nil {
+		return nil, fmt.Errorf("%s: %w", webWorkflowPrimitiveRetagMappingsFormatConstant, readError)
+	}
+
+	mappings := make([]map[string]any, 0, len(records))
+	for _, record := range records {
+		trimmedRecord := make([]string, 0, len(record))
+		for _, column := range record {
+			trimmedColumn := strings.TrimSpace(column)
+			if len(trimmedColumn) == 0 {
+				trimmedRecord = append(trimmedRecord, "")
+				continue
+			}
+			trimmedRecord = append(trimmedRecord, trimmedColumn)
+		}
+		if len(trimmedRecord) == 0 {
+			continue
+		}
+		if len(trimmedRecord) < 2 || len(trimmedRecord) > 3 {
+			return nil, errors.New(webWorkflowPrimitiveRetagMappingsFormatConstant)
+		}
+		if len(trimmedRecord[0]) == 0 || len(trimmedRecord[1]) == 0 {
+			return nil, errors.New(webWorkflowPrimitiveRetagMappingsFormatConstant)
+		}
+
+		mapping := map[string]any{
+			webWorkflowPrimitiveParameterTagConstant:    trimmedRecord[0],
+			webWorkflowPrimitiveParameterTargetConstant: trimmedRecord[1],
+		}
+		if len(trimmedRecord) == 3 && len(trimmedRecord[2]) > 0 {
+			mapping[webWorkflowPrimitiveParameterMessageConstant] = trimmedRecord[2]
+		}
+		mappings = append(mappings, mapping)
+	}
+
+	if len(mappings) == 0 {
+		return nil, errors.New(webWorkflowPrimitiveRetagMappingsFormatConstant)
+	}
+
+	return mappings, nil
+}

--- a/cmd/cli/application_web_workflow_primitives_test.go
+++ b/cmd/cli/application_web_workflow_primitives_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tyemirov/gix/internal/web"
+)
+
+func TestWebWorkflowPrimitiveCatalogIncludesAllBuiltInActions(t *testing.T) {
+	application := NewApplication()
+	catalog := application.newWebWorkflowPrimitiveCatalogLoader()(context.Background())
+
+	require.Empty(t, catalog.Error)
+	require.Equal(t, []string{
+		webWorkflowPrimitiveCanonicalRemoteConstant,
+		webWorkflowPrimitiveProtocolConversionConstant,
+		webWorkflowPrimitiveRenameFolderConstant,
+		webWorkflowPrimitiveDefaultBranchConstant,
+		webWorkflowPrimitiveReleaseTagConstant,
+		webWorkflowPrimitiveReleaseRetagConstant,
+		webWorkflowPrimitiveAuditReportConstant,
+		webWorkflowPrimitiveHistoryPurgeConstant,
+		webWorkflowPrimitiveFileReplaceConstant,
+		webWorkflowPrimitiveNamespaceRewriteConstant,
+	}, workflowPrimitiveCatalogIdentifiers(catalog.Primitives))
+}
+
+func TestWebWorkflowPrimitiveDefinitionsBuildOptions(t *testing.T) {
+	application := NewApplication()
+	definitions := workflowPrimitiveDefinitionIndex(application.webWorkflowPrimitiveDefinitions())
+
+	testCases := []struct {
+		name            string
+		primitiveID     string
+		parameters      map[string]any
+		expectedOptions map[string]any
+		expectedError   string
+	}{
+		{
+			name:        "protocol conversion validates select values",
+			primitiveID: webWorkflowPrimitiveProtocolConversionConstant,
+			parameters: map[string]any{
+				webWorkflowPrimitiveParameterFromConstant: webWorkflowPrimitiveProtocolHTTPSConstant,
+				webWorkflowPrimitiveParameterToConstant:   webWorkflowPrimitiveProtocolSSHConstant,
+			},
+			expectedOptions: map[string]any{
+				webWorkflowPrimitiveParameterFromConstant: webWorkflowPrimitiveProtocolHTTPSConstant,
+				webWorkflowPrimitiveParameterToConstant:   webWorkflowPrimitiveProtocolSSHConstant,
+			},
+		},
+		{
+			name:        "history purge parses multiline paths and boolean toggles",
+			primitiveID: webWorkflowPrimitiveHistoryPurgeConstant,
+			parameters: map[string]any{
+				webWorkflowPrimitiveParameterPathsConstant:       "vendor\nnode_modules\n",
+				webWorkflowPrimitiveParameterRemoteConstant:      "origin",
+				webWorkflowPrimitiveParameterPushConstant:        false,
+				webWorkflowPrimitiveParameterRestoreConstant:     true,
+				webWorkflowPrimitiveParameterPushMissingConstant: true,
+			},
+			expectedOptions: map[string]any{
+				webWorkflowPrimitiveParameterPathsConstant:       []string{"vendor", "node_modules"},
+				webWorkflowPrimitiveParameterRemoteConstant:      "origin",
+				webWorkflowPrimitiveParameterPushConstant:        false,
+				webWorkflowPrimitiveParameterRestoreConstant:     true,
+				webWorkflowPrimitiveParameterPushMissingConstant: true,
+			},
+		},
+		{
+			name:        "retag parses csv mappings",
+			primitiveID: webWorkflowPrimitiveReleaseRetagConstant,
+			parameters: map[string]any{
+				webWorkflowPrimitiveParameterRemoteConstant:   "origin",
+				webWorkflowPrimitiveParameterMappingsConstant: "v1.2.3,main,Retag main\nv1.2.4,release\n",
+			},
+			expectedOptions: map[string]any{
+				webWorkflowPrimitiveParameterRemoteConstant: "origin",
+				webWorkflowPrimitiveParameterMappingsConstant: []map[string]any{
+					{
+						webWorkflowPrimitiveParameterTagConstant:     "v1.2.3",
+						webWorkflowPrimitiveParameterTargetConstant:  "main",
+						webWorkflowPrimitiveParameterMessageConstant: "Retag main",
+					},
+					{
+						webWorkflowPrimitiveParameterTagConstant:    "v1.2.4",
+						webWorkflowPrimitiveParameterTargetConstant: "release",
+					},
+				},
+			},
+		},
+		{
+			name:        "namespace rewrite keeps optional values",
+			primitiveID: webWorkflowPrimitiveNamespaceRewriteConstant,
+			parameters: map[string]any{
+				webWorkflowPrimitiveParameterOldConstant:           "github.com/acme/old",
+				webWorkflowPrimitiveParameterNewConstant:           "github.com/acme/new",
+				webWorkflowPrimitiveParameterBranchPrefixConstant:  "rewrite/namespace",
+				webWorkflowPrimitiveParameterCommitMessageConstant: "Rewrite namespace",
+				webWorkflowPrimitiveParameterPushConstant:          false,
+				webWorkflowPrimitiveParameterRemoteConstant:        "origin",
+			},
+			expectedOptions: map[string]any{
+				webWorkflowPrimitiveParameterOldConstant:           "github.com/acme/old",
+				webWorkflowPrimitiveParameterNewConstant:           "github.com/acme/new",
+				webWorkflowPrimitiveParameterBranchPrefixConstant:  "rewrite/namespace",
+				webWorkflowPrimitiveParameterCommitMessageConstant: "Rewrite namespace",
+				webWorkflowPrimitiveParameterPushConstant:          false,
+				webWorkflowPrimitiveParameterRemoteConstant:        "origin",
+			},
+		},
+		{
+			name:        "file replace requires find value",
+			primitiveID: webWorkflowPrimitiveFileReplaceConstant,
+			parameters: map[string]any{
+				webWorkflowPrimitiveParameterPatternsConstant: "README.md",
+			},
+			expectedError: `workflow primitive repo.files.replace requires "find"`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			definition, exists := definitions[testCase.primitiveID]
+			require.True(t, exists)
+
+			options, optionsError := definition.buildOptions(testCase.parameters)
+			if len(testCase.expectedError) > 0 {
+				require.EqualError(t, optionsError, testCase.expectedError)
+				return
+			}
+
+			require.NoError(t, optionsError)
+			require.Equal(t, testCase.expectedOptions, options)
+		})
+	}
+}
+
+func TestWebWorkflowPrimitiveExecutorAppliesFileReplace(t *testing.T) {
+	repositoryPath := createTestRepository(t, filepath.Join(t.TempDir(), "workspace", "example"))
+
+	application := NewApplication()
+	response := application.newWebWorkflowPrimitiveExecutor()(context.Background(), web.WorkflowPrimitiveApplyRequest{
+		Actions: []web.WorkflowPrimitiveQueuedAction{
+			{
+				ID:             "wf-001",
+				RepositoryPath: repositoryPath,
+				PrimitiveID:    webWorkflowPrimitiveFileReplaceConstant,
+				Parameters: map[string]any{
+					webWorkflowPrimitiveParameterPatternsConstant: "README.md",
+					webWorkflowPrimitiveParameterFindConstant:     "initial",
+					webWorkflowPrimitiveParameterReplaceConstant:  "updated",
+				},
+			},
+		},
+	})
+
+	require.Empty(t, response.Error)
+	require.Len(t, response.Results, 1)
+	require.Equal(t, webAuditChangeStatusSucceededConstant, response.Results[0].Status)
+	require.Contains(t, response.Results[0].Stdout, "REPLACE-APPLY")
+	require.Empty(t, response.Results[0].Stderr)
+
+	updatedContent, readError := os.ReadFile(filepath.Join(repositoryPath, "README.md"))
+	require.NoError(t, readError)
+	require.Equal(t, "updated\n", string(updatedContent))
+}
+
+func workflowPrimitiveCatalogIdentifiers(primitives []web.WorkflowPrimitiveDescriptor) []string {
+	identifiers := make([]string, 0, len(primitives))
+	for _, primitive := range primitives {
+		identifiers = append(identifiers, primitive.ID)
+	}
+	return identifiers
+}
+
+func workflowPrimitiveDefinitionIndex(definitions []webWorkflowPrimitiveDefinition) map[string]webWorkflowPrimitiveDefinition {
+	index := make(map[string]webWorkflowPrimitiveDefinition, len(definitions))
+	for _, definition := range definitions {
+		index[definition.descriptor.ID] = definition
+	}
+	return index
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -24,6 +25,8 @@ const (
 	apiFoldersRoutePathConstant          = "/api/folders"
 	apiAuditInspectRoutePathConstant     = "/api/audit/inspect"
 	apiAuditApplyRoutePathConstant       = "/api/audit/apply"
+	apiWorkflowPrimitivesRouteConstant   = "/api/workflow/primitives"
+	apiWorkflowApplyRouteConstant        = "/api/workflow/apply"
 	apiRunsRoutePathConstant             = "/api/runs"
 	apiRunRoutePathTemplateConstant      = "/api/runs/:id"
 	indexDocumentFilePathConstant        = "ui/index.html"
@@ -35,6 +38,8 @@ const (
 	missingDirectoryBrowserErrorConstant = "missing directory browser"
 	missingAuditInspectorErrorConstant   = "missing audit inspector"
 	missingAuditChangeExecutorConstant   = "missing audit change executor"
+	missingWorkflowCatalogErrorConstant  = "missing workflow primitive catalog loader"
+	missingWorkflowExecutorErrorConstant = "missing workflow primitive executor"
 	missingRepositoryIDErrorConstant     = "missing repository identifier"
 	missingFolderPathErrorConstant       = "missing folder path"
 	repositoryNotFoundTemplateConstant   = "repository %q was not found"
@@ -44,14 +49,16 @@ const (
 var embeddedUIFiles embed.FS
 
 type serverRuntimeOptions struct {
-	address      string
-	repositories RepositoryCatalog
-	catalog      CommandCatalog
-	loadBranches BranchCatalogLoader
-	browseDirs   DirectoryBrowser
-	execute      CommandExecutor
-	inspectAudit AuditInspector
-	applyAudit   AuditChangeExecutor
+	address       string
+	repositories  RepositoryCatalog
+	catalog       CommandCatalog
+	loadBranches  BranchCatalogLoader
+	browseDirs    DirectoryBrowser
+	execute       CommandExecutor
+	inspectAudit  AuditInspector
+	applyAudit    AuditChangeExecutor
+	loadWorkflow  WorkflowPrimitiveCatalogLoader
+	applyWorkflow WorkflowPrimitiveExecutor
 }
 
 // Server hosts the embedded gix browser interface and JSON API.
@@ -177,16 +184,24 @@ func newServerRuntimeOptions(options ServerOptions) (serverRuntimeOptions, error
 	if options.ApplyAuditChanges == nil {
 		return serverRuntimeOptions{}, errors.New(missingAuditChangeExecutorConstant)
 	}
+	if options.LoadWorkflowPrimitives == nil {
+		return serverRuntimeOptions{}, errors.New(missingWorkflowCatalogErrorConstant)
+	}
+	if options.ApplyWorkflowActions == nil {
+		return serverRuntimeOptions{}, errors.New(missingWorkflowExecutorErrorConstant)
+	}
 
 	return serverRuntimeOptions{
-		address:      trimmedAddress,
-		repositories: options.Repositories,
-		catalog:      options.Catalog,
-		loadBranches: options.LoadBranches,
-		browseDirs:   options.BrowseDirectories,
-		execute:      options.Execute,
-		inspectAudit: options.InspectAudit,
-		applyAudit:   options.ApplyAuditChanges,
+		address:       trimmedAddress,
+		repositories:  options.Repositories,
+		catalog:       options.Catalog,
+		loadBranches:  options.LoadBranches,
+		browseDirs:    options.BrowseDirectories,
+		execute:       options.Execute,
+		inspectAudit:  options.InspectAudit,
+		applyAudit:    options.ApplyAuditChanges,
+		loadWorkflow:  options.LoadWorkflowPrimitives,
+		applyWorkflow: options.ApplyWorkflowActions,
 	}, nil
 }
 
@@ -214,6 +229,8 @@ func (server *Server) registerRoutes(assetsFileSystem http.FileSystem) {
 	server.engine.GET(apiFoldersRoutePathConstant, server.handleBrowseDirectories)
 	server.engine.POST(apiAuditInspectRoutePathConstant, server.handleInspectAudit)
 	server.engine.POST(apiAuditApplyRoutePathConstant, server.handleApplyAuditChanges)
+	server.engine.GET(apiWorkflowPrimitivesRouteConstant, server.handleWorkflowPrimitives)
+	server.engine.POST(apiWorkflowApplyRouteConstant, server.handleApplyWorkflowActions)
 	server.engine.POST(apiRunsRoutePathConstant, server.handleCreateRun)
 	server.engine.GET(apiRunRoutePathTemplateConstant, server.handleGetRun)
 }
@@ -239,8 +256,17 @@ func (server *Server) handleRepositoryBranches(requestContext *gin.Context) {
 
 	repository, exists := server.repositoryIndex[repositoryID]
 	if !exists {
-		requestContext.JSON(http.StatusNotFound, errorResponse{Error: fmt.Sprintf(repositoryNotFoundTemplateConstant, repositoryID)})
-		return
+		repositoryPath := strings.TrimSpace(requestContext.Query("path"))
+		if len(repositoryPath) == 0 {
+			requestContext.JSON(http.StatusNotFound, errorResponse{Error: fmt.Sprintf(repositoryNotFoundTemplateConstant, repositoryID)})
+			return
+		}
+
+		repository = RepositoryDescriptor{
+			ID:   repositoryID,
+			Name: filepath.Base(repositoryPath),
+			Path: repositoryPath,
+		}
 	}
 
 	requestContext.JSON(http.StatusOK, server.options.loadBranches(requestContext.Request.Context(), repository))
@@ -287,6 +313,20 @@ func (server *Server) handleApplyAuditChanges(requestContext *gin.Context) {
 	}
 
 	requestContext.JSON(http.StatusOK, server.options.applyAudit(requestContext.Request.Context(), request))
+}
+
+func (server *Server) handleWorkflowPrimitives(requestContext *gin.Context) {
+	requestContext.JSON(http.StatusOK, server.options.loadWorkflow(requestContext.Request.Context()))
+}
+
+func (server *Server) handleApplyWorkflowActions(requestContext *gin.Context) {
+	var request WorkflowPrimitiveApplyRequest
+	if bindError := requestContext.ShouldBindJSON(&request); bindError != nil {
+		requestContext.JSON(http.StatusBadRequest, errorResponse{Error: bindError.Error()})
+		return
+	}
+
+	requestContext.JSON(http.StatusOK, server.options.applyWorkflow(requestContext.Request.Context(), request))
 }
 
 func (server *Server) selectedRepository() *RepositoryDescriptor {

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -20,16 +20,24 @@ type AuditInspector func(context.Context, AuditInspectionRequest) AuditInspectio
 // AuditChangeExecutor applies queued audit changes.
 type AuditChangeExecutor func(context.Context, AuditChangeApplyRequest) AuditChangeApplyResponse
 
+// WorkflowPrimitiveCatalogLoader resolves the workflow primitives visible to the web interface.
+type WorkflowPrimitiveCatalogLoader func(context.Context) WorkflowPrimitiveCatalog
+
+// WorkflowPrimitiveExecutor applies queued workflow primitive actions.
+type WorkflowPrimitiveExecutor func(context.Context, WorkflowPrimitiveApplyRequest) WorkflowPrimitiveApplyResponse
+
 // ServerOptions configures the local web server.
 type ServerOptions struct {
-	Address           string
-	Repositories      RepositoryCatalog
-	Catalog           CommandCatalog
-	LoadBranches      BranchCatalogLoader
-	BrowseDirectories DirectoryBrowser
-	Execute           CommandExecutor
-	InspectAudit      AuditInspector
-	ApplyAuditChanges AuditChangeExecutor
+	Address                string
+	Repositories           RepositoryCatalog
+	Catalog                CommandCatalog
+	LoadBranches           BranchCatalogLoader
+	BrowseDirectories      DirectoryBrowser
+	Execute                CommandExecutor
+	InspectAudit           AuditInspector
+	ApplyAuditChanges      AuditChangeExecutor
+	LoadWorkflowPrimitives WorkflowPrimitiveCatalogLoader
+	ApplyWorkflowActions   WorkflowPrimitiveExecutor
 }
 
 // RepositoryCatalog describes the repositories visible to the web interface at launch time.
@@ -79,8 +87,9 @@ type DirectoryListing struct {
 
 // FolderDescriptor captures one immediate child folder entry.
 type FolderDescriptor struct {
-	Name string `json:"name"`
-	Path string `json:"path"`
+	Name       string                `json:"name"`
+	Path       string                `json:"path"`
+	Repository *RepositoryDescriptor `json:"repository,omitempty"`
 }
 
 // CommandCatalog describes the CLI commands exposed through the web interface.
@@ -213,4 +222,79 @@ type AuditChangeApplyResult struct {
 type AuditChangeApplyResponse struct {
 	Results []AuditChangeApplyResult `json:"results,omitempty"`
 	Error   string                   `json:"error,omitempty"`
+}
+
+// WorkflowPrimitiveCatalog describes the workflow primitives exposed through the web interface.
+type WorkflowPrimitiveCatalog struct {
+	Primitives []WorkflowPrimitiveDescriptor `json:"primitives,omitempty"`
+	Error      string                        `json:"error,omitempty"`
+}
+
+// WorkflowPrimitiveParameterControl describes the form control used for one workflow primitive parameter.
+type WorkflowPrimitiveParameterControl string
+
+const (
+	WorkflowPrimitiveParameterControlText     WorkflowPrimitiveParameterControl = "text"
+	WorkflowPrimitiveParameterControlTextarea WorkflowPrimitiveParameterControl = "textarea"
+	WorkflowPrimitiveParameterControlCheckbox WorkflowPrimitiveParameterControl = "checkbox"
+	WorkflowPrimitiveParameterControlSelect   WorkflowPrimitiveParameterControl = "select"
+)
+
+// WorkflowPrimitiveDescriptor captures one workflow primitive available through the web interface.
+type WorkflowPrimitiveDescriptor struct {
+	ID          string                                 `json:"id"`
+	Label       string                                 `json:"label"`
+	Description string                                 `json:"description,omitempty"`
+	Parameters  []WorkflowPrimitiveParameterDescriptor `json:"parameters,omitempty"`
+}
+
+// WorkflowPrimitiveParameterDescriptor captures the major parameters exposed for one workflow primitive.
+type WorkflowPrimitiveParameterDescriptor struct {
+	Key          string                             `json:"key"`
+	Label        string                             `json:"label"`
+	Description  string                             `json:"description,omitempty"`
+	Control      WorkflowPrimitiveParameterControl  `json:"control"`
+	Required     bool                               `json:"required"`
+	Placeholder  string                             `json:"placeholder,omitempty"`
+	DefaultValue string                             `json:"default_value,omitempty"`
+	DefaultBool  *bool                              `json:"default_bool,omitempty"`
+	Options      []WorkflowPrimitiveParameterOption `json:"options,omitempty"`
+}
+
+// WorkflowPrimitiveParameterOption captures one selectable parameter option.
+type WorkflowPrimitiveParameterOption struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+// WorkflowPrimitiveQueuedAction captures one queued workflow primitive action from the browser.
+type WorkflowPrimitiveQueuedAction struct {
+	ID             string         `json:"id"`
+	RepositoryID   string         `json:"repository_id,omitempty"`
+	RepositoryPath string         `json:"repository_path"`
+	PrimitiveID    string         `json:"primitive_id"`
+	Parameters     map[string]any `json:"parameters,omitempty"`
+}
+
+// WorkflowPrimitiveApplyRequest captures one queued workflow action apply request.
+type WorkflowPrimitiveApplyRequest struct {
+	Actions []WorkflowPrimitiveQueuedAction `json:"actions"`
+}
+
+// WorkflowPrimitiveApplyResult reports the result of one queued workflow primitive action.
+type WorkflowPrimitiveApplyResult struct {
+	ID             string `json:"id"`
+	RepositoryPath string `json:"repository_path"`
+	PrimitiveID    string `json:"primitive_id"`
+	Status         string `json:"status"`
+	Message        string `json:"message,omitempty"`
+	Stdout         string `json:"stdout,omitempty"`
+	Stderr         string `json:"stderr,omitempty"`
+	Error          string `json:"error,omitempty"`
+}
+
+// WorkflowPrimitiveApplyResponse returns per-action workflow execution results.
+type WorkflowPrimitiveApplyResponse struct {
+	Results []WorkflowPrimitiveApplyResult `json:"results,omitempty"`
+	Error   string                         `json:"error,omitempty"`
 }

--- a/internal/web/ui/assets/app.js
+++ b/internal/web/ui/assets/app.js
@@ -146,6 +146,7 @@ function reportBootstrapFailure(message) {
  * @typedef {{
  *   name: string,
  *   path: string,
+ *   repository?: RepositoryDescriptor,
  * }} FolderDescriptor
  */
 
@@ -226,14 +227,94 @@ function reportBootstrapFailure(message) {
 
 /**
  * @typedef {{
+ *   actionType: "audit" | "workflow",
  *   kind: string,
  *   label: string,
- *   queued?: boolean,
- *   queuedChangeID?: string,
+  *   queued?: boolean,
+  *   queuedChangeID?: string,
+ *   queuedWorkflowActionID?: string,
+ *   ready?: boolean,
+  *   title: string,
+  *   description: string,
+ *   primitiveID?: string,
+ *   parameters?: Record<string, any>,
+ *   buildChange?: (row: AuditInspectionRow) => Partial<AuditQueuedChange>,
+ * }} AuditRowActionDefinition
+ */
+
+/**
+ * @typedef {{
+ *   primitives?: WorkflowPrimitiveDescriptor[],
+ *   error?: string,
+ * }} WorkflowPrimitiveCatalog
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   label: string,
+ *   description?: string,
+ *   parameters?: WorkflowPrimitiveParameterDescriptor[],
+ * }} WorkflowPrimitiveDescriptor
+ */
+
+/**
+ * @typedef {{
+ *   key: string,
+ *   label: string,
+ *   description?: string,
+ *   control: string,
+ *   required: boolean,
+ *   placeholder?: string,
+ *   default_value?: string,
+ *   default_bool?: boolean,
+ *   options?: WorkflowPrimitiveParameterOption[],
+ * }} WorkflowPrimitiveParameterDescriptor
+ */
+
+/**
+ * @typedef {{
+ *   value: string,
+ *   label: string,
+ * }} WorkflowPrimitiveParameterOption
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   repository_id?: string,
+ *   repository_path: string,
+ *   primitive_id: string,
+ *   parameters?: Record<string, any>,
+ * }} WorkflowPrimitiveQueuedAction
+ */
+
+/**
+ * @typedef {WorkflowPrimitiveQueuedAction & {
  *   title: string,
  *   description: string,
- *   buildChange: (row: AuditInspectionRow) => Partial<AuditQueuedChange>,
- * }} AuditRowActionDefinition
+ *   repository_name: string,
+ * }} WorkflowPrimitiveQueueEntry
+ */
+
+/**
+ * @typedef {{
+ *   results?: WorkflowPrimitiveApplyResult[],
+ *   error?: string,
+ * }} WorkflowPrimitiveApplyResponse
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   repository_path: string,
+ *   primitive_id: string,
+ *   status: string,
+ *   message?: string,
+ *   stdout?: string,
+ *   stderr?: string,
+ *   error?: string,
+ * }} WorkflowPrimitiveApplyResult
  */
 
 /**
@@ -264,6 +345,8 @@ const commandsEndpoint = "/api/commands";
 const foldersEndpoint = "/api/folders";
 const auditInspectEndpoint = "/api/audit/inspect";
 const auditApplyEndpoint = "/api/audit/apply";
+const workflowPrimitivesEndpoint = "/api/workflow/primitives";
+const workflowApplyEndpoint = "/api/workflow/apply";
 const runsEndpoint = "/api/runs";
 const pollIntervalMilliseconds = 800;
 const currentRepoLaunchMode = "current_repo";
@@ -315,6 +398,13 @@ const auditSyncStrategyStashChangesValue = "stash_changes";
 const auditSyncStrategyCommitChangesValue = "commit_changes";
 const auditChangeStatusSucceededValue = "succeeded";
 const auditChangeStatusSkippedValue = "skipped";
+const workflowPrimitiveControlTextValue = "text";
+const workflowPrimitiveControlTextareaValue = "textarea";
+const workflowPrimitiveControlCheckboxValue = "checkbox";
+const workflowPrimitiveControlSelectValue = "select";
+const webWorkflowPrimitiveCanonicalRemoteValue = "repo.remote.update";
+const webWorkflowPrimitiveProtocolConversionValue = "repo.remote.convert-protocol";
+const webWorkflowPrimitiveRenameFolderValue = "repo.folder.rename";
 const auditHeaderMarkerValue = "folder_name,final_github_repo";
 const auditHeaderColumns = [
   "folder_name",
@@ -417,6 +507,12 @@ const pendingDirectoryLoads = new Map();
  *   allCommands: CommandDescriptor[],
  *   actionableCommands: CommandDescriptor[],
  *   advancedCommands: CommandDescriptor[],
+ *   workflowPrimitives: WorkflowPrimitiveDescriptor[],
+ *   selectedWorkflowPrimitiveID: string,
+ *   workflowPrimitiveDrafts: Record<string, Record<string, any>>,
+ *   workflowActionQueue: WorkflowPrimitiveQueueEntry[],
+ *   workflowActionQueueApplying: boolean,
+ *   nextWorkflowActionSequence: number,
  *   selectedPath: string,
  *   auditInspectionRoots: string[],
  *   auditInspectionRows: AuditInspectionRow[],
@@ -427,6 +523,7 @@ const pendingDirectoryLoads = new Map();
  *   auditQueueApplying: boolean,
  *   nextAuditChangeSequence: number,
  *   collapsedFolderPaths: string[],
+ *   repositoryTreeRootPathsOverride: string[],
  *   pollTimer: number | null,
  * }} */
 const state = {
@@ -438,7 +535,7 @@ const state = {
   activeRepositoryTreeKey: "",
   selectedFolderPath: "",
   selectedScope: scopeSelectedValue,
-  activeTask: taskInspectValue,
+  activeTask: taskWorkflowsValue,
   targetRefMode: refModeCurrentValue,
   targetRefValue: "",
   targetPathMode: pathModeNoneValue,
@@ -448,6 +545,12 @@ const state = {
   allCommands: [],
   actionableCommands: [],
   advancedCommands: [],
+  workflowPrimitives: [],
+  selectedWorkflowPrimitiveID: "",
+  workflowPrimitiveDrafts: {},
+  workflowActionQueue: [],
+  workflowActionQueueApplying: false,
+  nextWorkflowActionSequence: 1,
   selectedPath: "",
   auditInspectionRoots: [],
   auditInspectionRows: [],
@@ -458,6 +561,7 @@ const state = {
   auditQueueApplying: false,
   nextAuditChangeSequence: 1,
   collapsedFolderPaths: [],
+  repositoryTreeRootPathsOverride: [],
   pollTimer: null,
 };
 
@@ -475,19 +579,6 @@ const elements = {
   scopeSelected: document.querySelector("#scope-selected"),
   scopeChecked: document.querySelector("#scope-checked"),
   scopeAll: document.querySelector("#scope-all"),
-  targetRefSummary: document.querySelector("#target-ref-summary"),
-  targetRefMode: document.querySelector("#target-ref-mode"),
-  targetRefValueBlock: document.querySelector("#target-ref-value-block"),
-  targetRefValueLabel: document.querySelector("#target-ref-value-label"),
-  targetRefSelect: document.querySelector("#target-ref-select"),
-  targetRefValue: document.querySelector("#target-ref-value"),
-  targetRefDetail: document.querySelector("#target-ref-detail"),
-  targetPathSummary: document.querySelector("#target-path-summary"),
-  targetPathMode: document.querySelector("#target-path-mode"),
-  targetPathValueBlock: document.querySelector("#target-path-value-block"),
-  targetPathValueLabel: document.querySelector("#target-path-value-label"),
-  targetPathValue: document.querySelector("#target-path-value"),
-  targetPathDetail: document.querySelector("#target-path-detail"),
   actionContext: document.querySelector("#action-context"),
   taskCount: document.querySelector("#task-count"),
   taskInspect: document.querySelector("#task-inspect"),
@@ -527,6 +618,17 @@ const elements = {
   workflowWorkersInput: document.querySelector("#workflow-workers-input"),
   workflowRequireClean: document.querySelector("#workflow-require-clean"),
   taskWorkflowLoad: document.querySelector("#task-workflow-load"),
+  workflowActionRepo: document.querySelector("#workflow-action-repo"),
+  workflowPrimitiveSelect: document.querySelector("#workflow-primitive-select"),
+  workflowPrimitiveSummary: document.querySelector("#workflow-primitive-summary"),
+  workflowPrimitiveFields: document.querySelector("#workflow-primitive-fields"),
+  workflowActionQueueButton: document.querySelector("#workflow-action-queue"),
+  workflowActionSummary: document.querySelector("#workflow-action-summary"),
+  workflowQueuePanel: document.querySelector("#workflow-queue-panel"),
+  workflowQueueSummary: document.querySelector("#workflow-queue-summary"),
+  workflowQueueList: document.querySelector("#workflow-queue-list"),
+  workflowQueueClear: document.querySelector("#workflow-queue-clear"),
+  workflowQueueApply: document.querySelector("#workflow-queue-apply"),
   commandCount: document.querySelector("#command-count"),
   commandFilter: document.querySelector("#command-filter"),
   commandGroups: document.querySelector("#command-groups"),
@@ -567,9 +669,10 @@ async function initialize() {
   bindEvents();
   setStatus("loading");
 
-  const [repositoriesResponse, commandsResponse] = await Promise.all([
+  const [repositoriesResponse, commandsResponse, workflowPrimitivesResponse] = await Promise.all([
     fetch(repositoriesEndpoint),
     fetch(commandsEndpoint),
+    fetch(workflowPrimitivesEndpoint),
   ]);
   if (!repositoriesResponse.ok) {
     throw new Error(`Failed to load repositories: ${repositoriesResponse.status}`);
@@ -577,19 +680,34 @@ async function initialize() {
   if (!commandsResponse.ok) {
     throw new Error(`Failed to load actions: ${commandsResponse.status}`);
   }
+  if (!workflowPrimitivesResponse.ok) {
+    throw new Error(`Failed to load workflow primitives: ${workflowPrimitivesResponse.status}`);
+  }
 
   /** @type {RepositoryCatalog} */
   const repositoryCatalog = await repositoriesResponse.json();
   /** @type {CommandCatalog} */
   const commandCatalog = await commandsResponse.json();
+  /** @type {WorkflowPrimitiveCatalog} */
+  const workflowPrimitiveCatalog = await workflowPrimitivesResponse.json();
+  if (workflowPrimitiveCatalog.error) {
+    throw new Error(workflowPrimitiveCatalog.error);
+  }
   const visibleRepositories = (repositoryCatalog.repositories || []).slice().sort(compareRepositories);
 
   state.repositoryCatalog = repositoryCatalog;
   state.repositories = visibleRepositories;
   state.collapsedFolderPaths = [];
+  state.repositoryTreeRootPathsOverride = [];
   state.allCommands = (commandCatalog.commands || []).slice().sort((left, right) => left.path.localeCompare(right.path));
   state.actionableCommands = state.allCommands.filter((command) => command.actionable);
   state.advancedCommands = state.actionableCommands.filter((command) => inferTaskForCommand(command) === taskAdvancedValue);
+  state.workflowPrimitives = (workflowPrimitiveCatalog.primitives || []).slice();
+  state.selectedWorkflowPrimitiveID = state.workflowPrimitives[0]?.id || "";
+  state.workflowPrimitiveDrafts = {};
+  state.workflowActionQueue = [];
+  state.workflowActionQueueApplying = false;
+  state.nextWorkflowActionSequence = 1;
 
   const initialRepositoryID = state.repositories.some((repository) => repository.id === repositoryCatalog.selected_repository_id)
     ? repositoryCatalog.selected_repository_id || ""
@@ -601,10 +719,8 @@ async function initialize() {
   state.checkedRepositoryIDs = initialRepository ? [initialRepository.id] : [];
 
   elements.repoCount.textContent = String(state.repositories.length);
-  elements.taskCount.textContent = "6";
+  elements.taskCount.textContent = "1";
   elements.commandCount.textContent = String(state.advancedCommands.length);
-  elements.targetRefMode.value = state.targetRefMode;
-  elements.targetPathMode.value = state.targetPathMode;
   elements.fileTaskMode.value = state.fileTaskMode;
 
   renderRepositoryLaunchSummary();
@@ -624,6 +740,7 @@ async function initialize() {
   if (initialCommand) {
     selectCommand(initialCommand.path);
   }
+  setActiveTask(taskWorkflowsValue);
 
   setStatus("idle");
 }
@@ -632,6 +749,7 @@ function bindEvents() {
   elements.repoFilter.addEventListener("input", () => {
     void renderRepositoryTree(elements.repoFilter.value.trim().toLowerCase());
   });
+  elements.repoTree.addEventListener("click", handleRepositoryTreeCheckboxClick, true);
   elements.repoTree.addEventListener("click", handleRepositoryTreeAuditRootSelection);
 
   elements.taskInspect.addEventListener("click", () => {
@@ -695,45 +813,6 @@ function bindEvents() {
     setScope(scopeAllValue);
   });
 
-  elements.targetRefMode.addEventListener("change", () => {
-    state.targetRefMode = elements.targetRefMode.value;
-    if (state.targetRefMode !== refModeNamedValue && state.targetRefMode !== refModePatternValue) {
-      state.targetRefValue = "";
-    }
-    renderTargetState();
-    syncQuickActions();
-    repopulateSelectedCommand();
-  });
-
-  elements.targetRefSelect.addEventListener("change", () => {
-    state.targetRefValue = elements.targetRefSelect.value;
-    renderTargetState();
-    syncQuickActions();
-    repopulateSelectedCommand();
-  });
-
-  elements.targetRefValue.addEventListener("input", () => {
-    state.targetRefValue = elements.targetRefValue.value;
-    renderTargetState();
-    syncQuickActions();
-    repopulateSelectedCommand();
-  });
-
-  elements.targetPathMode.addEventListener("change", () => {
-    state.targetPathMode = elements.targetPathMode.value;
-    if (state.targetPathMode === pathModeNoneValue) {
-      state.targetPathValue = "";
-    }
-    renderTargetState();
-    repopulateSelectedCommand();
-  });
-
-  elements.targetPathValue.addEventListener("input", () => {
-    state.targetPathValue = elements.targetPathValue.value;
-    renderTargetState();
-    repopulateSelectedCommand();
-  });
-
   elements.fileTaskMode.addEventListener("change", () => {
     state.fileTaskMode = elements.fileTaskMode.value;
     renderTaskState();
@@ -792,6 +871,23 @@ function bindEvents() {
 
   elements.taskWorkflowLoad.addEventListener("click", () => {
     loadWorkflowTaskCommand();
+  });
+
+  elements.workflowPrimitiveSelect.addEventListener("change", () => {
+    state.selectedWorkflowPrimitiveID = elements.workflowPrimitiveSelect.value;
+    renderWorkflowPrimitiveState();
+  });
+
+  const handleWorkflowPrimitiveDraftChange = (event) => {
+    updateWorkflowPrimitiveDraft(event.target);
+  };
+  elements.workflowPrimitiveFields.addEventListener("input", handleWorkflowPrimitiveDraftChange);
+  elements.workflowPrimitiveFields.addEventListener("change", handleWorkflowPrimitiveDraftChange);
+  elements.workflowActionQueueButton.addEventListener("click", queueWorkflowPrimitiveAction);
+  elements.workflowQueueList.addEventListener("click", handleWorkflowQueueListClick);
+  elements.workflowQueueClear.addEventListener("click", clearWorkflowQueue);
+  elements.workflowQueueApply.addEventListener("click", () => {
+    void applyWorkflowQueue();
   });
 
   elements.commandFilter.addEventListener("input", () => {
@@ -872,16 +968,16 @@ function renderTaskState() {
     [elements.taskAdvanced, taskAdvancedValue],
   ];
   taskButtons.forEach(([element, taskID]) => {
-    element.classList.toggle("active", state.activeTask === taskID);
+    element.classList.toggle("active", taskID === taskWorkflowsValue);
   });
 
   elements.taskPanelInspect.hidden = false;
-  elements.taskPanelBranch.hidden = state.activeTask !== taskBranchValue;
-  elements.taskPanelFiles.hidden = state.activeTask !== taskFilesValue;
-  elements.taskPanelRemotes.hidden = state.activeTask !== taskRemotesValue;
-  elements.taskPanelCleanup.hidden = state.activeTask !== taskCleanupValue;
-  elements.taskPanelWorkflows.hidden = state.activeTask !== taskWorkflowsValue;
-  elements.taskPanelAdvanced.hidden = state.activeTask !== taskAdvancedValue;
+  elements.taskPanelBranch.hidden = true;
+  elements.taskPanelFiles.hidden = true;
+  elements.taskPanelRemotes.hidden = true;
+  elements.taskPanelCleanup.hidden = true;
+  elements.taskPanelWorkflows.hidden = false;
+  elements.taskPanelAdvanced.hidden = true;
 
   renderAuditTaskState();
   elements.fileTaskLoad.disabled = !repositoryTargetsAvailable;
@@ -891,6 +987,7 @@ function renderTaskState() {
   elements.taskWorkflowLoad.disabled = !repositoryTargetsAvailable;
 
   renderFileTaskState();
+  renderWorkflowPrimitiveState();
   updateActionContext();
 }
 
@@ -931,10 +1028,17 @@ function renderAuditTaskState() {
 }
 
 function renderAuditSelectionSummary() {
+  const auditRoots = workingFolderRoots();
   const selectedFolderPath = activeRepositoryTreeFolderPath();
   const launchRoots = configuredLaunchRoots();
-  const scopeRepositories = repositoryScopeRepositories();
+  const checkedRoots = checkedRepositories().map((repository) => repository.path);
   const includeAllEnabled = Boolean(elements.auditIncludeAll?.checked);
+
+  if (auditRoots.length > 1) {
+    elements.auditSelectionBadge.textContent = `${auditRoots.length} checked repos`;
+    elements.auditSelectionSummary.textContent = `Audit ${auditRoots.length} repositories: ${summarizeAuditSelectionValues(auditRoots)}.${includeAllEnabled ? " Non-Git folders under those roots will be included." : " Uncheck repositories in the tree when you want to narrow the run."}`;
+    return;
+  }
 
   if (selectedFolderPath) {
     elements.auditSelectionBadge.textContent = "Selected folder";
@@ -950,22 +1054,17 @@ function renderAuditSelectionSummary() {
     return;
   }
 
-  if (scopeRepositories.length === 0) {
+  if (checkedRoots.length === 1) {
+    elements.auditSelectionBadge.textContent = "Checked repo";
+    elements.auditSelectionSummary.textContent = `Audit ${checkedRoots[0]}.${includeAllEnabled ? " Non-Git folders under this root will be included." : " Click a folder in the left tree to narrow the run or check more repositories to inspect many roots."}`;
+    return;
+  }
+
+  if (auditRoots.length === 0) {
     elements.auditSelectionBadge.textContent = "No target";
     elements.auditSelectionSummary.textContent = "Select a repository on the left or click a folder in the tree to prepare the next audit run.";
     return;
   }
-
-  if (state.selectedScope === scopeSelectedValue && scopeRepositories.length === 1) {
-    const repository = scopeRepositories[0];
-    elements.auditSelectionBadge.textContent = "Selected repo";
-    elements.auditSelectionSummary.textContent = `Audit ${repository.name} at ${repository.path}.${includeAllEnabled ? " Non-Git folders under this root will be included." : " Click a folder in the left tree to narrow the run."}`;
-    return;
-  }
-
-  const scopeLabel = state.selectedScope === scopeCheckedValue ? "Checked scope" : "All repos";
-  elements.auditSelectionBadge.textContent = scopeLabel;
-  elements.auditSelectionSummary.textContent = `Audit ${scopeRepositories.length} repositories from the ${scopeLabel.toLowerCase()}: ${summarizeAuditSelectionValues(scopeRepositories.map((repository) => repository.name))}.${includeAllEnabled ? " Non-Git folders under those roots will be included." : " Click a folder in the left tree when you want to narrow the run."}`;
 }
 
 function loadFileTaskCommand() {
@@ -986,6 +1085,589 @@ function loadRemoteTaskCommand() {
 
 function loadWorkflowTaskCommand() {
   selectCommand(commandPathWorkflowValue);
+}
+
+function renderWorkflowPrimitiveState() {
+  let primitive = selectedWorkflowPrimitive();
+  const repository = selectedRepository();
+
+  elements.workflowActionRepo.textContent = repository
+    ? `${repository.name} at ${repository.path}`
+    : "Select a repository node in the tree to queue workflow actions.";
+
+  elements.workflowPrimitiveSelect.innerHTML = "";
+  if (state.workflowPrimitives.length === 0) {
+    elements.workflowPrimitiveSummary.textContent = "No workflow primitives are available in this build.";
+    elements.workflowPrimitiveFields.innerHTML = "";
+    appendEmptyState(elements.workflowPrimitiveFields, "No repo-scoped workflow primitives are available.");
+    elements.workflowActionQueueButton.disabled = true;
+    elements.workflowActionSummary.textContent = "No workflow actions available.";
+    renderWorkflowQueue();
+    return;
+  }
+
+  state.workflowPrimitives.forEach((candidate) => {
+    const option = document.createElement("option");
+    option.value = candidate.id;
+    option.textContent = candidate.label;
+    elements.workflowPrimitiveSelect.append(option);
+  });
+
+  primitive = selectedWorkflowPrimitive();
+  elements.workflowPrimitiveSelect.value = primitive?.id || "";
+  elements.workflowPrimitiveSummary.textContent = primitive?.description || "";
+  elements.workflowPrimitiveFields.innerHTML = "";
+
+  if (!primitive) {
+    appendEmptyState(elements.workflowPrimitiveFields, "Select a workflow primitive.");
+    elements.workflowActionQueueButton.disabled = true;
+    elements.workflowActionSummary.textContent = "Select a workflow action to continue.";
+    renderWorkflowQueue();
+    return;
+  }
+
+  const draft = workflowPrimitiveDraft(primitive);
+  const parameters = primitive.parameters || [];
+  if (parameters.length === 0) {
+    appendEmptyState(elements.workflowPrimitiveFields, "This workflow primitive does not expose major parameters.");
+  } else {
+    parameters.forEach((parameter) => {
+      elements.workflowPrimitiveFields.append(renderWorkflowPrimitiveParameterField(parameter, draft));
+    });
+  }
+
+  renderWorkflowPrimitiveComposerState();
+  renderWorkflowQueue();
+}
+
+function renderWorkflowPrimitiveComposerState() {
+  const primitive = selectedWorkflowPrimitive();
+  const repository = selectedRepository();
+  const draft = primitive ? workflowPrimitiveDraft(primitive) : {};
+  const readyToQueue = Boolean(repository && primitive && workflowPrimitiveDraftCanQueue(primitive, draft) && !state.workflowActionQueueApplying);
+
+  elements.workflowActionQueueButton.disabled = !readyToQueue;
+  elements.workflowActionSummary.textContent = buildWorkflowPrimitiveSummary(repository, primitive, draft);
+}
+
+/**
+ * @param {RepositoryDescriptor | null} repository
+ * @param {WorkflowPrimitiveDescriptor | null} primitive
+ * @param {Record<string, any>} draft
+ * @returns {string}
+ */
+function buildWorkflowPrimitiveSummary(repository, primitive, draft) {
+  if (!primitive) {
+    return "Select a workflow action to continue.";
+  }
+  if (!repository) {
+    return "Select a repository node in the tree to queue a workflow action.";
+  }
+  if (!workflowPrimitiveDraftCanQueue(primitive, draft)) {
+    return `Complete the required parameters for ${primitive.label}.`;
+  }
+
+  const parameterSummary = summarizeWorkflowPrimitiveParameters(primitive, draft);
+  if (!parameterSummary) {
+    return `Queue ${primitive.label} for ${repository.name} with the default parameters.`;
+  }
+  return `Queue ${primitive.label} for ${repository.name}. ${parameterSummary}`;
+}
+
+/**
+ * @param {WorkflowPrimitiveDescriptor} primitive
+ * @returns {Record<string, any>}
+ */
+function workflowPrimitiveDraft(primitive) {
+  if (!state.workflowPrimitiveDrafts[primitive.id]) {
+    state.workflowPrimitiveDrafts[primitive.id] = defaultWorkflowPrimitiveDraft(primitive);
+  }
+  return state.workflowPrimitiveDrafts[primitive.id];
+}
+
+/**
+ * @param {WorkflowPrimitiveDescriptor} primitive
+ * @returns {Record<string, any>}
+ */
+function defaultWorkflowPrimitiveDraft(primitive) {
+  const draft = {};
+  (primitive.parameters || []).forEach((parameter) => {
+    if (parameter.control === workflowPrimitiveControlCheckboxValue) {
+      draft[parameter.key] = typeof parameter.default_bool === "boolean" ? parameter.default_bool : false;
+      return;
+    }
+    draft[parameter.key] = parameter.default_value || "";
+  });
+  return draft;
+}
+
+/**
+ * @returns {WorkflowPrimitiveDescriptor | null}
+ */
+function selectedWorkflowPrimitive() {
+  if (state.workflowPrimitives.length === 0) {
+    return null;
+  }
+
+  const matchedPrimitive = state.workflowPrimitives.find((primitive) => primitive.id === state.selectedWorkflowPrimitiveID) || state.workflowPrimitives[0];
+  state.selectedWorkflowPrimitiveID = matchedPrimitive?.id || "";
+  return matchedPrimitive || null;
+}
+
+/**
+ * @param {WorkflowPrimitiveParameterDescriptor} parameter
+ * @param {Record<string, any>} draft
+ * @returns {DocumentFragment}
+ */
+function renderWorkflowPrimitiveParameterField(parameter, draft) {
+  const fragment = document.createDocumentFragment();
+
+  if (parameter.control === workflowPrimitiveControlCheckboxValue) {
+    const label = document.createElement("label");
+    label.className = "checkbox-row";
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = Boolean(draft[parameter.key]);
+    checkbox.dataset.workflowParamKey = parameter.key;
+    checkbox.dataset.workflowParamControl = parameter.control;
+
+    const copy = document.createElement("span");
+    copy.textContent = parameter.label;
+
+    label.append(checkbox, copy);
+    fragment.append(label);
+  } else {
+    const fieldLabel = document.createElement("label");
+    fieldLabel.className = "field-label";
+    fieldLabel.textContent = parameter.required ? `${parameter.label} *` : parameter.label;
+    fragment.append(fieldLabel);
+
+    if (parameter.control === workflowPrimitiveControlTextareaValue) {
+      const textarea = document.createElement("textarea");
+      textarea.className = "code-input task-code-input";
+      textarea.spellcheck = false;
+      textarea.placeholder = parameter.placeholder || "";
+      textarea.value = String(draft[parameter.key] || "");
+      textarea.dataset.workflowParamKey = parameter.key;
+      textarea.dataset.workflowParamControl = parameter.control;
+      fragment.append(textarea);
+    } else if (parameter.control === workflowPrimitiveControlSelectValue) {
+      const select = document.createElement("select");
+      select.className = "text-input";
+      select.dataset.workflowParamKey = parameter.key;
+      select.dataset.workflowParamControl = parameter.control;
+
+      if (!parameter.required) {
+        const automaticOption = document.createElement("option");
+        automaticOption.value = "";
+        automaticOption.textContent = "Use current value";
+        select.append(automaticOption);
+      }
+
+      (parameter.options || []).forEach((optionValue) => {
+        const option = document.createElement("option");
+        option.value = optionValue.value;
+        option.textContent = optionValue.label;
+        select.append(option);
+      });
+
+      select.value = String(draft[parameter.key] || "");
+      fragment.append(select);
+    } else {
+      const input = document.createElement("input");
+      input.className = "text-input";
+      input.type = "text";
+      input.placeholder = parameter.placeholder || "";
+      input.value = String(draft[parameter.key] || "");
+      input.dataset.workflowParamKey = parameter.key;
+      input.dataset.workflowParamControl = parameter.control || workflowPrimitiveControlTextValue;
+      fragment.append(input);
+    }
+  }
+
+  if (parameter.description) {
+    const note = document.createElement("p");
+    note.className = "panel-note";
+    note.textContent = parameter.description;
+    fragment.append(note);
+  }
+
+  return fragment;
+}
+
+/**
+ * @param {EventTarget | null} target
+ * @returns {void}
+ */
+function updateWorkflowPrimitiveDraft(target) {
+  if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement)) {
+    return;
+  }
+
+  const parameterKey = target.dataset.workflowParamKey || "";
+  if (!parameterKey) {
+    return;
+  }
+
+  const primitive = selectedWorkflowPrimitive();
+  if (!primitive) {
+    return;
+  }
+
+  const draft = workflowPrimitiveDraft(primitive);
+  draft[parameterKey] = target instanceof HTMLInputElement && target.type === "checkbox"
+    ? target.checked
+    : target.value;
+  renderWorkflowPrimitiveComposerState();
+}
+
+function queueWorkflowPrimitiveAction() {
+  const repository = selectedRepository();
+  const primitive = selectedWorkflowPrimitive();
+  if (!repository || !primitive) {
+    renderRunError("Select a repository node and workflow action before queueing.");
+    return;
+  }
+
+  const draft = workflowPrimitiveDraft(primitive);
+  if (!workflowPrimitiveDraftCanQueue(primitive, draft)) {
+    renderRunError(`Complete the required parameters for ${primitive.label} before queueing it.`);
+    return;
+  }
+
+  const parameters = workflowPrimitiveParameterSnapshot(primitive, draft);
+  enqueueWorkflowPrimitiveAction(repository, primitive, parameters);
+}
+
+/**
+ * @param {{ id?: string, name: string, path: string }} repository
+ * @param {WorkflowPrimitiveDescriptor} primitive
+ * @param {Record<string, any>} parameters
+ * @returns {void}
+ */
+function enqueueWorkflowPrimitiveAction(repository, primitive, parameters) {
+  const parameterSummary = summarizeWorkflowPrimitiveParameters(primitive, parameters);
+  state.workflowActionQueue = state.workflowActionQueue.concat({
+    id: `workflow-${state.nextWorkflowActionSequence}`,
+    repository_id: repository.id || "",
+    repository_path: repository.path,
+    primitive_id: primitive.id,
+    parameters: { ...parameters },
+    title: `${primitive.label} · ${repository.name}`,
+    description: parameterSummary || "Use default parameters.",
+    repository_name: repository.name,
+  });
+  state.nextWorkflowActionSequence += 1;
+  renderRunError("");
+  renderWorkflowQueue();
+  renderWorkflowPrimitiveComposerState();
+}
+
+/**
+ * @param {WorkflowPrimitiveDescriptor} primitive
+ * @param {Record<string, any>} draft
+ * @returns {Record<string, any>}
+ */
+function workflowPrimitiveParameterSnapshot(primitive, draft) {
+  const snapshot = {};
+  (primitive.parameters || []).forEach((parameter) => {
+    snapshot[parameter.key] = draft[parameter.key];
+  });
+  return snapshot;
+}
+
+/**
+ * @param {WorkflowPrimitiveDescriptor} primitive
+ * @param {Record<string, any>} draft
+ * @returns {boolean}
+ */
+function workflowPrimitiveDraftCanQueue(primitive, draft) {
+  return (primitive.parameters || []).every((parameter) => {
+    if (!parameter.required || parameter.control === workflowPrimitiveControlCheckboxValue) {
+      return true;
+    }
+
+    const rawValue = draft[parameter.key];
+    if (typeof rawValue === "string") {
+      return rawValue.trim().length > 0;
+    }
+    return String(rawValue || "").trim().length > 0;
+  });
+}
+
+/**
+ * @param {WorkflowPrimitiveDescriptor} primitive
+ * @param {Record<string, any>} parameters
+ * @returns {string}
+ */
+function summarizeWorkflowPrimitiveParameters(primitive, parameters) {
+  const summaryParts = [];
+  (primitive.parameters || []).forEach((parameter) => {
+    const rawValue = parameters[parameter.key];
+    if (parameter.control === workflowPrimitiveControlCheckboxValue) {
+      const currentValue = Boolean(rawValue);
+      const defaultValue = typeof parameter.default_bool === "boolean" ? parameter.default_bool : false;
+      if (currentValue !== defaultValue) {
+        summaryParts.push(`${parameter.label}: ${currentValue ? "yes" : "no"}`);
+      }
+      return;
+    }
+
+    const normalizedValue = summarizeWorkflowPrimitiveTextValue(String(rawValue || ""));
+    if (!normalizedValue) {
+      return;
+    }
+    if (normalizedValue === summarizeWorkflowPrimitiveTextValue(String(parameter.default_value || ""))) {
+      return;
+    }
+    summaryParts.push(`${parameter.label}: ${normalizedValue}`);
+  });
+  return summaryParts.join(" • ");
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function summarizeWorkflowPrimitiveTextValue(value) {
+  const normalizedValue = String(value || "")
+    .trim()
+    .replace(/\s*\n\s*/g, " | ")
+    .replace(/\s+/g, " ");
+  if (!normalizedValue) {
+    return "";
+  }
+  if (normalizedValue.length <= 72) {
+    return normalizedValue;
+  }
+  return `${normalizedValue.slice(0, 69)}...`;
+}
+
+function renderWorkflowQueue() {
+  const shouldShowQueue = state.workflowActionQueue.length > 0 || state.workflowActionQueueApplying;
+  if (!shouldShowQueue) {
+    elements.workflowQueuePanel.hidden = true;
+    elements.workflowQueueSummary.textContent = "";
+    elements.workflowQueueList.innerHTML = "";
+    return;
+  }
+
+  elements.workflowQueuePanel.hidden = false;
+  elements.workflowQueueSummary.textContent = workflowQueueSummary(state.workflowActionQueue.length);
+  elements.workflowQueueList.innerHTML = "";
+
+  if (state.workflowActionQueue.length === 0) {
+    appendEmptyState(elements.workflowQueueList, "No workflow actions are queued.");
+  } else {
+    state.workflowActionQueue.forEach((action) => {
+      const container = document.createElement("article");
+      container.className = "audit-queue-item";
+
+      const heading = document.createElement("div");
+      heading.className = "audit-queue-item-heading";
+
+      const title = document.createElement("strong");
+      title.textContent = action.title;
+      heading.append(title);
+
+      const removeButton = document.createElement("button");
+      removeButton.type = "button";
+      removeButton.className = "secondary-button audit-queue-remove";
+      removeButton.dataset.workflowQueueRemoveId = action.id;
+      removeButton.textContent = "Remove";
+      heading.append(removeButton);
+
+      const description = document.createElement("p");
+      description.className = "audit-queue-description";
+      description.textContent = action.description;
+
+      const meta = document.createElement("div");
+      meta.className = "audit-queue-meta";
+      appendToken(meta, workflowPrimitiveLabel(action.primitive_id), "token-default");
+      appendToken(meta, action.repository_path, "token-context");
+
+      container.append(heading, description, meta);
+      elements.workflowQueueList.append(container);
+    });
+  }
+
+  elements.workflowQueueClear.disabled = state.workflowActionQueue.length === 0 || state.workflowActionQueueApplying;
+  elements.workflowQueueApply.disabled = state.workflowActionQueue.length === 0 || state.workflowActionQueueApplying;
+}
+
+/**
+ * @param {Event} event
+ * @returns {void}
+ */
+function handleWorkflowQueueListClick(event) {
+  const actionButton = event.target instanceof HTMLElement
+    ? event.target.closest("[data-workflow-queue-remove-id]")
+    : null;
+  const queueID = actionButton?.dataset.workflowQueueRemoveId || "";
+  if (!queueID) {
+    return;
+  }
+
+  removeQueuedWorkflowAction(queueID);
+}
+
+function clearWorkflowQueue() {
+  state.workflowActionQueue = [];
+  renderRunError("");
+  renderWorkflowQueue();
+}
+
+/**
+ * @param {string} queueID
+ * @returns {void}
+ */
+function removeQueuedWorkflowAction(queueID) {
+  if (!queueID) {
+    return;
+  }
+
+  state.workflowActionQueue = state.workflowActionQueue.filter((action) => action.id !== queueID);
+  renderRunError("");
+  renderWorkflowQueue();
+}
+
+async function applyWorkflowQueue() {
+  if (state.workflowActionQueue.length === 0 || state.workflowActionQueueApplying) {
+    return;
+  }
+
+  state.workflowActionQueueApplying = true;
+  renderWorkflowQueue();
+  renderWorkflowPrimitiveComposerState();
+  clearRunnerOutput();
+  clearPolling();
+  renderRunError("");
+  setStatus("loading");
+  elements.runID.textContent = "workflow apply";
+
+  try {
+    const response = await fetch(workflowApplyEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        actions: state.workflowActionQueue.map((action) => ({
+          id: action.id,
+          repository_id: action.repository_id || "",
+          repository_path: action.repository_path,
+          primitive_id: action.primitive_id,
+          parameters: { ...(action.parameters || {}) },
+        })),
+      }),
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+      throw new Error(payload.error || `Failed to apply queued workflow actions: ${response.status}`);
+    }
+
+    /** @type {WorkflowPrimitiveApplyResponse} */
+    const applyResponse = await response.json();
+    if (applyResponse.error) {
+      throw new Error(applyResponse.error);
+    }
+
+    const results = applyResponse.results || [];
+    renderWorkflowApplyResults(results);
+
+    const succeededIDs = new Set(
+      results
+        .filter((result) => result.status === auditChangeStatusSucceededValue)
+        .map((result) => result.id),
+    );
+    state.workflowActionQueue = state.workflowActionQueue.filter((action) => !succeededIDs.has(action.id));
+
+    const failedResults = results.filter((result) => result.status !== auditChangeStatusSucceededValue);
+    if (failedResults.length > 0) {
+      renderRunError(`${failedResults.map(formatWorkflowApplyIssue).join("\n")}\nRefresh the audit table when you want a new snapshot.`);
+      setStatus("failed");
+    } else {
+      renderRunError("Apply finished. Refresh the audit table when you want a new snapshot.");
+      setStatus("succeeded");
+    }
+  } catch (error) {
+    renderRunError(String(error));
+    setStatus("failed");
+  } finally {
+    state.workflowActionQueueApplying = false;
+    renderWorkflowQueue();
+    renderWorkflowPrimitiveComposerState();
+  }
+}
+
+/**
+ * @param {WorkflowPrimitiveApplyResult[]} results
+ */
+function renderWorkflowApplyResults(results) {
+  const stdoutSections = [];
+  const stderrSections = [];
+
+  results.forEach((result) => {
+    const headingParts = [workflowPrimitiveLabel(result.primitive_id)];
+    if (result.repository_path) {
+      headingParts.push(result.repository_path);
+    }
+    const heading = headingParts.join(" · ");
+
+    const stdoutLines = [];
+    if (result.message) {
+      stdoutLines.push(result.message);
+    }
+    if (result.stdout) {
+      stdoutLines.push(result.stdout.trim());
+    }
+    if (stdoutLines.length > 0) {
+      stdoutSections.push(`${heading}\n${stdoutLines.filter(Boolean).join("\n")}`.trim());
+    }
+
+    const stderrLines = [];
+    if (result.error) {
+      stderrLines.push(result.error);
+    }
+    if (result.stderr) {
+      stderrLines.push(result.stderr.trim());
+    }
+    if (stderrLines.length > 0) {
+      stderrSections.push(`${heading}\n${stderrLines.filter(Boolean).join("\n")}`.trim());
+    }
+  });
+
+  elements.stdoutOutput.textContent = stdoutSections.join("\n\n");
+  elements.stderrOutput.textContent = stderrSections.join("\n\n");
+}
+
+/**
+ * @param {WorkflowPrimitiveApplyResult} result
+ * @returns {string}
+ */
+function formatWorkflowApplyIssue(result) {
+  if (result.error) {
+    return result.error;
+  }
+  if (result.status === auditChangeStatusSkippedValue) {
+    return `${workflowPrimitiveLabel(result.primitive_id)} skipped for ${result.repository_path}`;
+  }
+  return `${workflowPrimitiveLabel(result.primitive_id)} failed for ${result.repository_path}`;
+}
+
+/**
+ * @param {number} count
+ * @returns {string}
+ */
+function workflowQueueSummary(count) {
+  return `${count} queued ${count === 1 ? "action" : "actions"}`;
+}
+
+/**
+ * @param {string} primitiveID
+ * @returns {string}
+ */
+function workflowPrimitiveLabel(primitiveID) {
+  return state.workflowPrimitives.find((primitive) => primitive.id === primitiveID)?.label || primitiveID;
 }
 
 async function runAuditTask() {
@@ -1107,173 +1789,9 @@ function renderTargetState() {
   elements.targetRepoSummary.textContent = `${scopeRepositories.length} ${scopeRepositories.length === 1 ? "repo" : "repos"}`;
   elements.targetRepoDetail.textContent = buildRepositoryScopeDetail(scopeLabel, scopeRepositories);
 
-  elements.targetRefMode.value = state.targetRefMode;
-  renderRefValueField();
-  elements.targetRefSummary.textContent = buildRefSummary();
-  elements.targetRefDetail.textContent = buildRefDetail();
-
-  elements.targetPathMode.value = state.targetPathMode;
-  renderPathValueField();
-  elements.targetPathSummary.textContent = buildPathSummary();
-  elements.targetPathDetail.textContent = buildPathDetail();
-
   renderAuditTaskState();
   renderFileTaskState();
   updateActionContext();
-}
-
-function renderRefValueField() {
-  const namedMode = state.targetRefMode === refModeNamedValue;
-  const patternMode = state.targetRefMode === refModePatternValue;
-  const explicitValueMode = namedMode || patternMode;
-  const namedOptions = namedRefOptions();
-
-  elements.targetRefValueBlock.hidden = !explicitValueMode;
-  elements.targetRefValueLabel.hidden = !explicitValueMode;
-  elements.targetRefSelect.hidden = !namedMode;
-  elements.targetRefSelect.disabled = !namedMode || namedOptions.length === 0;
-  elements.targetRefValue.hidden = namedMode;
-  elements.targetRefValue.disabled = !patternMode;
-  elements.targetRefValue.placeholder = patternMode ? "branch-*" : "Resolved automatically";
-
-  if (namedMode) {
-    if (namedOptions.length > 0 && !namedOptions.some((option) => option.value === state.targetRefValue)) {
-      state.targetRefValue = namedOptions[0].value;
-    }
-    if (namedOptions.length === 0) {
-      state.targetRefValue = "";
-    }
-
-    elements.targetRefSelect.innerHTML = "";
-    if (namedOptions.length === 0) {
-      const emptyOption = document.createElement("option");
-      emptyOption.value = "";
-      emptyOption.textContent = "No named refs available";
-      elements.targetRefSelect.append(emptyOption);
-      elements.targetRefSelect.value = "";
-      return;
-    }
-
-    namedOptions.forEach((option) => {
-      const optionElement = document.createElement("option");
-      optionElement.value = option.value;
-      optionElement.textContent = option.label;
-      elements.targetRefSelect.append(optionElement);
-    });
-    elements.targetRefSelect.value = state.targetRefValue;
-    return;
-  }
-
-  elements.targetRefSelect.innerHTML = "";
-  elements.targetRefValue.value = patternMode ? state.targetRefValue : "";
-}
-
-function renderPathValueField() {
-  const pathInputVisible = state.targetPathMode !== pathModeNoneValue;
-  const multilinePathMode = state.targetPathMode === pathModeMultipleValue;
-
-  elements.targetPathValueBlock.hidden = !pathInputVisible;
-  elements.targetPathValueLabel.hidden = !pathInputVisible;
-  elements.targetPathValue.disabled = !pathInputVisible;
-  elements.targetPathValue.placeholder = pathInputPlaceholder();
-  elements.targetPathValue.value = state.targetPathValue;
-  elements.targetPathValue.classList.toggle("target-path-input-expanded", multilinePathMode);
-}
-
-/**
- * @returns {{ value: string, label: string }[]}
- */
-function namedRefOptions() {
-  const repository = selectedRepository();
-  const options = [];
-  const seenValues = new Set();
-
-  /**
-   * @param {string} value
-   * @param {string} label
-   */
-  const appendOption = (value, label) => {
-    const trimmedValue = value.trim();
-    if (!trimmedValue || seenValues.has(trimmedValue)) {
-      return;
-    }
-    seenValues.add(trimmedValue);
-    options.push({ value: trimmedValue, label });
-  };
-
-  if (repository?.current_branch) {
-    appendOption(repository.current_branch, `${repository.current_branch} · current`);
-  }
-  if (repository?.default_branch) {
-    appendOption(repository.default_branch, `${repository.default_branch} · default`);
-  }
-  state.branches.forEach((branch) => {
-    const branchSuffix = branch.current
-      ? "current"
-      : repository?.default_branch === branch.name
-        ? "default"
-        : branch.upstream || "local";
-    appendOption(branch.name, `${branch.name} · ${branchSuffix}`);
-  });
-
-  return options;
-}
-
-/**
- * @returns {string}
- */
-function buildRefDetail() {
-  const repository = selectedRepository();
-
-  if (!repository) {
-    return "Select a repository to resolve ref targets.";
-  }
-
-  if (state.targetRefMode === refModeNamedValue) {
-    if (namedRefOptions().length === 0) {
-      return "No local named refs are available for the selected repository.";
-    }
-    return state.selectedScope === scopeSelectedValue
-      ? "Named refs come from the selected repository branch list."
-      : "Named refs come from the selected repository branch list and apply across the active repository scope.";
-  }
-
-  if (state.targetRefMode === refModePatternValue) {
-    return "Enter a branch pattern when the command accepts pattern-based ref targeting.";
-  }
-
-  if (state.targetRefMode === refModeCurrentValue) {
-    return state.selectedScope === scopeSelectedValue
-      ? `Current resolves to ${repository.current_branch || "the checked out branch"}.`
-      : "Current resolves independently inside each active repository.";
-  }
-
-  if (state.targetRefMode === refModeDefaultValue) {
-    return state.selectedScope === scopeSelectedValue
-      ? `Default resolves to ${repository.default_branch || "the inferred default branch"}.`
-      : "Default resolves independently inside each active repository.";
-  }
-
-  return "Any leaves ref selection to the command or repository state.";
-}
-
-/**
- * @returns {string}
- */
-function buildPathDetail() {
-  if (state.targetPathMode === pathModeNoneValue) {
-    return "No path filter will be applied.";
-  }
-
-  if (state.targetPathMode === pathModeRelativeValue) {
-    return "Target one relative path.";
-  }
-
-  if (state.targetPathMode === pathModeGlobValue) {
-    return "Target one glob pattern.";
-  }
-
-  return "Target multiple paths or patterns, one per line.";
 }
 
 /**
@@ -1285,6 +1803,7 @@ async function renderRepositoryTree(query) {
   }
 
   elements.repoTree.classList.remove("wb-skeleton", "wb-initializing");
+  await ensureRepositoryTreeDirectoryDataLoaded();
 
   const treeModel = buildRepositoryTreeModel(state.repositories);
   if (treeModel.length === 0) {
@@ -1348,6 +1867,7 @@ function ensureRepositoryTreeControl() {
       if (typeof event.node?.setExpanded === "function") {
         void event.node.setExpanded(nextExpanded);
       }
+      void handleRepositoryTreeFolderClick(state.selectedFolderPath);
 
       if (typeof event.node?.setExpanded === "function") {
         return false;
@@ -1365,13 +1885,6 @@ function ensureRepositoryTreeControl() {
         syncAuditSelectionFromTree();
       }
     },
-    select: (event) => {
-      const repositoryID = String(event.node.data?.repository_id || "");
-      if (!repositoryID) {
-        return;
-      }
-      toggleCheckedRepository(repositoryID, Boolean(event.node.selected));
-    },
     render: annotateRepositoryTreeNode,
   });
 
@@ -1388,6 +1901,17 @@ function repositoryTreeExpandedKeys() {
     return [];
   }
   return treeState.expandedKeys.slice();
+}
+
+/**
+ * @returns {string[]}
+ */
+function repositoryTreeExpandedFolderPaths() {
+  return repositoryTreeExpandedKeys()
+    .map((key) => String(key || ""))
+    .filter((key) => key.startsWith("folder:"))
+    .map((key) => normalizeRepositoryTreePath(key.slice("folder:".length)))
+    .filter(Boolean);
 }
 
 /**
@@ -1490,7 +2014,26 @@ function buildRepositoryTreeSource(treeModel, expandedKeys) {
  * @returns {RepoTreeNodeModel[]}
  */
 function buildRepositoryTreeModel(repositories) {
-  return buildFolderExplorerTreeModel(repositories, explorerRootPaths());
+  return buildFolderExplorerTreeModel(repositories, repositoryTreeRootPaths());
+}
+
+/**
+ * @returns {string[]}
+ */
+function defaultRepositoryTreeRootPaths() {
+  const launchRoots = configuredLaunchRoots();
+  if (launchRoots.length > 1) {
+    const commonRootPath = normalizeRepositoryTreePath(state.repositoryCatalog?.explorer_root || state.repositoryCatalog?.launch_path || "");
+    return commonRootPath ? [commonRootPath] : launchRoots;
+  }
+
+  if (launchRoots.length === 1) {
+    const parentRootPath = parentDirectoryPath(launchRoots[0]);
+    return parentRootPath ? [parentRootPath] : launchRoots;
+  }
+
+  const explorerRoot = normalizeRepositoryTreePath(state.repositoryCatalog?.explorer_root || state.repositoryCatalog?.launch_path || "");
+  return explorerRoot ? [explorerRoot] : [];
 }
 
 /**
@@ -1518,6 +2061,22 @@ function explorerRootPaths() {
 }
 
 /**
+ * @returns {string[]}
+ */
+function repositoryTreeRootPaths() {
+  const overridePaths = (Array.isArray(state.repositoryTreeRootPathsOverride)
+    ? state.repositoryTreeRootPathsOverride
+    : [])
+    .map((rootPath) => normalizeRepositoryTreePath(rootPath))
+    .filter(Boolean);
+  if (overridePaths.length > 0) {
+    return overridePaths;
+  }
+
+  return defaultRepositoryTreeRootPaths();
+}
+
+/**
  * @param {RepositoryDescriptor[]} repositories
  * @param {string[]} rootPaths
  * @returns {RepoTreeNodeModel[]}
@@ -1536,7 +2095,8 @@ function buildFolderExplorerTreeModel(repositories, rootPaths) {
   const treeModel = [];
 
   normalizedRootPaths.forEach((rootPath) => {
-    ensureFolderExplorerRootNode(treeModel, nodeIndex, rootPath);
+    const rootNode = ensureFolderExplorerRootNode(treeModel, nodeIndex, rootPath);
+    populateLoadedFolderExplorerChildren(rootNode, nodeIndex);
   });
 
   repositories.forEach((repository) => {
@@ -1555,6 +2115,18 @@ function buildFolderExplorerTreeModel(repositories, rootPaths) {
 
   sortRepositoryTreeNodes(treeModel);
   return treeModel;
+}
+
+/**
+ * @param {RepoTreeNodeModel} parentNode
+ * @param {Map<string, RepoTreeNodeModel>} nodeIndex
+ * @returns {void}
+ */
+function populateLoadedFolderExplorerChildren(parentNode, nodeIndex) {
+  directoryFoldersForPath(parentNode.absolute_path || parentNode.path).forEach((folder) => {
+    const childNode = ensureFolderExplorerChildNode(parentNode, nodeIndex, folder.path);
+    populateLoadedFolderExplorerChildren(childNode, nodeIndex);
+  });
 }
 
 /**
@@ -1770,7 +2342,7 @@ function repositoryTreeShouldExpandFolder(node, expandedKeys) {
     return false;
   }
 
-  if (explorerRootPaths().includes(folderPath)) {
+  if (repositoryTreeRootPaths().includes(folderPath) || configuredLaunchRoots().includes(folderPath)) {
     return true;
   }
 
@@ -2043,6 +2615,7 @@ function annotateRepositoryTreeNode(event) {
   if (rowElement instanceof HTMLElement) {
     rowElement.dataset.repoTreeKind = kind;
     rowElement.dataset.repoTreeKey = String(event.node.key || "");
+    rowElement.dataset.repoTreeRepositoryId = String(event.node.data?.repository_id || "");
     if (absolutePath) {
       rowElement.dataset.repoTreeAbsolutePath = absolutePath;
     } else {
@@ -2098,6 +2671,35 @@ function handleRepositoryTreeAuditRootSelection(event) {
 }
 
 /**
+ * @param {MouseEvent} event
+ */
+function handleRepositoryTreeCheckboxClick(event) {
+  const eventTarget = event.target;
+  if (!(eventTarget instanceof HTMLElement)) {
+    return;
+  }
+
+  const checkboxElement = eventTarget.closest(".wb-checkbox");
+  if (!(checkboxElement instanceof HTMLElement)) {
+    return;
+  }
+
+  const rowElement = checkboxElement.closest(".wb-row");
+  if (!(rowElement instanceof HTMLElement)) {
+    return;
+  }
+
+  const repositoryID = String(rowElement.dataset.repoTreeRepositoryId || "").trim();
+  if (!repositoryID) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  toggleCheckedRepository(repositoryID, !state.checkedRepositoryIDs.includes(repositoryID));
+}
+
+/**
  * @returns {void}
  */
 function syncAuditSelectionFromTree() {
@@ -2128,7 +2730,9 @@ async function selectRepository(repositoryID) {
   renderActionGroups(elements.commandFilter.value.trim().toLowerCase());
   syncQuickActions();
 
-  const response = await fetch(`${repositoriesEndpoint}/${encodeURIComponent(repositoryID)}/branches`);
+  const response = await fetch(
+    `${repositoriesEndpoint}/${encodeURIComponent(repositoryID)}/branches?path=${encodeURIComponent(repository.path)}`,
+  );
   if (!response.ok) {
     state.branches = [];
     syncQuickActions(`Failed to load branches: ${response.status}`);
@@ -2147,6 +2751,28 @@ async function selectRepository(repositoryID) {
   renderTargetState();
   syncQuickActions();
   repopulateSelectedCommand();
+}
+
+/**
+ * @param {string} folderPath
+ * @returns {Promise<void>}
+ */
+async function handleRepositoryTreeFolderClick(folderPath) {
+  const normalizedFolderPath = normalizeRepositoryTreePath(folderPath);
+  if (!normalizedFolderPath) {
+    return;
+  }
+
+  const currentRootPaths = repositoryTreeRootPaths();
+  if (currentRootPaths.length === 1 && currentRootPaths[0] === normalizedFolderPath) {
+    const parentPath = parentDirectoryPath(normalizedFolderPath);
+    if (parentPath) {
+      state.repositoryTreeRootPathsOverride = [parentPath];
+    }
+  }
+
+  await ensureDirectoryFoldersLoaded(normalizedFolderPath);
+  await renderRepositoryTree(elements.repoFilter.value.trim().toLowerCase());
 }
 
 /**
@@ -2203,6 +2829,11 @@ function preferredInitialRepositoryTreeKey(initialRepositoryID) {
  * @returns {string}
  */
 function preferredInitialRepositoryTreeFolderPath() {
+  const launchRoots = configuredLaunchRoots();
+  if (launchRoots.length > 0) {
+    return launchRoots[0];
+  }
+
   return explorerRootPaths()[0] || "";
 }
 
@@ -2235,7 +2866,7 @@ function renderSelectedRepository() {
   if (!repository) {
     elements.repoTitle.textContent = state.repositoryCatalog?.error ? "Repository context unavailable" : "No repository selected";
     elements.repoPath.textContent = activeRepositoryTreeFolderPath() || state.repositoryCatalog?.launch_path || "";
-    elements.repoSummary.textContent = state.repositoryCatalog?.error || "Select a repository folder to scope branch and repository actions.";
+    elements.repoSummary.textContent = state.repositoryCatalog?.error || "Select a repository folder to queue repo-scoped workflow actions.";
     elements.repoStateTokens.innerHTML = "";
     return;
   }
@@ -2259,92 +2890,25 @@ function renderSelectedRepository() {
 }
 
 function updateActionContext() {
-  const scopeRepositories = repositoryScopeRepositories();
-  const selectedCommand = findSelectedCommand();
-  const commandDraft = selectedCommand ? resolveCommandDraft(selectedCommand) : null;
-  const repositorySummary = `${scopeRepositories.length} ${scopeRepositories.length === 1 ? "repo" : "repos"}`;
-  const refSummary = buildRefSummary();
-  const pathSummary = buildPathSummary();
+  const auditRoots = workingFolderRoots();
+  const repository = selectedRepository();
 
-  switch (state.activeTask) {
-    case taskInspectValue:
-      if (resolveAuditRoots().length === 0) {
-        elements.actionContext.textContent = "Audit is the primary flow above. Select a folder in the tree to inspect.";
-        return;
-      }
-      elements.actionContext.textContent = `Audit is configured above for ${workingFolderRoots().length} ${workingFolderRoots().length === 1 ? "folder" : "folders"}. Run it there, then return here for follow-up commands.`;
-      return;
-    case taskBranchValue:
-      if (selectedCommand && selectedCommand.target.group === commandGroupBranchValue && commandDraft?.reason) {
-        elements.actionContext.textContent = commandDraft.reason;
-        return;
-      }
-      if (scopeRepositories.length === 0) {
-        elements.actionContext.textContent = "Choose a repository target set before running branch commands.";
-        return;
-      }
-      elements.actionContext.textContent = `Branch task targets ${repositorySummary}. Ref mode ${refSummary}.`;
-      return;
-    case taskFilesValue:
-      if (selectedCommand && selectedCommand.target.group === commandGroupFilesValue && commandDraft?.reason) {
-        elements.actionContext.textContent = commandDraft.reason;
-        return;
-      }
-      if (scopeRepositories.length === 0) {
-        elements.actionContext.textContent = "Choose a repository target set before running file commands.";
-        return;
-      }
-      elements.actionContext.textContent = `Files task targets ${repositorySummary}. Ref mode ${refSummary}. Path mode ${pathSummary}.`;
-      return;
-    case taskRemotesValue:
-      if (scopeRepositories.length === 0) {
-        elements.actionContext.textContent = "Choose a repository target set before running remote normalization.";
-        return;
-      }
-      if (selectedCommand && selectedCommand.target.group === commandGroupRemoteValue && commandDraft?.reason) {
-        elements.actionContext.textContent = commandDraft.reason;
-        return;
-      }
-      elements.actionContext.textContent = `Remote normalization targets ${repositorySummary}.`;
-      return;
-    case taskCleanupValue:
-      if (scopeRepositories.length === 0) {
-        elements.actionContext.textContent = "Choose a repository target set before running cleanup commands.";
-        return;
-      }
-      elements.actionContext.textContent = `Cleanup task targets ${repositorySummary}.`;
-      return;
-    case taskWorkflowsValue: {
-      const workflowTarget = elements.workflowTargetInput?.value.trim() || "WORKFLOW_OR_PRESET";
-      if (scopeRepositories.length === 0) {
-        elements.actionContext.textContent = "Choose a repository target set before running workflow commands.";
-        return;
-      }
-      elements.actionContext.textContent = `Workflow task targets ${repositorySummary}. Workflow ${workflowTarget}.`;
-      return;
-    }
-    case taskAdvancedValue:
-      if (selectedCommand && commandDraft?.reason) {
-        elements.actionContext.textContent = commandDraft.reason;
-        return;
-      }
-      if (selectedCommand && selectedCommand.target.repository === targetRequirementNoneValue) {
-        elements.actionContext.textContent = "This command is global and ignores repository, ref, and path targets.";
-        return;
-      }
-      if (scopeRepositories.length === 0) {
-        elements.actionContext.textContent = "Advanced mode exposes raw commands. Select repository targets when the command is repo-scoped.";
-        return;
-      }
-      if (selectedCommand && selectedCommand.target.path !== targetRequirementNoneValue) {
-        elements.actionContext.textContent = `Advanced mode targeting ${repositorySummary}. Ref mode ${refSummary}. Path mode ${pathSummary}.`;
-        return;
-      }
-      elements.actionContext.textContent = `Advanced mode targeting ${repositorySummary}. Ref mode ${refSummary}.`;
-      return;
-    default:
-      elements.actionContext.textContent = "";
+  if (!repository && auditRoots.length === 0) {
+    elements.actionContext.textContent = "Select folders in the tree, inspect them above, and then select a repository node to queue repo-scoped workflow actions.";
+    return;
   }
+
+  if (!repository) {
+    elements.actionContext.textContent = `Inspect ${auditRoots.length} ${auditRoots.length === 1 ? "folder" : "folders"} above, then select a repository node in the tree to queue repo-scoped workflow actions.`;
+    return;
+  }
+
+  if (auditRoots.length === 0) {
+    elements.actionContext.textContent = `Select folders in the tree, inspect them above, and then queue workflow actions for ${repository.name}.`;
+    return;
+  }
+
+  elements.actionContext.textContent = `Inspect ${auditRoots.length} ${auditRoots.length === 1 ? "folder" : "folders"} above. Queue workflow actions for ${repository.name}. Apply actions, review the results, then inspect again when you want a refreshed audit table.`;
 }
 
 function syncQuickActions(errorText = "") {
@@ -2499,7 +3063,6 @@ function selectCommand(commandPath, options = {}) {
     return;
   }
 
-  state.activeTask = inferTaskForCommand(command);
   state.selectedPath = command.path;
   renderTaskState();
   renderActionGroups(elements.commandFilter.value.trim().toLowerCase());
@@ -2554,7 +3117,7 @@ function resolveCommandDraft(command) {
   if (command.target.repository !== targetRequirementNoneValue && rootArguments.length === 0) {
     return {
       arguments: [],
-      reason: "Select at least one repository in the target bar to run this command.",
+      reason: "Select at least one repository in the tree to run this command.",
     };
   }
 
@@ -2618,7 +3181,7 @@ function buildRemoteTaskArguments(rootArguments) {
   if (rootArguments.length === 0) {
     return {
       arguments: [],
-      reason: "Select at least one repository in the target bar to run remote normalization.",
+      reason: "Select at least one repository in the tree to run remote normalization.",
     };
   }
 
@@ -2639,7 +3202,7 @@ function buildWorkflowTaskArguments() {
   if (repositoryRoots.length === 0) {
     return {
       arguments: [],
-      reason: "Select at least one repository in the target bar to run a workflow command.",
+      reason: "Select at least one repository in the tree to run a workflow command.",
     };
   }
 
@@ -3441,10 +4004,17 @@ function renderTypedAuditTable(rows) {
           if (action.queued) {
             button.classList.add("audit-action-button-queued");
           }
+          if (action.actionType === "workflow" && action.ready === false && !action.queuedWorkflowActionID) {
+            button.classList.add("audit-action-button-configure");
+          }
+          button.dataset.auditActionType = action.actionType;
           button.dataset.auditAction = action.kind;
           button.dataset.auditPath = row.path;
           if (action.queuedChangeID) {
             button.dataset.auditQueuedChangeId = action.queuedChangeID;
+          }
+          if (action.queuedWorkflowActionID) {
+            button.dataset.workflowQueuedActionId = action.queuedWorkflowActionID;
           }
           button.textContent = action.label;
           actionsList.append(button);
@@ -3647,9 +4217,16 @@ function handleAuditResultsClick(event) {
     return;
   }
 
+  const actionType = actionButton.dataset.auditActionType || "audit";
   const actionKind = actionButton.dataset.auditAction || "";
   const actionPath = actionButton.dataset.auditPath || "";
   if (!actionKind || !actionPath) {
+    return;
+  }
+
+  const queuedWorkflowActionID = actionButton.dataset.workflowQueuedActionId || "";
+  if (actionType === "workflow" && queuedWorkflowActionID) {
+    removeQueuedWorkflowAction(queuedWorkflowActionID);
     return;
   }
 
@@ -3665,9 +4242,14 @@ function handleAuditResultsClick(event) {
     return;
   }
 
-  const action = buildAuditRowActions(row).find((candidate) => candidate.kind === actionKind);
+  const action = buildAuditRowActions(row).find((candidate) => candidate.actionType === actionType && candidate.kind === actionKind);
   if (!action) {
-    renderRunError(`Audit action ${actionKind} is not available for ${actionPath}.`);
+    renderRunError(`${actionType === "workflow" ? "Workflow" : "Audit"} action ${actionKind} is not available for ${actionPath}.`);
+    return;
+  }
+
+  if (actionType === "workflow") {
+    queueWorkflowActionFromAuditRow(row, action);
     return;
   }
 
@@ -3787,10 +4369,11 @@ function updateAuditQueueText(changeID, fieldName, fieldValue) {
  */
 function buildAuditRowActions(row) {
   /** @type {AuditRowActionDefinition[]} */
-  const actions = [];
+  const auditActions = [];
   if (row.is_git_repository) {
     if (row.name_matches === "no") {
-      actions.push({
+      auditActions.push({
+        actionType: "audit",
         kind: auditChangeKindRenameFolderValue,
         label: "Queue rename",
         title: "Rename folder",
@@ -3806,7 +4389,8 @@ function buildAuditRowActions(row) {
     }
 
     if (protocolFixAvailable(row)) {
-      actions.push({
+      auditActions.push({
+        actionType: "audit",
         kind: auditChangeKindConvertProtocolValue,
         label: "Queue protocol fix",
         title: "Fix protocol",
@@ -3821,7 +4405,8 @@ function buildAuditRowActions(row) {
     }
 
     if (row.origin_remote_status === "configured" && row.origin_matches_canonical === "no") {
-      actions.push({
+      auditActions.push({
+        actionType: "audit",
         kind: auditChangeKindUpdateCanonicalValue,
         label: "Queue remote fix",
         title: "Fix canonical remote",
@@ -3836,7 +4421,8 @@ function buildAuditRowActions(row) {
     }
 
     if (row.origin_remote_status === "configured" && row.in_sync === "no" && row.remote_default_branch && row.remote_default_branch !== "n/a") {
-      actions.push({
+      auditActions.push({
+        actionType: "audit",
         kind: auditChangeKindSyncWithRemoteValue,
         label: "Queue sync",
         title: "Sync with remote",
@@ -3851,7 +4437,8 @@ function buildAuditRowActions(row) {
   }
 
   if (row.path) {
-    actions.push({
+    auditActions.push({
+      actionType: "audit",
       kind: auditChangeKindDeleteFolderValue,
       label: "Queue delete",
       title: "Delete folder",
@@ -3864,7 +4451,7 @@ function buildAuditRowActions(row) {
     });
   }
 
-  return actions.map((action) => {
+  const queuedAuditActions = auditActions.map((action) => {
     const queuedChange = queuedAuditChangeForAction(row.path, action.kind);
     if (!queuedChange) {
       return action;
@@ -3877,6 +4464,94 @@ function buildAuditRowActions(row) {
       queuedChangeID: queuedChange.id,
     };
   });
+
+  return queuedAuditActions.concat(buildWorkflowRowActions(row));
+}
+
+/**
+ * @param {AuditInspectionRow} row
+ * @returns {AuditRowActionDefinition[]}
+ */
+function buildWorkflowRowActions(row) {
+  if (!row.is_git_repository || !row.path) {
+    return [];
+  }
+
+  const repository = repositoryForFolderPath(row.path) || {
+    id: "",
+    name: row.folder_name || row.path,
+    path: row.path,
+  };
+
+  return state.workflowPrimitives
+    .filter((primitive) => workflowPrimitiveVisibleInAuditTable(primitive.id))
+    .map((primitive) => {
+      const draft = workflowPrimitiveDraft(primitive);
+      const parameters = workflowPrimitiveParameterSnapshot(primitive, draft);
+      const ready = workflowPrimitiveDraftCanQueue(primitive, draft);
+      const queuedAction = queuedWorkflowActionForAuditRow(repository.path, primitive.id, parameters);
+      const label = queuedAction
+        ? `Dequeue ${primitive.label}`
+        : ready
+          ? `Queue ${primitive.label}`
+          : `Configure ${primitive.label}`;
+      const parameterSummary = summarizeWorkflowPrimitiveParameters(primitive, parameters);
+
+      return {
+        actionType: "workflow",
+        kind: primitive.id,
+        label,
+        queued: Boolean(queuedAction),
+        queuedWorkflowActionID: queuedAction?.id || "",
+        ready,
+        title: primitive.label,
+        description: ready
+          ? `Queue ${primitive.label} for ${repository.name}. ${parameterSummary || "Use default parameters."}`
+          : `Complete the required parameters for ${primitive.label} in Workflow Actions before queueing it for ${repository.name}.`,
+        primitiveID: primitive.id,
+        parameters,
+      };
+    });
+}
+
+/**
+ * @param {string} primitiveID
+ * @returns {boolean}
+ */
+function workflowPrimitiveVisibleInAuditTable(primitiveID) {
+  return ![
+    webWorkflowPrimitiveCanonicalRemoteValue,
+    webWorkflowPrimitiveProtocolConversionValue,
+    webWorkflowPrimitiveRenameFolderValue,
+  ].includes(primitiveID);
+}
+
+/**
+ * @param {string} repositoryPath
+ * @param {string} primitiveID
+ * @param {Record<string, any>} parameters
+ * @returns {WorkflowPrimitiveQueueEntry | undefined}
+ */
+function queuedWorkflowActionForAuditRow(repositoryPath, primitiveID, parameters) {
+  const normalizedRepositoryPath = normalizeRepositoryTreePath(repositoryPath);
+  const parameterSignature = workflowPrimitiveParameterSignature(parameters);
+  return state.workflowActionQueue.find((action) => {
+    return normalizeRepositoryTreePath(action.repository_path) === normalizedRepositoryPath &&
+      action.primitive_id === primitiveID &&
+      workflowPrimitiveParameterSignature(action.parameters || {}) === parameterSignature;
+  });
+}
+
+/**
+ * @param {Record<string, any>} parameters
+ * @returns {string}
+ */
+function workflowPrimitiveParameterSignature(parameters) {
+  const normalizedParameters = {};
+  Object.keys(parameters || {}).sort().forEach((key) => {
+    normalizedParameters[key] = parameters[key];
+  });
+  return JSON.stringify(normalizedParameters);
 }
 
 /**
@@ -3923,6 +4598,34 @@ function queueAuditChange(row, action) {
   state.auditQueueVisible = true;
   renderRunError("");
   renderAuditQueueState();
+}
+
+/**
+ * @param {AuditInspectionRow} row
+ * @param {AuditRowActionDefinition} action
+ * @returns {void}
+ */
+function queueWorkflowActionFromAuditRow(row, action) {
+  const primitive = state.workflowPrimitives.find((candidate) => candidate.id === action.primitiveID);
+  if (!primitive) {
+    renderRunError(`Workflow action ${action.kind} is not available in this build.`);
+    return;
+  }
+
+  const repository = repositoryForFolderPath(row.path) || {
+    id: "",
+    name: row.folder_name || row.path,
+    path: row.path,
+  };
+
+  if (!action.ready) {
+    state.selectedWorkflowPrimitiveID = primitive.id;
+    renderWorkflowPrimitiveState();
+    renderRunError(`Complete the required parameters for ${primitive.label} in Workflow Actions before queueing it from the audit table.`);
+    return;
+  }
+
+  enqueueWorkflowPrimitiveAction(repository, primitive, action.parameters || {});
 }
 
 function clearAuditQueue() {
@@ -4063,21 +4766,12 @@ async function applyAuditQueue() {
     );
     state.auditQueue = state.auditQueue.filter((change) => !succeededIDs.has(change.id));
 
-    if (state.auditInspectionRoots.length > 0) {
-      await inspectAuditRequest(
-        {
-          roots: state.auditInspectionRoots.slice(),
-          include_all: state.auditInspectionIncludeAll,
-        },
-        false,
-      );
-    }
-
     const failedResults = results.filter((result) => result.status !== auditChangeStatusSucceededValue);
     if (failedResults.length > 0) {
-      renderRunError(failedResults.map(formatAuditApplyIssue).join("\n"));
+      renderRunError(`${failedResults.map(formatAuditApplyIssue).join("\n")}\nRefresh the audit table when you want a new snapshot.`);
       setStatus("failed");
     } else {
+      renderRunError("Apply finished. Refresh the audit table when you want a new snapshot.");
       setStatus("succeeded");
     }
   } catch (error) {
@@ -4687,6 +5381,77 @@ function repositoryForFolderPath(folderPath) {
 }
 
 /**
+ * @param {any} repository
+ * @returns {RepositoryDescriptor | null}
+ */
+function normalizeDiscoveredRepository(repository) {
+  if (!repository || typeof repository !== "object") {
+    return null;
+  }
+
+  const repositoryPath = normalizeRepositoryTreePath(String(repository.path || ""));
+  if (!repositoryPath) {
+    return null;
+  }
+
+  const pathSegments = splitRepositoryTreePath(repositoryPath);
+  const fallbackName = pathSegments[pathSegments.length - 1] || repositoryPath;
+  return {
+    id: String(repository.id || repositoryPath).trim(),
+    name: String(repository.name || "").trim() || fallbackName,
+    path: repositoryPath,
+    current_branch: String(repository.current_branch || "").trim(),
+    default_branch: String(repository.default_branch || "").trim(),
+    dirty: Boolean(repository.dirty),
+    context_current: Boolean(repository.context_current),
+    error: String(repository.error || "").trim(),
+  };
+}
+
+/**
+ * @param {RepositoryDescriptor[]} repositories
+ * @returns {void}
+ */
+function mergeKnownRepositories(repositories) {
+  if (!Array.isArray(repositories) || repositories.length === 0) {
+    return;
+  }
+
+  const repositoriesByPath = new Map(
+    state.repositories.map((repository, repositoryIndex) => [normalizeRepositoryTreePath(repository.path), repositoryIndex]),
+  );
+
+  repositories.forEach((repository) => {
+    const normalizedRepositoryPath = normalizeRepositoryTreePath(repository.path);
+    if (!normalizedRepositoryPath) {
+      return;
+    }
+
+    const existingRepositoryIndex = repositoriesByPath.get(normalizedRepositoryPath);
+    if (typeof existingRepositoryIndex === "number") {
+      const existingRepository = state.repositories[existingRepositoryIndex];
+      state.repositories[existingRepositoryIndex] = {
+        ...existingRepository,
+        ...repository,
+        id: existingRepository.id || repository.id,
+        path: normalizedRepositoryPath,
+        context_current: Boolean(existingRepository.context_current || repository.context_current),
+      };
+      return;
+    }
+
+    repositoriesByPath.set(normalizedRepositoryPath, state.repositories.length);
+    state.repositories.push({
+      ...repository,
+      path: normalizedRepositoryPath,
+    });
+  });
+
+  state.repositories = state.repositories.slice().sort(compareRepositories);
+  elements.repoCount.textContent = String(state.repositories.length);
+}
+
+/**
  * @returns {RepositoryDescriptor[]}
  */
 function checkedRepositories() {
@@ -4707,6 +5472,48 @@ function repositoryScopeRepositories() {
 
   const repository = selectedRepository();
   return repository ? [repository] : [];
+}
+
+async function ensureRepositoryTreeDirectoryDataLoaded() {
+  const rootPaths = repositoryTreeRootPaths();
+  if (rootPaths.length === 0) {
+    return;
+  }
+
+  const pathsToLoad = new Set();
+  rootPaths.forEach((rootPath) => {
+    pathsToLoad.add(rootPath);
+  });
+
+  const selectedFolderPath = normalizeRepositoryTreePath(state.selectedFolderPath || "");
+  if (selectedFolderPath) {
+    rootPaths.forEach((rootPath) => {
+      collectDirectoryPathChain(rootPath, selectedFolderPath).forEach((path) => {
+        pathsToLoad.add(path);
+      });
+    });
+  }
+
+  const selectedRepositoryParentPath = parentDirectoryPath(selectedRepository()?.path || "");
+  if (selectedRepositoryParentPath) {
+    rootPaths.forEach((rootPath) => {
+      collectDirectoryPathChain(rootPath, selectedRepositoryParentPath).forEach((path) => {
+        pathsToLoad.add(path);
+      });
+    });
+  }
+
+  repositoryTreeExpandedFolderPaths().forEach((folderPath) => {
+    rootPaths.forEach((rootPath) => {
+      collectDirectoryPathChain(rootPath, folderPath).forEach((path) => {
+        pathsToLoad.add(path);
+      });
+    });
+  });
+
+  for (const path of pathsToLoad) {
+    await ensureDirectoryFoldersLoaded(path);
+  }
 }
 
 async function ensureSingleConfiguredRootTreeDataLoaded() {
@@ -4767,12 +5574,22 @@ async function ensureDirectoryFoldersLoaded(folderPath) {
       throw new Error(listing.error);
     }
 
+    const discoveredRepositories = (listing.folders || [])
+      .map((folder) => normalizeDiscoveredRepository(folder.repository))
+      .filter(Boolean);
+    mergeKnownRepositories(discoveredRepositories);
+
     state.directoryFolders[normalizedFolderPath] = (listing.folders || [])
       .map((folder) => ({
         name: String(folder.name || "").trim(),
         path: normalizeRepositoryTreePath(folder.path),
+        repository: normalizeDiscoveredRepository(folder.repository),
       }))
-      .filter((folder) => folder.name && folder.path);
+      .filter((folder) => folder.name && folder.path)
+      .map((folder) => ({
+        ...folder,
+        repository: folder.repository ? (repositoryForFolderPath(folder.repository.path) || folder.repository) : undefined,
+      }));
   })().catch(() => {
     state.directoryFolders[normalizedFolderPath] = [];
   });
@@ -4890,9 +5707,18 @@ function activeRepositoryTreeFolderPath() {
  * @returns {string[]}
  */
 function workingFolderRoots() {
+  const checkedRoots = checkedRepositories().map((repository) => repository.path);
+  if (checkedRoots.length > 1) {
+    return checkedRoots;
+  }
+
   const selectedFolderPath = activeRepositoryTreeFolderPath();
   if (selectedFolderPath) {
     return [selectedFolderPath];
+  }
+
+  if (checkedRoots.length === 1) {
+    return checkedRoots;
   }
 
   return explorerRootPaths();
@@ -5004,33 +5830,6 @@ function buildRepositoryScopeDetail(scopeLabel, repositories) {
 /**
  * @returns {string}
  */
-function buildRefSummary() {
-  if (state.targetRefMode === refModeNamedValue || state.targetRefMode === refModePatternValue) {
-    const value = state.targetRefValue.trim();
-    return value ? `${state.targetRefMode}:${value}` : state.targetRefMode;
-  }
-
-  if (state.targetRefMode === refModeCurrentValue) {
-    const currentBranch = currentRepositoryBranchName();
-    if (state.selectedScope === scopeSelectedValue && currentBranch) {
-      return `current:${currentBranch}`;
-    }
-    return state.selectedScope === scopeSelectedValue ? refModeCurrentValue : "current per repo";
-  }
-
-  if (state.targetRefMode === refModeDefaultValue) {
-    if (state.selectedScope === scopeSelectedValue && selectedRepository()?.default_branch) {
-      return `default:${selectedRepository()?.default_branch || ""}`;
-    }
-    return state.selectedScope === scopeSelectedValue ? refModeDefaultValue : "default per repo";
-  }
-
-  return state.targetRefMode;
-}
-
-/**
- * @returns {string}
- */
 function buildPathSummary() {
   const values = resolvePathValues();
   if (state.targetPathMode === pathModeNoneValue) {
@@ -5040,19 +5839,6 @@ function buildPathSummary() {
     return state.targetPathMode;
   }
   return `${state.targetPathMode}:${values.length}`;
-}
-
-/**
- * @returns {string}
- */
-function pathInputPlaceholder() {
-  if (state.targetPathMode === pathModeGlobValue) {
-    return pathPlaceholderGlobValue;
-  }
-  if (state.targetPathMode === pathModeMultipleValue) {
-    return pathPlaceholderMultipleValue;
-  }
-  return pathPlaceholderRelativeValue;
 }
 
 /**

--- a/internal/web/ui/assets/styles.css
+++ b/internal/web/ui/assets/styles.css
@@ -83,6 +83,13 @@ textarea {
   gap: 1.25rem;
 }
 
+.workspace-layout > *,
+.layout-row > *,
+.details-grid > *,
+.output-grid > * {
+  min-width: 0;
+}
+
 .context-row {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: start;
@@ -261,6 +268,20 @@ h4 {
   color: var(--muted);
 }
 
+.repo-focus-summary,
+.repo-focus-path,
+.target-detail,
+.error-message,
+#audit-selection-summary,
+#workflow-action-repo,
+#workflow-primitive-summary,
+#workflow-action-summary,
+#workflow-queue-summary,
+#run-error {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .lede,
 .repo-focus-summary {
   margin-top: 0.85rem;
@@ -278,6 +299,13 @@ h4 {
   align-items: center;
   justify-content: space-between;
   gap: 0.8rem;
+}
+
+.panel-heading > *,
+.button-row > *,
+.repo-focus-header > *,
+.audit-stage-header > * {
+  min-width: 0;
 }
 
 .field-label {
@@ -661,12 +689,24 @@ h4 {
 .repo-focus-path {
   margin-top: 0.55rem;
   font-size: 0.88rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .repo-focus-summary {
   margin-top: 0.35rem;
   font-size: 0.9rem;
   line-height: 1.35;
+}
+
+.repo-panel .repo-focus-summary,
+.repo-panel .target-detail,
+#repo-launch-summary {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .repo-scope {
@@ -1162,6 +1202,12 @@ h4 {
   border-color: rgba(139, 47, 43, 0.28);
   color: var(--danger);
   background: rgba(255, 241, 238, 0.94);
+}
+
+.audit-action-button-configure {
+  border-color: rgba(154, 104, 34, 0.22);
+  color: var(--warning);
+  background: rgba(255, 247, 232, 0.96);
 }
 
 @media (max-width: 1400px) {

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -15,7 +15,7 @@
             <h2>Repos</h2>
             <span id="repo-count" class="pill">0</span>
           </div>
-          <div class="repo-focus">
+          <div class="repo-focus" hidden>
             <div class="repo-focus-header">
               <div class="repo-focus-identity">
                 <p class="eyebrow">Selected Repo</p>
@@ -26,7 +26,7 @@
             <p id="repo-path" class="repo-focus-path"></p>
             <p id="repo-summary" class="repo-focus-summary"></p>
           </div>
-          <section class="repo-scope">
+          <section class="repo-scope" hidden>
             <div class="panel-heading">
               <h3>Scope</h3>
               <span id="target-repo-summary" class="pill">0</span>
@@ -38,7 +38,7 @@
             </div>
             <p id="target-repo-detail" class="panel-note target-detail"></p>
           </section>
-          <p id="repo-launch-summary" class="panel-note"></p>
+          <p id="repo-launch-summary" class="panel-note" hidden></p>
           <label class="field-label" for="repo-filter">Filter</label>
           <input id="repo-filter" class="text-input" type="search" placeholder="Find a repository">
           <div id="repo-tree" class="repo-tree" aria-live="polite"></div>
@@ -50,7 +50,7 @@
               <div class="audit-stage-copy">
                 <p class="eyebrow">Primary Flow</p>
                 <h1>Audit Workspace</h1>
-                <p class="lede">Pick a folder in the left pane, inspect it here, then queue the fixes you want before dropping into follow-up commands.</p>
+                <p class="lede">Pick one or many folders in the left pane, inspect them here, queue the actions you want, execute them, review the results, and then refresh the table when you need a new snapshot.</p>
               </div>
               <div class="audit-stage-meta">
                 <span id="audit-selection-badge" class="pill">No target</span>
@@ -70,7 +70,7 @@
                 <span>Include non-Git folders in the inspected roots</span>
               </label>
               <div class="button-row audit-stage-actions">
-                <button id="task-inspect-load" class="primary-button" type="button">Inspect audit table</button>
+                <button id="task-inspect-load" class="primary-button" type="button">Inspect or refresh audit table</button>
                 <span id="run-error" class="error-message"></span>
               </div>
             </section>
@@ -101,63 +101,21 @@
             </div>
           </section>
 
-          <section class="panel brand-panel secondary-brand-panel">
-            <p class="eyebrow">Secondary Tools</p>
-            <h2>Follow-up Commands</h2>
-            <p class="lede">After the audit table is in place, use the controls below to target branches, files, remotes, workflows, or raw commands against the selected repository scope.</p>
-          </section>
-
-          <section class="layout-row context-row">
-            <section class="panel target-card">
-              <div class="panel-heading">
-                <h3>Refs</h3>
-                <span id="target-ref-summary" class="pill">current</span>
-              </div>
-              <label class="field-label" for="target-ref-mode">Mode</label>
-              <select id="target-ref-mode" class="select-input">
-                <option value="current">Current</option>
-                <option value="default">Default</option>
-                <option value="named">Named</option>
-                <option value="pattern">Pattern</option>
-                <option value="any">Any</option>
-              </select>
-              <div id="target-ref-value-block" class="ref-value-field">
-                <label id="target-ref-value-label" class="field-label">Value</label>
-                <select id="target-ref-select" class="select-input" aria-label="Named ref selection" hidden disabled></select>
-                <input id="target-ref-value" class="text-input" type="text" aria-label="Ref value" placeholder="branch-name or pattern" disabled>
-              </div>
-              <p id="target-ref-detail" class="panel-note target-detail"></p>
-            </section>
-
-            <section class="panel target-card">
-              <div class="panel-heading">
-                <h3>Paths</h3>
-                <span id="target-path-summary" class="pill">none</span>
-              </div>
-              <label class="field-label" for="target-path-mode">Mode</label>
-              <select id="target-path-mode" class="select-input">
-                <option value="none">None</option>
-                <option value="relative">Relative Path</option>
-                <option value="glob">Glob</option>
-                <option value="multiple">Multiple Paths</option>
-              </select>
-              <div id="target-path-value-block" class="target-path-value-block">
-                <label id="target-path-value-label" class="field-label" for="target-path-value">Value</label>
-                <textarea id="target-path-value" class="code-input target-path-input" spellcheck="false" placeholder="One path or glob per line" disabled></textarea>
-              </div>
-              <p id="target-path-detail" class="panel-note target-detail"></p>
-            </section>
+          <section class="panel brand-panel secondary-brand-panel" hidden>
+            <p class="eyebrow">Step 2</p>
+            <h2>Queue Actions</h2>
+            <p class="lede">After the audit table is in place, queue the fixes surfaced by the audit table or add repo-scoped workflow actions for the selected repository.</p>
           </section>
 
           <section class="layout-row tasks-row">
             <section class="panel actions-panel">
               <div class="panel-heading">
-                <h3>Follow-up Tasks</h3>
-                <span id="task-count" class="pill">6</span>
+                <h3>Workflow Actions</h3>
+                <span id="task-count" class="pill">1</span>
               </div>
-              <p id="action-context" class="panel-note"></p>
+              <p id="action-context" class="panel-note">Queue repo-scoped workflow primitives for the selected repository. Files, refs, remotes, and raw commands are intentionally not exposed here.</p>
 
-              <div class="task-switcher" role="tablist" aria-label="Task switcher">
+              <div class="task-switcher" role="tablist" aria-label="Task switcher" hidden>
                 <button id="task-inspect" class="task-button" type="button" hidden>Audit</button>
                 <button id="task-branch" class="task-button" type="button">Branch</button>
                 <button id="task-files" class="task-button" type="button">Files</button>
@@ -170,7 +128,7 @@
               <section id="task-panel-branch" class="task-panel" hidden>
                 <div class="task-copy">
                   <h4>Branch Operations</h4>
-                  <p class="panel-note">The target bar defines which repositories and refs you are operating on. Use the Refs mode and value controls above to choose a concrete branch when the action needs one.</p>
+                  <p class="panel-note">Branch operations follow the selected repository in the tree.</p>
                 </div>
                 <div class="quick-actions" aria-label="Branch quick actions">
                   <button id="action-switch-default" class="secondary-button" type="button">Run switch to default branch command</button>
@@ -182,7 +140,7 @@
               <section id="task-panel-files" class="task-panel" hidden>
                 <div class="task-copy">
                   <h4>File Changes</h4>
-                  <p class="panel-note">Repos, refs, and paths come from the target bar. This task only captures the file-operation specific inputs.</p>
+                  <p class="panel-note">File changes apply to the selected repository in the tree.</p>
                 </div>
 
                 <label class="field-label" for="file-task-mode">Operation</label>
@@ -232,29 +190,59 @@
               </section>
 
               <section id="task-panel-workflows" class="task-panel" hidden>
-                <div class="task-copy">
-                  <h4>Workflow Runner</h4>
-                  <p class="panel-note">Run an embedded preset or a workflow configuration file against the current repository target set. Repositories still come from the target bar.</p>
+                <div hidden>
+                  <label class="field-label" for="workflow-target-input">Preset or Config</label>
+                  <input id="workflow-target-input" class="text-input" type="text" placeholder="license or ./workflow.yaml">
+
+                  <label class="field-label" for="workflow-vars-input">Variables</label>
+                  <textarea id="workflow-vars-input" class="code-input task-code-input" spellcheck="false" placeholder="key=value"></textarea>
+
+                  <label class="field-label" for="workflow-var-files-input">Variable Files</label>
+                  <textarea id="workflow-var-files-input" class="code-input task-code-input" spellcheck="false" placeholder="./vars.yaml"></textarea>
+
+                  <label class="field-label" for="workflow-workers-input">Workflow Workers</label>
+                  <input id="workflow-workers-input" class="text-input" type="number" min="1" step="1" value="1">
+
+                  <label class="checkbox-row" for="workflow-require-clean">
+                    <input id="workflow-require-clean" type="checkbox">
+                    <span>Require clean worktrees for rename operations</span>
+                  </label>
+
+                  <button id="task-workflow-load" class="secondary-button" type="button">Run workflow command</button>
                 </div>
 
-                <label class="field-label" for="workflow-target-input">Preset or Config</label>
-                <input id="workflow-target-input" class="text-input" type="text" placeholder="license or ./workflow.yaml">
+                <div class="task-copy">
+                  <h4>Action Queue</h4>
+                  <p class="panel-note">Queue repo-scoped workflow primitives with their major parameters. The queue applies only to the selected repository in the tree.</p>
+                </div>
 
-                <label class="field-label" for="workflow-vars-input">Variables</label>
-                <textarea id="workflow-vars-input" class="code-input task-code-input" spellcheck="false" placeholder="key=value"></textarea>
+                <div class="panel-heading">
+                  <h4>Selected Repo</h4>
+                  <span id="workflow-action-repo" class="panel-note"></span>
+                </div>
 
-                <label class="field-label" for="workflow-var-files-input">Variable Files</label>
-                <textarea id="workflow-var-files-input" class="code-input task-code-input" spellcheck="false" placeholder="./vars.yaml"></textarea>
+                <label class="field-label" for="workflow-primitive-select">Workflow Action</label>
+                <select id="workflow-primitive-select" class="text-input"></select>
+                <p id="workflow-primitive-summary" class="panel-note"></p>
 
-                <label class="field-label" for="workflow-workers-input">Workflow Workers</label>
-                <input id="workflow-workers-input" class="text-input" type="number" min="1" step="1" value="1">
+                <div id="workflow-primitive-fields" class="task-subpanel" aria-live="polite"></div>
 
-                <label class="checkbox-row" for="workflow-require-clean">
-                  <input id="workflow-require-clean" type="checkbox">
-                  <span>Require clean worktrees for rename operations</span>
-                </label>
+                <div class="button-row">
+                  <button id="workflow-action-queue" class="secondary-button" type="button">Queue workflow action</button>
+                  <span id="workflow-action-summary" class="panel-note"></span>
+                </div>
 
-                <button id="task-workflow-load" class="secondary-button" type="button">Run workflow command</button>
+                <section id="workflow-queue-panel" class="audit-queue-panel" hidden>
+                  <div class="panel-heading">
+                    <h4>Queued Workflow Actions</h4>
+                    <span id="workflow-queue-summary" class="panel-note"></span>
+                  </div>
+                  <div id="workflow-queue-list" class="audit-queue-list"></div>
+                  <div class="button-row">
+                    <button id="workflow-queue-clear" class="secondary-button" type="button">Clear queue</button>
+                    <button id="workflow-queue-apply" class="primary-button" type="button">Apply queued workflow actions</button>
+                  </div>
+                </section>
               </section>
 
               <section id="task-panel-advanced" class="task-panel" hidden>
@@ -294,33 +282,35 @@
           <section class="layout-row runner-row">
             <section class="panel runner-panel">
               <div class="panel-heading">
-                <h3>Runner</h3>
+                <h3>Execution Results</h3>
                 <span id="run-status" class="status-pill status-idle">idle</span>
               </div>
-              <p class="panel-note">The runner is prefilled from the active task and the target bar. Adjust arguments directly when you need the exact CLI shape.</p>
-              <div class="preview-shell">
-                <span class="preview-label">Preview</span>
-                <pre id="command-preview" class="command-preview"></pre>
-              </div>
+              <p class="panel-note">Apply queued actions, review the execution output here, and then inspect the selected folders again when you want a refreshed audit table.</p>
+              <div hidden>
+                <div class="preview-shell">
+                  <span class="preview-label">Preview</span>
+                  <pre id="command-preview" class="command-preview"></pre>
+                </div>
 
-              <div class="editor-block">
-                <label class="field-label" for="arguments-input">Arguments</label>
-                <textarea id="arguments-input" class="code-input" spellcheck="false"></textarea>
-              </div>
+                <div class="editor-block">
+                  <label class="field-label" for="arguments-input">Arguments</label>
+                  <textarea id="arguments-input" class="code-input" spellcheck="false"></textarea>
+                </div>
 
-              <div class="editor-block">
-                <label class="field-label" for="stdin-input">Standard Input</label>
-                <textarea id="stdin-input" class="code-input stdin-input" spellcheck="false" placeholder="Paste stdin payload when a command expects it"></textarea>
-              </div>
+                <div class="editor-block">
+                  <label class="field-label" for="stdin-input">Standard Input</label>
+                  <textarea id="stdin-input" class="code-input stdin-input" spellcheck="false" placeholder="Paste stdin payload when a command expects it"></textarea>
+                </div>
 
-              <div class="button-row">
-                <button id="run-command" class="primary-button" type="button">Run</button>
-                <span id="run-id" class="panel-note">No run started</span>
+                <div class="button-row">
+                  <button id="run-command" class="primary-button" type="button">Run</button>
+                  <span id="run-id" class="panel-note">No run started</span>
+                </div>
               </div>
 
               <section class="runner-output">
                 <div class="panel-heading">
-                  <h4>Run Output</h4>
+                  <h4>Latest Apply Output</h4>
                 </div>
                 <div class="output-grid">
                   <div>

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -254,9 +254,6 @@ func (executor *Executor) Execute(executionContext context.Context, roots []stri
 	if errorWriter == nil {
 		errorWriter = reporterOutput
 	}
-	if executor.dependencies.Errors != nil {
-		reporterOutput = executor.dependencies.Errors
-	}
 	if !executor.dependencies.HumanReadableLogging || executor.dependencies.DisableWorkflowLogging {
 		reporterOutput = io.Discard
 	}

--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -165,6 +165,78 @@ func TestExecutorEmitsDiscoveryStepSummary(testInstance *testing.T) {
 	require.Contains(testInstance, outputText, "reason: discovered")
 }
 
+func TestExecutorWritesSuccessfulReporterEventsToOutputOnly(testInstance *testing.T) {
+	tempDirectory := testInstance.TempDir()
+	repositoryPath := filepath.Join(tempDirectory, "sample")
+	require.NoError(testInstance, os.Mkdir(repositoryPath, 0o755))
+
+	gitExecutor := newStubWorkflowGitExecutor()
+	repositoryManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(testInstance, managerError)
+
+	outputBuffer := &bytes.Buffer{}
+	errorBuffer := &bytes.Buffer{}
+
+	dependencies := Dependencies{
+		RepositoryDiscoverer: executorStubRepositoryDiscoverer{repositories: []string{repositoryPath}},
+		GitExecutor:          gitExecutor,
+		RepositoryManager:    repositoryManager,
+		Output:               outputBuffer,
+		Errors:               errorBuffer,
+		HumanReadableLogging: true,
+	}
+
+	executor := NewExecutor([]Operation{repoSwitchOperation{}}, dependencies)
+
+	outcome, executionError := executor.Execute(
+		context.Background(),
+		[]string{repositoryPath},
+		RuntimeOptions{SkipRepositoryMetadata: true},
+	)
+	require.NoError(testInstance, executionError)
+	require.Equal(testInstance, 1, outcome.RepositoryCount)
+	require.Contains(testInstance, outputBuffer.String(), "REPO_SWITCHED")
+	require.Empty(testInstance, errorBuffer.String())
+}
+
+func TestExecutorWritesErrorReporterEventsToErrorOnly(testInstance *testing.T) {
+	tempDirectory := testInstance.TempDir()
+	repositoryPath := filepath.Join(tempDirectory, "sample")
+	require.NoError(testInstance, os.Mkdir(repositoryPath, 0o755))
+
+	gitExecutor := newStubWorkflowGitExecutor()
+	repositoryManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(testInstance, managerError)
+
+	githubClient, clientError := githubcli.NewClient(gitExecutor)
+	require.NoError(testInstance, clientError)
+
+	outputBuffer := &bytes.Buffer{}
+	errorBuffer := &bytes.Buffer{}
+
+	dependencies := Dependencies{
+		RepositoryDiscoverer: executorStubRepositoryDiscoverer{repositories: []string{repositoryPath}},
+		GitExecutor:          gitExecutor,
+		RepositoryManager:    repositoryManager,
+		GitHubClient:         githubClient,
+		Output:               outputBuffer,
+		Errors:               errorBuffer,
+		HumanReadableLogging: true,
+	}
+
+	executor := NewExecutor([]Operation{failingOperation{}}, dependencies)
+
+	outcome, executionError := executor.Execute(
+		context.Background(),
+		[]string{repositoryPath},
+		RuntimeOptions{SkipRepositoryMetadata: true},
+	)
+	require.Error(testInstance, executionError)
+	require.Equal(testInstance, 1, outcome.RepositoryCount)
+	require.Empty(testInstance, outputBuffer.String())
+	require.Contains(testInstance, errorBuffer.String(), "ORIGIN_OWNER_MISSING")
+}
+
 func TestExecutorSeedsVariablesFromRuntimeOptions(testInstance *testing.T) {
 	tempDirectory := testInstance.TempDir()
 	repositoryPath := filepath.Join(tempDirectory, "sample")


### PR DESCRIPTION
## Summary
- turn the web surface into an audit -> queue -> apply flow with backend-owned workflow primitives
- make the repo tree behave like a repo-only folder browser, including explicit-root traversal and dynamic discovery outside launch roots
- remove the legacy Refs/Paths controls, fix successful workflow output routing, and extend browser/backend coverage

## Verification
- make ci
- make build