### PR TITLE
[codex] Fix B005 cd dirty worktree fast-forward refresh

### DIFF
--- a/internal/branches/cd/service.go
+++ b/internal/branches/cd/service.go
@@ -46,6 +46,7 @@ const (
 	gitSetUpstreamToFlagConstant              = "--set-upstream-to"
 	gitPullSubcommandConstant                 = "pull"
 	gitPullRebaseFlagConstant                 = "--rebase"
+	gitPullFastForwardFlagConstant            = "--ff-only"
 	gitRevParseSubcommandConstant             = "rev-parse"
 	gitVerifyFlagConstant                     = "--verify"
 	gitTerminalPromptEnvironmentNameConstant  = "GIT_TERMINAL_PROMPT"
@@ -73,7 +74,7 @@ type Options struct {
 	BranchName      string
 	RemoteName      string
 	CreateIfMissing bool
-	SkipPull        bool
+	pullMode        pullMode
 }
 
 // Result captures the outcome of a branch change.
@@ -90,6 +91,16 @@ type Service struct {
 	executor shared.GitExecutor
 	logger   *zap.Logger
 }
+
+type pullMode struct {
+	name string
+}
+
+var (
+	pullModeRebase          = pullMode{name: "rebase"}
+	pullModeFastForwardOnly = pullMode{name: "fast-forward-only"}
+	pullModeSkip            = pullMode{name: "skip"}
+)
 
 // NewService constructs a Service from the provided dependencies.
 func NewService(dependencies ServiceDependencies) (*Service, error) {
@@ -140,7 +151,8 @@ func (service *Service) Change(executionContext context.Context, options Options
 	}
 
 	shouldFetch := remoteEnumeration.hasRemotes && (remoteEnumeration.requestedExists || useAllRemotes)
-	shouldPull := shouldFetch && !options.SkipPull
+	selectedPullMode := options.pullMode.withDefault()
+	shouldPull := shouldFetch && !selectedPullMode.skip()
 	shouldTrackRemote := remoteEnumeration.requestedExists && shouldFetch
 	warnings := make([]string, 0)
 
@@ -240,7 +252,7 @@ func (service *Service) Change(executionContext context.Context, options Options
 
 	if shouldPull {
 		if _, err := service.executor.ExecuteGit(executionContext, execshell.CommandDetails{
-			Arguments:            []string{gitPullSubcommandConstant, gitPullRebaseFlagConstant},
+			Arguments:            selectedPullMode.arguments(),
 			WorkingDirectory:     trimmedRepositoryPath,
 			EnvironmentVariables: environment,
 		}); err != nil {
@@ -266,6 +278,26 @@ func (service *Service) Change(executionContext context.Context, options Options
 		Warnings:           warnings,
 		TrackingRemoteName: trackingRemoteName,
 	}, nil
+}
+
+func (mode pullMode) withDefault() pullMode {
+	if strings.TrimSpace(mode.name) == "" {
+		return pullModeRebase
+	}
+	return mode
+}
+
+func (mode pullMode) skip() bool {
+	return mode.name == pullModeSkip.name
+}
+
+func (mode pullMode) arguments() []string {
+	switch mode.name {
+	case pullModeFastForwardOnly.name:
+		return []string{gitPullSubcommandConstant, gitPullFastForwardFlagConstant}
+	default:
+		return []string{gitPullSubcommandConstant, gitPullRebaseFlagConstant}
+	}
 }
 
 func (service *Service) trySwitch(executionContext context.Context, repositoryPath string, branchName string, environment map[string]string) error {

--- a/internal/branches/cd/service_test.go
+++ b/internal/branches/cd/service_test.go
@@ -269,6 +269,24 @@ func TestChangeWarnsWhenPullFails(t *testing.T) {
 	require.Equal(t, []string{"pull", "--rebase"}, executor.recorded[3].Arguments)
 }
 
+func TestChangeUsesFastForwardPullMode(t *testing.T) {
+	executor := &stubGitExecutor{responses: []stubGitResponse{
+		{result: execshell.ExecutionResult{StandardOutput: "origin\n"}},
+	}}
+	service, err := NewService(ServiceDependencies{GitExecutor: executor})
+	require.NoError(t, err)
+
+	result, changeError := service.Change(context.Background(), Options{
+		RepositoryPath: "/tmp/repo",
+		BranchName:     "main",
+		pullMode:       pullModeFastForwardOnly,
+	})
+	require.NoError(t, changeError)
+	require.Empty(t, result.Warnings)
+	require.Len(t, executor.recorded, 4)
+	require.Equal(t, []string{"pull", "--ff-only"}, executor.recorded[3].Arguments)
+}
+
 func TestChangeUsesSingleRemoteWhenDefaultMissing(t *testing.T) {
 	executor := &stubGitExecutor{responses: []stubGitResponse{
 		{result: execshell.ExecutionResult{StandardOutput: "upstream\n"}},

--- a/internal/branches/cd/task_action.go
+++ b/internal/branches/cd/task_action.go
@@ -224,7 +224,7 @@ func handleBranchChangeAction(ctx context.Context, environment *workflow.Environ
 		BranchName:      resolvedBranchName,
 		RemoteName:      remoteName,
 		CreateIfMissing: createIfMissing,
-		SkipPull:        refreshSkipped,
+		pullMode:        pullModeForRefreshState(refreshSkipped),
 	})
 	if changeError != nil {
 		return changeError
@@ -342,6 +342,13 @@ func handleBranchChangeAction(ctx context.Context, environment *workflow.Environ
 	}
 
 	return nil
+}
+
+func pullModeForRefreshState(refreshSkipped bool) pullMode {
+	if refreshSkipped {
+		return pullModeFastForwardOnly
+	}
+	return pullModeRebase
 }
 
 func branchHasTrackingRemote(ctx context.Context, executor shared.GitExecutor, repositoryPath string, branchName string) (bool, error) {

--- a/internal/branches/cd/task_action_test.go
+++ b/internal/branches/cd/task_action_test.go
@@ -347,11 +347,12 @@ func TestHandleBranchChangeActionSkipsRefreshWhenDirty(t *testing.T) {
 
 	err := handleBranchChangeAction(context.Background(), environment, repository, parameters)
 	require.NoError(t, err)
-	require.Len(t, executor.recorded, 4)
+	require.Len(t, executor.recorded, 5)
 	require.Equal(t, []string{"status", "--porcelain"}, executor.recorded[0].Arguments)
 	require.Equal(t, []string{"remote"}, executor.recorded[1].Arguments)
 	require.Equal(t, []string{"fetch", "--prune", "origin"}, executor.recorded[2].Arguments)
 	require.Equal(t, []string{"switch", "feature/foo"}, executor.recorded[3].Arguments)
+	require.Equal(t, []string{"pull", "--ff-only"}, executor.recorded[4].Arguments)
 	require.Len(t, reporter.events, 2)
 	require.Equal(t, shared.EventCodeTaskSkip, reporter.events[0].Code)
 	require.Contains(t, reporter.events[0].Message, "refresh skipped (dirty worktree)")

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -11,6 +11,20 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
 
 ## BugFixes
 
+- [x] [B005] (P1) `gix cd` skips remote fast-forward updates when the worktree has tracked local changes.
+  Requested on 2026-05-10 after `gix cd` reported `refresh skipped (dirty worktree)` in `/Users/tyemirov/Documents/Projects/Fiction`, while a manual `git pull` immediately fast-forwarded `master`.
+  ## Observation
+  - Dirty tracked changes disable the clean-worktree refresh path and are passed through to the branch-change service as a full pull skip.
+  - That prevents safe fast-forward updates that Git can apply when the remote changes do not overlap with local edits.
+  ## Deliverable
+  - Keep the clean-worktree refresh skip for tracked local changes, but still attempt a fast-forward-only pull after switching to the target branch.
+  - Preserve warnings for real pull failures instead of turning conflicts into hard crashes.
+  - Add black-box `gix cd` coverage proving unrelated remote changes land while local tracked edits remain.
+  ## Resolution
+  - Dirty refresh skips now use a fast-forward-only pull mode, leaving the strict clean-worktree refresh disabled while still accepting safe remote updates.
+  - Added black-box coverage that keeps a tracked local edit, advances the remote on an unrelated file, and verifies `gix cd master` runs `git pull --ff-only`, lands the remote file, and preserves the local edit.
+  - `make ci` passed locally.
+
 - [x] [B001] First output appears late when running gix against 20–30 repositories because repository discovery/inspection emits no user-facing progress until the first repository finishes its first workflow step.
   LegacyExternalID: GX-345
   (Unresolved: stream discovery/inspection progress or emit an initial discovery step summary.)

--- a/tests/cd_refresh_integration_test.go
+++ b/tests/cd_refresh_integration_test.go
@@ -20,7 +20,7 @@ const (
 	cdRefreshIntegrationGitInvocationLog = "git-invocations.log"
 )
 
-func TestCdSkipsPullWhenWorktreeIsDirty(testInstance *testing.T) {
+func TestCdFastForwardPullsWhenWorktreeHasUnrelatedTrackedChanges(testInstance *testing.T) {
 	testInstance.Helper()
 
 	repositoryRoot := integrationRepositoryRoot(testInstance)
@@ -31,7 +31,7 @@ func TestCdSkipsPullWhenWorktreeIsDirty(testInstance *testing.T) {
 	gitStubScript := []byte(strings.Join([]string{
 		"#!/bin/sh",
 		"echo \"$@\" >> " + gitInvocationLog,
-		"if [ \"$1\" = \"pull\" ]; then exit 42; fi",
+		"if [ \"$1\" = \"pull\" ] && [ \"$2\" = \"--rebase\" ]; then exit 42; fi",
 		"exec " + realGitPath + " \"$@\"",
 	}, "\n") + "\n")
 	pathVariable := buildStubbedExecutablePath(testInstance, "git", string(gitStubScript))
@@ -73,7 +73,35 @@ func TestCdSkipsPullWhenWorktreeIsDirty(testInstance *testing.T) {
 	pushCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, pushCommand.Run())
 
-	require.NoError(testInstance, os.WriteFile(readmePath, []byte("modified\n"), 0o644))
+	upstreamPath := filepath.Join(testInstance.TempDir(), "upstream")
+	cloneCommand := exec.Command("git", "clone", remotePath, upstreamPath)
+	cloneCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, cloneCommand.Run())
+
+	upstreamNameCommand := exec.Command("git", "-C", upstreamPath, "config", "user.name", "Cd Refresh")
+	upstreamNameCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, upstreamNameCommand.Run())
+
+	upstreamEmailCommand := exec.Command("git", "-C", upstreamPath, "config", "user.email", "cd-refresh@example.com")
+	upstreamEmailCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, upstreamEmailCommand.Run())
+
+	upstreamFilePath := filepath.Join(upstreamPath, "UPSTREAM.md")
+	require.NoError(testInstance, os.WriteFile(upstreamFilePath, []byte("remote update\n"), 0o644))
+
+	upstreamAddCommand := exec.Command("git", "-C", upstreamPath, "add", "UPSTREAM.md")
+	upstreamAddCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, upstreamAddCommand.Run())
+
+	upstreamCommitCommand := exec.Command("git", "-C", upstreamPath, "commit", "-m", "remote update")
+	upstreamCommitCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, upstreamCommitCommand.Run())
+
+	upstreamPushCommand := exec.Command("git", "-C", upstreamPath, "push", "origin", "master")
+	upstreamPushCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, upstreamPushCommand.Run())
+
+	require.NoError(testInstance, os.WriteFile(readmePath, []byte("modified locally\n"), 0o644))
 
 	commandArguments := []string{
 		cdRefreshIntegrationRunCommand,
@@ -97,5 +125,14 @@ func TestCdSkipsPullWhenWorktreeIsDirty(testInstance *testing.T) {
 
 	invocationLogContents, readError := os.ReadFile(gitInvocationLog)
 	require.NoError(testInstance, readError)
-	require.NotContains(testInstance, string(invocationLogContents), "pull")
+	require.Contains(testInstance, string(invocationLogContents), "pull --ff-only")
+	require.NotContains(testInstance, string(invocationLogContents), "pull --rebase")
+
+	remoteFileContents, remoteReadError := os.ReadFile(filepath.Join(repositoryPath, "UPSTREAM.md"))
+	require.NoError(testInstance, remoteReadError)
+	require.Equal(testInstance, "remote update\n", string(remoteFileContents))
+
+	localFileContents, localReadError := os.ReadFile(readmePath)
+	require.NoError(testInstance, localReadError)
+	require.Equal(testInstance, "modified locally\n", string(localFileContents))
 }


### PR DESCRIPTION
## Summary

Fixes B005 by allowing `gix cd` to accept safe remote fast-forwards even when the worktree has tracked local changes.

## Root Cause

The dirty-worktree path intentionally skipped the strict clean refresh, but it also passed that skip through as a full pull skip. That meant `gix cd` fetched and switched branches, then refused to apply unrelated remote updates that plain Git could fast-forward cleanly.

## Changes

- Replaced the branch-change pull skip boolean with an explicit pull mode.
- Kept normal clean/default branch changes on `git pull --rebase`.
- Changed dirty refresh skips to run `git pull --ff-only`, preserving the clean-refresh guard while accepting safe remote updates.
- Added a black-box regression where a tracked local edit remains while an unrelated remote commit lands through `gix cd master`.
- Recorded and resolved B005 in `issues.md/ISSUES.md`.

## Validation

- `go test ./tests -run TestCdFastForwardPullsWhenWorktreeHasUnrelatedTrackedChanges -count=1`
- `go test ./internal/branches/cd -count=1`
- `make ci`
- `git diff --check`
