### PR TITLE
Fix cd sibling worktree adoption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,38 @@
-# Managed by ISSUES Managing Director (planning worktree)
-*
-!.gitignore
-!AGENTS.md
-!.mprl/
-!.mprl/**
-!internal/
-!internal/web/
-!internal/web/ui/
-!internal/web/ui/assets/
-!internal/web/ui/assets/shared.js
-!internal/web/ui/assets/repo_tree.js
-!internal/web/ui/assets/audit.js
-!internal/web/ui/assets/main.js
+# macOS filesystem metadata
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+
+# Editor and local tool state
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
+# Local environment and secrets
+.env
+.env.*
+!.env.example
+
+# Go build, test, and profiling artifacts
+/bin/
+/build/
+/dist/
+/tmp/
+/coverage/
+/coverage.out
+*.coverprofile
+*.test
+*.prof
+*.pprof
+/gix
+
+# Local generated output and browser automation traces
+/output/
+/.playwright-cli/
+
+# Ephemeral local planning scratch
+/PLAN.md

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Top-level commands and their subcommands. Aliases are shown in parentheses.
 - `gix default <target-branch> [--roots <dir>...] [-y]`
  - Promotes the default branch across repositories.
 - `gix cd [branch] [--remote <name>] [--stash | --commit] [--require-clean] [--roots <dir>...]` (alias `switch`)
- - Switches repositories to the selected branch when provided, or the repository default when omitted. Creates the branch if missing, rebases onto the remote, and, when `--stash` or `--commit` are enabled, performs an additional refresh cycle that fetches/pulls with stash/commit-based recovery.
+ - Switches repositories to the selected branch when provided, or the repository default when omitted. Creates the branch if missing, rebases onto the remote, and, when `--stash` or `--commit` are enabled, performs an additional refresh cycle that fetches/pulls with stash/commit-based recovery. If the target branch is checked out in a sibling worktree, `cd` commits dirty sibling changes with a generated message, pushes sibling commits that must be preserved, removes the sibling worktree, prunes metadata, then retries the normal switch and pull.
 ## Configuration essentials
 
 - `gix --init LOCAL` writes an embeddable starter `config.yaml` to the current directory; `gix --init user` places it under `$XDG_CONFIG_HOME/gix` or `$HOME/.gix`.

--- a/cmd/cli/application_bootstrap.go
+++ b/cmd/cli/application_bootstrap.go
@@ -541,6 +541,15 @@ func (application *Application) branchCleanupConfiguration() branches.CommandCon
 
 func (application *Application) branchChangeConfiguration() branchcdcmd.CommandConfiguration {
 	configuration := branchcdcmd.DefaultCommandConfiguration()
+	messageConfiguration := application.commitMessageConfiguration()
+	configuration.CommitMessage = branchcdcmd.CommitMessageConfiguration{
+		APIKeyEnv:      messageConfiguration.APIKeyEnv,
+		BaseURL:        messageConfiguration.BaseURL,
+		Model:          messageConfiguration.Model,
+		MaxTokens:      messageConfiguration.MaxTokens,
+		Temperature:    messageConfiguration.Temperature,
+		TimeoutSeconds: messageConfiguration.TimeoutSeconds,
+	}
 	application.decodeOperationConfiguration(branchChangeOperationNameConstant, &configuration)
 
 	options, optionsExist := application.lookupOperationOptions(branchChangeOperationNameConstant)
@@ -673,13 +682,15 @@ func (application *Application) workflowCommandConfiguration() workflowcmd.Comma
 
 func (application *Application) changelogMessageConfiguration() changelogcmd.MessageConfiguration {
 	configuration := changelogcmd.DefaultMessageConfiguration()
-	application.decodeOperationConfiguration(changelogMessageOperationNameConstant, &configuration)
+	application.decodeOperationConfigurationIfPresent(changelogMessageConfigurationKeyConstant, &configuration)
+	application.decodeOperationConfigurationIfPresent(changelogMessageOperationNameConstant, &configuration)
 	return configuration.Sanitize()
 }
 
 func (application *Application) commitMessageConfiguration() commitcmd.MessageConfiguration {
 	configuration := commitcmd.DefaultMessageConfiguration()
-	application.decodeOperationConfiguration(commitMessageOperationNameConstant, &configuration)
+	application.decodeOperationConfigurationIfPresent(commitMessageConfigurationKeyConstant, &configuration)
+	application.decodeOperationConfigurationIfPresent(commitMessageOperationNameConstant, &configuration)
 	return configuration.Sanitize()
 }
 
@@ -703,6 +714,13 @@ func (application *Application) decodeOperationConfiguration(operationName strin
 			zap.Error(decodeError),
 		)
 	}
+}
+
+func (application *Application) decodeOperationConfigurationIfPresent(operationName string, target any) {
+	if _, exists := application.lookupOperationOptions(operationName); !exists {
+		return
+	}
+	application.decodeOperationConfiguration(operationName, target)
 }
 
 func (application *Application) lookupOperationOptions(operationName string) (map[string]any, bool) {

--- a/cmd/cli/application_constants.go
+++ b/cmd/cli/application_constants.go
@@ -127,7 +127,7 @@ const (
 	branchChangeCommandUseNameConstant                               = "cd"
 	branchChangeCommandUsageTemplateConstant                         = branchChangeCommandUseNameConstant + " [branch]"
 	branchChangeCommandAliasConstant                                 = "switch"
-	branchChangeLongDescriptionConstant                              = "cd fetches updates, switches to the requested branch (or repository default when omitted), creates it when missing, and rebases onto the remote for each repository root. Provide the branch name as the first argument before any optional repository roots or flags, or configure a default branch in the application settings."
+	branchChangeLongDescriptionConstant                              = "cd fetches updates, switches to the requested branch (or repository default when omitted), creates it when missing, and rebases onto the remote for each repository root. When the branch is checked out in a sibling worktree, cd preserves dirty sibling changes with a generated commit, pushes required sibling commits, removes the sibling worktree, prunes metadata, and retries the switch. Provide the branch name as the first argument before any optional repository roots or flags, or configure a default branch in the application settings."
 	messageNamespaceUseNameConstant                                  = "message"
 	messageNamespaceAliasConstant                                    = "msg"
 	messageNamespaceShortDescriptionConstant                         = "Message assistance commands"
@@ -148,6 +148,8 @@ const (
 	releaseRetagCommandPathKeyConstant                               = repoReleaseCommandUseNameConstant + "/" + releaseRetagCommandUseNameConstant
 	commitMessageCommandPathKeyConstant                              = messageNamespaceUseNameConstant + "/" + commitMessageUseNameConstant
 	changelogMessageCommandPathKeyConstant                           = messageNamespaceUseNameConstant + "/" + changelogMessageUseNameConstant
+	commitMessageConfigurationKeyConstant                            = messageNamespaceUseNameConstant + " " + commitMessageUseNameConstant
+	changelogMessageConfigurationKeyConstant                         = messageNamespaceUseNameConstant + " " + changelogMessageUseNameConstant
 	renameNestedLongDescriptionConstant                              = "folder rename normalizes repository directory names to match canonical GitHub repositories."
 	updateRemoteCanonicalLongDescriptionConstant                     = "remote update-to-canonical adjusts origin remotes to match canonical GitHub repositories."
 	updateProtocolLongDescriptionConstant                            = "remote update-protocol converts origin URLs to a desired protocol."

--- a/docs/command_warning_matrix.md
+++ b/docs/command_warning_matrix.md
@@ -5,6 +5,7 @@ The table below categorises the major maintenance commands into **fatal** and **
 | Command | Step | Classification | Behaviour |
 | --- | --- | --- | --- |
 | cd | Enumerate remotes, switch branch, create branch (when missing) | Fatal | Missing dependencies or branch creation errors abort execution. |
+|  | Sibling worktree adoption (commit message generation, commit, push, remove, prune) | Fatal | Any preservation or cleanup failure aborts before retrying the switch. |
 |  | Fetch remote (`git fetch`) | Non-fatal | Logged as `FETCH-SKIP` and the command proceeds without pulling. |
 |  | Pull branch (`git pull --rebase`) | Non-fatal | Logged as `PULL-SKIP`; branch switch still succeeds. |
 |  | Preview skip | Non-fatal | Explicit message and continue. |

--- a/internal/branches/cd/command.go
+++ b/internal/branches/cd/command.go
@@ -20,7 +20,7 @@ const (
 	commandUsageTemplateConstant            = commandUseNameConstant + " [branch]"
 	commandExampleTemplateConstant          = "gix cd feature/new-branch --roots ~/Development"
 	commandShortDescriptionConstant         = "Switch repositories to the selected branch"
-	commandLongDescriptionConstant          = "cd fetches updates, switches to the requested branch, creates it if missing, and rebases onto the remote for each repository root. Provide the branch name as the first argument before any optional repository roots or flags, or configure a default branch in the application settings."
+	commandLongDescriptionConstant          = "cd fetches updates, switches to the requested branch, creates it if missing, and rebases onto the remote for each repository root. When the branch is checked out in a sibling worktree, cd preserves dirty sibling changes with a generated commit, pushes required sibling commits, removes the sibling worktree, prunes metadata, and retries the switch. Provide the branch name as the first argument before any optional repository roots or flags, or configure a default branch in the application settings."
 	missingBranchMessageConstant            = "unable to determine branch; provide a branch argument or configure a default branch"
 	changeSuccessMessageTemplateConstant    = "SWITCHED: %s -> %s"
 	changeCreatedSuffixConstant             = " (created)"
@@ -158,6 +158,7 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 	if commitRequested {
 		actionOptions[taskOptionCommitChanges] = true
 	}
+	actionOptions[taskOptionWorktreeCommitMessage] = worktreeAdoptionCommitMessageOptionsFromConfiguration(configuration.CommitMessage)
 
 	taskBranchLabel := strings.TrimSpace(explicitBranch)
 	if len(taskBranchLabel) == 0 {

--- a/internal/branches/cd/configuration.go
+++ b/internal/branches/cd/configuration.go
@@ -8,15 +8,32 @@ import (
 
 var commandConfigurationRepositorySanitizer = pathutils.NewRepositoryPathSanitizerWithConfiguration(nil, pathutils.RepositoryPathSanitizerConfiguration{PruneNestedPaths: true})
 
+const (
+	defaultCommitMessageAPIKeyEnvironment = "OPENAI_API_KEY"
+	defaultCommitMessageModel             = "gpt-4.1-mini"
+	defaultCommitMessageTimeoutSeconds    = 60
+)
+
+// CommitMessageConfiguration captures LLM settings for automatic worktree checkpoint commits.
+type CommitMessageConfiguration struct {
+	APIKeyEnv      string  `mapstructure:"api_key_env"`
+	BaseURL        string  `mapstructure:"base_url"`
+	Model          string  `mapstructure:"model"`
+	MaxTokens      int     `mapstructure:"max_completion_tokens"`
+	Temperature    float64 `mapstructure:"temperature"`
+	TimeoutSeconds int     `mapstructure:"timeout_seconds"`
+}
+
 // CommandConfiguration captures configuration values for the cd command.
 type CommandConfiguration struct {
-	RepositoryRoots []string `mapstructure:"roots"`
-	DefaultBranch   string   `mapstructure:"branch"`
-	RemoteName      string   `mapstructure:"remote"`
-	CreateIfMissing bool     `mapstructure:"create_if_missing"`
-	RequireClean    bool     `mapstructure:"require_clean"`
-	StashChanges    bool     `mapstructure:"stash"`
-	CommitChanges   bool     `mapstructure:"commit"`
+	RepositoryRoots []string                   `mapstructure:"roots"`
+	DefaultBranch   string                     `mapstructure:"branch"`
+	RemoteName      string                     `mapstructure:"remote"`
+	CreateIfMissing bool                       `mapstructure:"create_if_missing"`
+	RequireClean    bool                       `mapstructure:"require_clean"`
+	StashChanges    bool                       `mapstructure:"stash"`
+	CommitChanges   bool                       `mapstructure:"commit"`
+	CommitMessage   CommitMessageConfiguration `mapstructure:"commit_message"`
 }
 
 // DefaultCommandConfiguration returns the baseline configuration for cd.
@@ -24,6 +41,16 @@ func DefaultCommandConfiguration() CommandConfiguration {
 	return CommandConfiguration{
 		CreateIfMissing: true,
 		RequireClean:    true,
+		CommitMessage:   DefaultCommitMessageConfiguration(),
+	}
+}
+
+// DefaultCommitMessageConfiguration returns baseline LLM settings for adoption commits.
+func DefaultCommitMessageConfiguration() CommitMessageConfiguration {
+	return CommitMessageConfiguration{
+		APIKeyEnv:      defaultCommitMessageAPIKeyEnvironment,
+		Model:          defaultCommitMessageModel,
+		TimeoutSeconds: defaultCommitMessageTimeoutSeconds,
 	}
 }
 
@@ -33,5 +60,35 @@ func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized.RepositoryRoots = commandConfigurationRepositorySanitizer.Sanitize(configuration.RepositoryRoots)
 	sanitized.DefaultBranch = strings.TrimSpace(configuration.DefaultBranch)
 	sanitized.RemoteName = strings.TrimSpace(configuration.RemoteName)
+	sanitized.CommitMessage = configuration.CommitMessage.Sanitize()
+	return sanitized
+}
+
+// Sanitize normalizes commit-message configuration values.
+func (configuration CommitMessageConfiguration) Sanitize() CommitMessageConfiguration {
+	sanitized := configuration
+
+	apiKeyEnv := strings.TrimSpace(configuration.APIKeyEnv)
+	if apiKeyEnv == "" {
+		apiKeyEnv = defaultCommitMessageAPIKeyEnvironment
+	}
+	sanitized.APIKeyEnv = apiKeyEnv
+
+	sanitized.BaseURL = strings.TrimSpace(configuration.BaseURL)
+
+	model := strings.TrimSpace(configuration.Model)
+	if model == "" {
+		model = defaultCommitMessageModel
+	}
+	sanitized.Model = model
+
+	if sanitized.MaxTokens < 0 {
+		sanitized.MaxTokens = 0
+	}
+
+	if sanitized.TimeoutSeconds <= 0 {
+		sanitized.TimeoutSeconds = defaultCommitMessageTimeoutSeconds
+	}
+
 	return sanitized
 }

--- a/internal/branches/cd/task_action.go
+++ b/internal/branches/cd/task_action.go
@@ -23,6 +23,7 @@ const (
 	taskOptionRequireClean            = "require_clean"
 	taskOptionStashChanges            = "stash"
 	taskOptionCommitChanges           = "commit"
+	taskOptionWorktreeCommitMessage   = "worktree_commit_message"
 
 	branchResolutionSourceExplicit      = "explicit"
 	branchResolutionSourceRemoteDefault = "remote_default"
@@ -160,7 +161,6 @@ func handleBranchChangeAction(ctx context.Context, environment *workflow.Environ
 		}
 		trackedStatus, untrackedStatus = worktree.SplitStatusEntries(statusEntries, nil)
 	}
-
 	refreshSkippedDetails := map[string]string{}
 	refreshSkipped := false
 	if refreshRequested && requireClean && !stashChanges && !commitChanges {
@@ -219,13 +219,29 @@ func handleBranchChangeAction(ctx context.Context, environment *workflow.Environ
 		return serviceError
 	}
 
-	result, changeError := service.Change(ctx, Options{
+	changeOptions := Options{
 		RepositoryPath:  repository.Path,
 		BranchName:      resolvedBranchName,
 		RemoteName:      remoteName,
 		CreateIfMissing: createIfMissing,
 		pullMode:        pullModeForRefreshState(refreshSkipped),
-	})
+	}
+	result, changeError := service.Change(ctx, changeOptions)
+	if changeError != nil && isBranchAlreadyUsedByWorktreeError(changeError) {
+		commitMessageOptions, commitMessageErr := worktreeAdoptionCommitMessageOptionsFromParameters(parameters)
+		if commitMessageErr != nil {
+			return commitMessageErr
+		}
+		adoptionOptions := worktreeAdoptionOptions{
+			BranchName:     resolvedBranchName,
+			RemoteName:     remoteName,
+			CommitMessages: commitMessageOptions,
+		}
+		if adoptionErr := adoptExistingBranchWorktree(ctx, environment, repository, adoptionOptions); adoptionErr != nil {
+			return adoptionErr
+		}
+		result, changeError = service.Change(ctx, changeOptions)
+	}
 	if changeError != nil {
 		return changeError
 	}

--- a/internal/branches/cd/worktree_adoption.go
+++ b/internal/branches/cd/worktree_adoption.go
@@ -1,0 +1,404 @@
+package cd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tyemirov/gix/internal/commitmsg"
+	"github.com/tyemirov/gix/internal/execshell"
+	"github.com/tyemirov/gix/internal/repos/shared"
+	"github.com/tyemirov/gix/internal/workflow"
+	"github.com/tyemirov/utils/llm"
+)
+
+const (
+	gitWorktreeSubcommandConstant             = "worktree"
+	gitWorktreeListSubcommandConstant         = "list"
+	gitWorktreeRemoveSubcommandConstant       = "remove"
+	gitWorktreePruneSubcommandConstant        = "prune"
+	gitPorcelainFlagConstant                  = "--porcelain"
+	gitPorcelainBranchFlagConstant            = "--branch"
+	gitStatusSubcommand                       = "status"
+	gitAddSubcommand                          = "add"
+	gitCommitSubcommand                       = "commit"
+	gitPushSubcommand                         = "push"
+	gitAddAllFlag                             = "--all"
+	gitCommitMessageFlag                      = "-m"
+	gitPushSetUpstreamFlag                    = "--set-upstream"
+	gitBranchReferencePrefix                  = "refs/heads/"
+	gitStatusBranchHeaderPrefix               = "## "
+	gitStatusAheadMarker                      = "ahead "
+	gitBranchAlreadyUsedByWorktreeIndicator   = "already used by worktree"
+	worktreeListFailureTemplate               = "failed to list worktrees before switching to %q: %w"
+	worktreeStatusFailureTemplate             = "failed to inspect worktree %s: %w"
+	worktreeLockedFailureTemplate             = "target branch %q is checked out in locked worktree %s"
+	worktreeStageFailureTemplate              = "failed to stage sibling worktree changes at %s: %w"
+	worktreeCommitFailureTemplate             = "failed to commit sibling worktree changes at %s: %w"
+	worktreePushFailureTemplate               = "failed to push adopted worktree branch %q from %s: %w"
+	worktreeRemoveFailureTemplate             = "failed to remove sibling worktree %s: %w"
+	worktreePruneFailureTemplate              = "failed to prune worktrees after removing %s: %w"
+	worktreeMessageClientConfigurationFailure = "commit message generation requires model and api key configuration"
+	worktreeMessageAPIKeyFailureTemplate      = "environment variable %s must be set to generate a commit message"
+	worktreeMessageClientFailureTemplate      = "failed to initialize commit message client: %w"
+	worktreeMessageGenerationFailureTemplate  = "failed to generate commit message for sibling worktree %s: %w"
+	worktreeAdoptDetectedMessage              = "adopting sibling worktree"
+	worktreeAdoptCommitMessage                = "committed sibling worktree changes"
+	worktreeAdoptPushMessage                  = "pushed sibling worktree branch"
+	worktreeAdoptRemoveMessage                = "removed sibling worktree"
+	worktreeAdoptPruneMessage                 = "pruned worktree metadata"
+)
+
+type worktreeAdoptionOptions struct {
+	BranchName     string
+	RemoteName     string
+	CommitMessages worktreeAdoptionCommitMessageOptions
+}
+
+func isBranchAlreadyUsedByWorktreeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), gitBranchAlreadyUsedByWorktreeIndicator)
+}
+
+type worktreeAdoptionCommitMessageOptions struct {
+	APIKeyEnv      string
+	BaseURL        string
+	Model          string
+	MaxTokens      int
+	Temperature    float64
+	TimeoutSeconds int
+	Client         llm.ChatClient
+}
+
+type listedWorktree struct {
+	Path       string
+	BranchName string
+	Locked     bool
+}
+
+type worktreeStatus struct {
+	Dirty bool
+	Ahead bool
+}
+
+func worktreeAdoptionCommitMessageOptionsFromConfiguration(configuration CommitMessageConfiguration) worktreeAdoptionCommitMessageOptions {
+	sanitized := configuration.Sanitize()
+	return worktreeAdoptionCommitMessageOptions{
+		APIKeyEnv:      sanitized.APIKeyEnv,
+		BaseURL:        sanitized.BaseURL,
+		Model:          sanitized.Model,
+		MaxTokens:      sanitized.MaxTokens,
+		Temperature:    sanitized.Temperature,
+		TimeoutSeconds: sanitized.TimeoutSeconds,
+	}
+}
+
+func worktreeAdoptionCommitMessageOptionsFromParameters(parameters map[string]any) (worktreeAdoptionCommitMessageOptions, error) {
+	rawOptions, exists := parameters[taskOptionWorktreeCommitMessage]
+	if !exists || rawOptions == nil {
+		return worktreeAdoptionCommitMessageOptions{}, nil
+	}
+	typedOptions, ok := rawOptions.(worktreeAdoptionCommitMessageOptions)
+	if !ok {
+		return worktreeAdoptionCommitMessageOptions{}, fmt.Errorf("%s must be commit message options", taskOptionWorktreeCommitMessage)
+	}
+	return typedOptions, nil
+}
+
+func adoptExistingBranchWorktree(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, options worktreeAdoptionOptions) error {
+	if environment == nil || repository == nil {
+		return nil
+	}
+	if environment.GitExecutor == nil {
+		return ErrGitExecutorNotConfigured
+	}
+
+	branchName := strings.TrimSpace(options.BranchName)
+	if branchName == "" {
+		return nil
+	}
+
+	worktrees, listErr := listRepositoryWorktrees(ctx, environment.GitExecutor, repository.Path, branchName)
+	if listErr != nil {
+		return listErr
+	}
+
+	for worktreeIndex := range worktrees {
+		candidate := worktrees[worktreeIndex]
+		if candidate.BranchName != branchName {
+			continue
+		}
+		if sameFilesystemPath(candidate.Path, repository.Path) {
+			continue
+		}
+		if candidate.Locked {
+			return fmt.Errorf(worktreeLockedFailureTemplate, branchName, candidate.Path)
+		}
+		return adoptSiblingWorktree(ctx, environment, repository, candidate, options)
+	}
+
+	return nil
+}
+
+func listRepositoryWorktrees(ctx context.Context, executor shared.GitExecutor, repositoryPath string, branchName string) ([]listedWorktree, error) {
+	result, listErr := executor.ExecuteGit(ctx, execshell.CommandDetails{
+		Arguments:        []string{gitWorktreeSubcommandConstant, gitWorktreeListSubcommandConstant, gitPorcelainFlagConstant},
+		WorkingDirectory: repositoryPath,
+	})
+	if listErr != nil {
+		return nil, fmt.Errorf(worktreeListFailureTemplate, branchName, listErr)
+	}
+	return parseListedWorktrees(result.StandardOutput), nil
+}
+
+func parseListedWorktrees(output string) []listedWorktree {
+	var worktrees []listedWorktree
+	current := listedWorktree{}
+	flushCurrent := func() {
+		if strings.TrimSpace(current.Path) == "" {
+			current = listedWorktree{}
+			return
+		}
+		worktrees = append(worktrees, current)
+		current = listedWorktree{}
+	}
+
+	lines := strings.Split(output, "\n")
+	for lineIndex := range lines {
+		line := strings.TrimSpace(lines[lineIndex])
+		if line == "" {
+			flushCurrent()
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		switch fields[0] {
+		case "worktree":
+			flushCurrent()
+			current.Path = strings.TrimSpace(strings.TrimPrefix(line, "worktree"))
+		case "branch":
+			referenceName := strings.TrimSpace(strings.TrimPrefix(line, "branch"))
+			current.BranchName = strings.TrimPrefix(referenceName, gitBranchReferencePrefix)
+		case "locked":
+			current.Locked = true
+		}
+	}
+	flushCurrent()
+	return worktrees
+}
+
+func adoptSiblingWorktree(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, worktree listedWorktree, options worktreeAdoptionOptions) error {
+	branchName := strings.TrimSpace(options.BranchName)
+	remoteName := strings.TrimSpace(options.RemoteName)
+	if remoteName == "" {
+		remoteName = defaultRemoteNameConstant
+	}
+
+	environment.ReportRepositoryEvent(
+		repository,
+		shared.EventLevelInfo,
+		shared.EventCodeWorktreeAdopt,
+		worktreeAdoptDetectedMessage,
+		map[string]string{"branch": branchName, "worktree": worktree.Path},
+	)
+
+	status, statusErr := inspectSiblingWorktreeStatus(ctx, environment.GitExecutor, worktree.Path)
+	if statusErr != nil {
+		return statusErr
+	}
+
+	pushed := false
+	if status.Dirty {
+		commitMessage, commitMessageErr := generateSiblingCommitMessage(ctx, environment.GitExecutor, worktree.Path, options.CommitMessages)
+		if commitMessageErr != nil {
+			return commitMessageErr
+		}
+		if commitErr := executeGit(ctx, environment.GitExecutor, worktree.Path, []string{gitCommitSubcommand, gitCommitMessageFlag, commitMessage}); commitErr != nil {
+			return fmt.Errorf(worktreeCommitFailureTemplate, worktree.Path, commitErr)
+		}
+		environment.ReportRepositoryEvent(
+			repository,
+			shared.EventLevelInfo,
+			shared.EventCodeWorktreeAdopt,
+			worktreeAdoptCommitMessage,
+			map[string]string{"branch": branchName, "worktree": worktree.Path},
+		)
+		if pushErr := pushSiblingBranch(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
+			return pushErr
+		}
+		pushed = true
+	}
+
+	if !status.Dirty && status.Ahead {
+		if pushErr := pushSiblingBranch(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
+			return pushErr
+		}
+		pushed = true
+	}
+
+	if pushed {
+		environment.ReportRepositoryEvent(
+			repository,
+			shared.EventLevelInfo,
+			shared.EventCodeWorktreeAdopt,
+			worktreeAdoptPushMessage,
+			map[string]string{"branch": branchName, "remote": remoteName, "worktree": worktree.Path},
+		)
+	}
+
+	if removeErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreeRemoveSubcommandConstant, worktree.Path}); removeErr != nil {
+		return fmt.Errorf(worktreeRemoveFailureTemplate, worktree.Path, removeErr)
+	}
+	environment.ReportRepositoryEvent(
+		repository,
+		shared.EventLevelInfo,
+		shared.EventCodeWorktreeAdopt,
+		worktreeAdoptRemoveMessage,
+		map[string]string{"branch": branchName, "worktree": worktree.Path},
+	)
+
+	if pruneErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreePruneSubcommandConstant}); pruneErr != nil {
+		return fmt.Errorf(worktreePruneFailureTemplate, worktree.Path, pruneErr)
+	}
+	environment.ReportRepositoryEvent(
+		repository,
+		shared.EventLevelInfo,
+		shared.EventCodeWorktreeAdopt,
+		worktreeAdoptPruneMessage,
+		map[string]string{"branch": branchName, "worktree": worktree.Path},
+	)
+
+	return nil
+}
+
+func inspectSiblingWorktreeStatus(ctx context.Context, executor shared.GitExecutor, worktreePath string) (worktreeStatus, error) {
+	result, statusErr := executor.ExecuteGit(ctx, execshell.CommandDetails{
+		Arguments:        []string{gitStatusSubcommand, gitPorcelainFlagConstant, gitPorcelainBranchFlagConstant},
+		WorkingDirectory: worktreePath,
+	})
+	if statusErr != nil {
+		return worktreeStatus{}, fmt.Errorf(worktreeStatusFailureTemplate, worktreePath, statusErr)
+	}
+
+	status := worktreeStatus{}
+	lines := strings.Split(result.StandardOutput, "\n")
+	for lineIndex := range lines {
+		line := strings.TrimSpace(lines[lineIndex])
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, gitStatusBranchHeaderPrefix) {
+			status.Ahead = strings.Contains(line, gitStatusAheadMarker)
+			continue
+		}
+		status.Dirty = true
+	}
+	return status, nil
+}
+
+func generateSiblingCommitMessage(ctx context.Context, executor shared.GitExecutor, worktreePath string, options worktreeAdoptionCommitMessageOptions) (string, error) {
+	if stageErr := executeGit(ctx, executor, worktreePath, []string{gitAddSubcommand, gitAddAllFlag}); stageErr != nil {
+		return "", fmt.Errorf(worktreeStageFailureTemplate, worktreePath, stageErr)
+	}
+
+	client, clientErr := resolveCommitMessageClient(options)
+	if clientErr != nil {
+		return "", clientErr
+	}
+
+	var temperature *float64
+	if options.Temperature != 0 {
+		temperatureValue := options.Temperature
+		temperature = &temperatureValue
+	}
+
+	generator := commitmsg.Generator{
+		GitExecutor: executor,
+		Client:      client,
+	}
+	result, generateErr := generator.Generate(ctx, commitmsg.Options{
+		RepositoryPath: worktreePath,
+		Source:         commitmsg.DiffSourceStaged,
+		MaxTokens:      options.MaxTokens,
+		Temperature:    temperature,
+	})
+	if generateErr != nil {
+		return "", fmt.Errorf(worktreeMessageGenerationFailureTemplate, worktreePath, generateErr)
+	}
+	return result.Message, nil
+}
+
+func resolveCommitMessageClient(options worktreeAdoptionCommitMessageOptions) (llm.ChatClient, error) {
+	if options.Client != nil {
+		return options.Client, nil
+	}
+	apiKeyEnv := strings.TrimSpace(options.APIKeyEnv)
+	model := strings.TrimSpace(options.Model)
+	if apiKeyEnv == "" || model == "" {
+		return nil, errors.New(worktreeMessageClientConfigurationFailure)
+	}
+	apiKey := strings.TrimSpace(os.Getenv(apiKeyEnv))
+	if apiKey == "" {
+		return nil, fmt.Errorf(worktreeMessageAPIKeyFailureTemplate, apiKeyEnv)
+	}
+	timeoutSeconds := options.TimeoutSeconds
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = defaultCommitMessageTimeoutSeconds
+	}
+	client, clientErr := llm.NewFactory(llm.Config{
+		BaseURL:             strings.TrimSpace(options.BaseURL),
+		APIKey:              apiKey,
+		Model:               model,
+		MaxCompletionTokens: options.MaxTokens,
+		Temperature:         options.Temperature,
+		RequestTimeout:      time.Duration(timeoutSeconds) * time.Second,
+	})
+	if clientErr != nil {
+		return nil, fmt.Errorf(worktreeMessageClientFailureTemplate, clientErr)
+	}
+	return client, nil
+}
+
+func pushSiblingBranch(ctx context.Context, executor shared.GitExecutor, worktreePath string, remoteName string, branchName string) error {
+	if pushErr := executeGit(ctx, executor, worktreePath, []string{gitPushSubcommand, gitPushSetUpstreamFlag, remoteName, branchName}); pushErr != nil {
+		return fmt.Errorf(worktreePushFailureTemplate, branchName, worktreePath, pushErr)
+	}
+	return nil
+}
+
+func executeGit(ctx context.Context, executor shared.GitExecutor, workingDirectory string, arguments []string) error {
+	_, executionErr := executor.ExecuteGit(ctx, execshell.CommandDetails{
+		Arguments:        arguments,
+		WorkingDirectory: workingDirectory,
+	})
+	return executionErr
+}
+
+func sameFilesystemPath(firstPath string, secondPath string) bool {
+	normalizedFirst := normalizeFilesystemPath(firstPath)
+	normalizedSecond := normalizeFilesystemPath(secondPath)
+	if normalizedFirst == "" || normalizedSecond == "" {
+		return strings.TrimSpace(firstPath) == strings.TrimSpace(secondPath)
+	}
+	return normalizedFirst == normalizedSecond
+}
+
+func normalizeFilesystemPath(path string) string {
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return ""
+	}
+	absolutePath, absoluteErr := filepath.Abs(trimmedPath)
+	if absoluteErr != nil {
+		return filepath.Clean(trimmedPath)
+	}
+	return filepath.Clean(absolutePath)
+}

--- a/internal/branches/cd/worktree_adoption.go
+++ b/internal/branches/cd/worktree_adoption.go
@@ -27,9 +27,11 @@ const (
 	gitAddSubcommand                          = "add"
 	gitCommitSubcommand                       = "commit"
 	gitPushSubcommand                         = "push"
+	gitRevListSubcommand                      = "rev-list"
 	gitAddAllFlag                             = "--all"
 	gitCommitMessageFlag                      = "-m"
 	gitPushSetUpstreamFlag                    = "--set-upstream"
+	gitRevListCountFlag                       = "--count"
 	gitBranchReferencePrefix                  = "refs/heads/"
 	gitStatusBranchHeaderPrefix               = "## "
 	gitStatusAheadMarker                      = "ahead "
@@ -40,6 +42,8 @@ const (
 	worktreeStageFailureTemplate              = "failed to stage sibling worktree changes at %s: %w"
 	worktreeCommitFailureTemplate             = "failed to commit sibling worktree changes at %s: %w"
 	worktreePushFailureTemplate               = "failed to push adopted worktree branch %q from %s: %w"
+	worktreePushInspectionFailureTemplate     = "failed to inspect push requirement for branch %q against %q from %s: %w"
+	worktreeRemoteInspectionFailureTemplate   = "failed to inspect remote branch %q from %s: %w"
 	worktreeRemoveFailureTemplate             = "failed to remove sibling worktree %s: %w"
 	worktreePruneFailureTemplate              = "failed to prune worktrees after removing %s: %w"
 	worktreeMessageClientConfigurationFailure = "commit message generation requires model and api key configuration"
@@ -237,11 +241,17 @@ func adoptSiblingWorktree(ctx context.Context, environment *workflow.Environment
 		pushed = true
 	}
 
-	if !status.Dirty && status.Ahead {
-		if pushErr := pushSiblingBranch(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
-			return pushErr
+	if !status.Dirty {
+		needsPush, needsPushErr := cleanSiblingBranchNeedsPush(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName, status)
+		if needsPushErr != nil {
+			return needsPushErr
 		}
-		pushed = true
+		if needsPush {
+			if pushErr := pushSiblingBranch(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
+				return pushErr
+			}
+			pushed = true
+		}
 	}
 
 	if pushed {
@@ -302,6 +312,46 @@ func inspectSiblingWorktreeStatus(ctx context.Context, executor shared.GitExecut
 		status.Dirty = true
 	}
 	return status, nil
+}
+
+func cleanSiblingBranchNeedsPush(ctx context.Context, executor shared.GitExecutor, worktreePath string, remoteName string, branchName string, status worktreeStatus) (bool, error) {
+	if status.Ahead {
+		return true, nil
+	}
+
+	remoteReference := fmt.Sprintf("%s/%s", remoteName, branchName)
+	remoteExists, remoteErr := remoteBranchReferenceExists(ctx, executor, worktreePath, remoteReference)
+	if remoteErr != nil {
+		return false, remoteErr
+	}
+	if !remoteExists {
+		return true, nil
+	}
+
+	comparisonRange := fmt.Sprintf("%s..%s", remoteReference, branchName)
+	result, countErr := executor.ExecuteGit(ctx, execshell.CommandDetails{
+		Arguments:        []string{gitRevListSubcommand, gitRevListCountFlag, comparisonRange},
+		WorkingDirectory: worktreePath,
+	})
+	if countErr != nil {
+		return false, fmt.Errorf(worktreePushInspectionFailureTemplate, branchName, remoteReference, worktreePath, countErr)
+	}
+
+	return strings.TrimSpace(result.StandardOutput) != "0", nil
+}
+
+func remoteBranchReferenceExists(ctx context.Context, executor shared.GitExecutor, worktreePath string, remoteReference string) (bool, error) {
+	_, remoteErr := executor.ExecuteGit(ctx, execshell.CommandDetails{
+		Arguments:        []string{gitRevParseSubcommandConstant, gitVerifyFlagConstant, remoteReference},
+		WorkingDirectory: worktreePath,
+	})
+	if remoteErr == nil {
+		return true, nil
+	}
+	if isBranchMissingError(remoteErr) {
+		return false, nil
+	}
+	return false, fmt.Errorf(worktreeRemoteInspectionFailureTemplate, remoteReference, worktreePath, remoteErr)
 }
 
 func generateSiblingCommitMessage(ctx context.Context, executor shared.GitExecutor, worktreePath string, options worktreeAdoptionCommitMessageOptions) (string, error) {

--- a/internal/repos/shared/event_codes.go
+++ b/internal/repos/shared/event_codes.go
@@ -4,6 +4,7 @@ package shared
 const (
 	EventCodeRepoSwitched             = "REPO_SWITCHED"
 	EventCodeRepoDirty                = "REPO_DIRTY"
+	EventCodeWorktreeAdopt            = "WORKTREE_ADOPT"
 	EventCodeNamespacePlan            = "NAMESPACE_PLAN"
 	EventCodeNamespaceApply           = "NAMESPACE_APPLY"
 	EventCodeNamespaceSkip            = "NAMESPACE_SKIP"

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -36,7 +36,7 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Abort before removal when commit generation, commit, push, or worktree removal fails.
   ## Resolution
   - `gix cd` now recognizes the Git worktree collision error, adopts the sibling worktree for the requested branch, commits dirty sibling changes with the configured generated commit-message path, pushes preserved commits, removes the sibling with `git worktree remove`, prunes metadata, and retries the normal switch/pull flow.
-  - Clean sibling worktrees skip the commit step; clean sibling worktrees that are ahead of upstream are pushed before removal.
+  - Clean sibling worktrees skip the commit step; clean sibling worktrees that contain commits missing from the configured remote are pushed before removal, even when the branch has no upstream metadata.
   - Added black-box integration coverage for dirty sibling adoption and clean-ahead sibling adoption.
   - `make ci` passed locally.
 

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -11,6 +11,35 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
 
 ## BugFixes
 
+- [x] [B007] (P1) `.gitignore` hides new source and test files by default.
+  Requested on 2026-05-21 after new `gix cd` implementation files were present on disk but only visible under ignored status because `.gitignore` used a catch-all `*` with a narrow allowlist.
+  ## Observation
+  - The catch-all ignore shape made normal implementation files invisible to `git status`.
+  - That increased the chance of shipping partial changes unless new files were manually force-added.
+  ## Deliverable
+  - Replace the blanket ignore with explicit rules for OS/editor noise, local environment files, Go build/test artifacts, generated output, browser automation traces, and local planning scratch.
+  - Ensure normal source, test, docs, config, and workflow files are trackable without force-add.
+  ## Resolution
+  - Rewrote `.gitignore` as an explicit project ignore list.
+  - New Go source and integration test files now appear in regular `git status`.
+
+- [x] [B006] (P1) `gix cd` fails when the target branch is already checked out in a sibling worktree.
+  Requested on 2026-05-21 after `gix cd tyemirov/bugfix/B005-sample-title-center` failed in `/Users/tyemirov/Development/Hecate` because the branch was already used by `/Users/tyemirov/Development/Hecate-pr108`.
+  ## Observation
+  - Git refuses to switch a branch that is already checked out by another worktree.
+  - The operator intent for `gix cd` is to make the requested branch active in the current checkout, automatically preserving and removing the disposable sibling worktree when safe.
+  ## Deliverable
+  - Detect sibling worktrees that own the requested branch before switching.
+  - If the sibling worktree has uncommitted changes, stage all changes, generate a commit message, commit them, and push the branch to the configured remote.
+  - If the sibling worktree is clean, skip the commit step; if it is clean but ahead of upstream, push before removal.
+  - Remove the sibling worktree with `git worktree remove`, prune worktree metadata, then switch and pull the requested branch through the existing `gix cd` path.
+  - Abort before removal when commit generation, commit, push, or worktree removal fails.
+  ## Resolution
+  - `gix cd` now recognizes the Git worktree collision error, adopts the sibling worktree for the requested branch, commits dirty sibling changes with the configured generated commit-message path, pushes preserved commits, removes the sibling with `git worktree remove`, prunes metadata, and retries the normal switch/pull flow.
+  - Clean sibling worktrees skip the commit step; clean sibling worktrees that are ahead of upstream are pushed before removal.
+  - Added black-box integration coverage for dirty sibling adoption and clean-ahead sibling adoption.
+  - `make ci` passed locally.
+
 - [x] [B005] (P1) `gix cd` skips remote fast-forward updates when the worktree has tracked local changes.
   Requested on 2026-05-10 after `gix cd` reported `refresh skipped (dirty worktree)` in `/Users/tyemirov/Documents/Projects/Fiction`, while a manual `git pull` immediately fast-forwarded `master`.
   ## Observation

--- a/tests/cd_worktree_adoption_integration_test.go
+++ b/tests/cd_worktree_adoption_integration_test.go
@@ -71,6 +71,8 @@ func TestCdAdoptsCleanAheadSiblingWorktree(testInstance *testing.T) {
 	require.NoError(testInstance, os.WriteFile(aheadPath, []byte("already committed locally\n"), 0o644))
 	runGit(testInstance, fixture.SiblingPath, "add", "ahead.txt")
 	runGit(testInstance, fixture.SiblingPath, "commit", "-m", "chore: local sibling commit")
+	runGit(testInstance, fixture.SiblingPath, "branch", "--unset-upstream")
+	require.NotContains(testInstance, runGit(testInstance, fixture.SiblingPath, "status", "--porcelain", "--branch"), "ahead")
 
 	configurationPath := writeCdWorktreeAdoptionConfiguration(testInstance, "")
 	output := runIntegrationCommand(

--- a/tests/cd_worktree_adoption_integration_test.go
+++ b/tests/cd_worktree_adoption_integration_test.go
@@ -1,0 +1,187 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	cdWorktreeAdoptionTimeout        = 20 * time.Second
+	cdWorktreeAdoptionBranchName     = "feature/adopt-worktree"
+	cdWorktreeAdoptionCommitSubject  = "chore: save sibling changes"
+	cdWorktreeAdoptionAPIKeyVariable = "TEST_GIX_LLM_KEY"
+)
+
+type cdWorktreeAdoptionFixture struct {
+	RemotePath     string
+	RepositoryPath string
+	SiblingPath    string
+	BranchName     string
+}
+
+func TestCdAdoptsDirtySiblingWorktree(testInstance *testing.T) {
+	repositoryRoot := integrationRepositoryRoot(testInstance)
+	fixture := createCdWorktreeAdoptionFixture(testInstance)
+	serverRequestCount := 0
+	mockLLMServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		serverRequestCount++
+		require.Equal(testInstance, "/chat/completions", request.URL.Path)
+		require.Equal(testInstance, "Bearer test-api-key", request.Header.Get("Authorization"))
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, writeError := responseWriter.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"` + cdWorktreeAdoptionCommitSubject + `"},"finish_reason":"stop"}]}`))
+		require.NoError(testInstance, writeError)
+	}))
+	defer mockLLMServer.Close()
+
+	dirtyPath := filepath.Join(fixture.SiblingPath, "feature.txt")
+	require.NoError(testInstance, os.WriteFile(dirtyPath, []byte("dirty sibling change\n"), 0o644))
+
+	configurationPath := writeCdWorktreeAdoptionConfiguration(testInstance, mockLLMServer.URL)
+	output := runIntegrationCommand(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{EnvironmentOverrides: map[string]string{cdWorktreeAdoptionAPIKeyVariable: "test-api-key"}},
+		cdWorktreeAdoptionTimeout,
+		[]string{"run", ".", "--config", configurationPath, "cd", fixture.BranchName, "--roots", fixture.RepositoryPath},
+	)
+
+	require.Contains(testInstance, output, "WORKTREE_ADOPT")
+	require.Equal(testInstance, 1, serverRequestCount)
+	require.NoDirExists(testInstance, fixture.SiblingPath)
+	require.Equal(testInstance, fixture.BranchName, strings.TrimSpace(runGit(testInstance, fixture.RepositoryPath, "branch", "--show-current")))
+	require.Equal(testInstance, "dirty sibling change\n", readFile(testInstance, filepath.Join(fixture.RepositoryPath, "feature.txt")))
+	require.Equal(testInstance, cdWorktreeAdoptionCommitSubject, strings.TrimSpace(runGitWithDir(testInstance, "", "--git-dir", fixture.RemotePath, "log", "-1", "--pretty=%s", "refs/heads/"+fixture.BranchName)))
+	require.Equal(testInstance, "0", strings.TrimSpace(runGit(testInstance, fixture.RepositoryPath, "rev-list", "--count", "origin/"+fixture.BranchName+".."+fixture.BranchName)))
+}
+
+func TestCdAdoptsCleanAheadSiblingWorktree(testInstance *testing.T) {
+	repositoryRoot := integrationRepositoryRoot(testInstance)
+	fixture := createCdWorktreeAdoptionFixture(testInstance)
+
+	aheadPath := filepath.Join(fixture.SiblingPath, "ahead.txt")
+	require.NoError(testInstance, os.WriteFile(aheadPath, []byte("already committed locally\n"), 0o644))
+	runGit(testInstance, fixture.SiblingPath, "add", "ahead.txt")
+	runGit(testInstance, fixture.SiblingPath, "commit", "-m", "chore: local sibling commit")
+
+	configurationPath := writeCdWorktreeAdoptionConfiguration(testInstance, "")
+	output := runIntegrationCommand(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{},
+		cdWorktreeAdoptionTimeout,
+		[]string{"run", ".", "--config", configurationPath, "cd", fixture.BranchName, "--roots", fixture.RepositoryPath},
+	)
+
+	require.Contains(testInstance, output, "WORKTREE_ADOPT")
+	require.NoDirExists(testInstance, fixture.SiblingPath)
+	require.Equal(testInstance, fixture.BranchName, strings.TrimSpace(runGit(testInstance, fixture.RepositoryPath, "branch", "--show-current")))
+	require.Equal(testInstance, "chore: local sibling commit", strings.TrimSpace(runGitWithDir(testInstance, "", "--git-dir", fixture.RemotePath, "log", "-1", "--pretty=%s", "refs/heads/"+fixture.BranchName)))
+	require.Equal(testInstance, "0", strings.TrimSpace(runGit(testInstance, fixture.RepositoryPath, "rev-list", "--count", "origin/"+fixture.BranchName+".."+fixture.BranchName)))
+}
+
+func createCdWorktreeAdoptionFixture(testInstance *testing.T) cdWorktreeAdoptionFixture {
+	testInstance.Helper()
+
+	workspacePath := testInstance.TempDir()
+	remotePath := filepath.Join(workspacePath, "remote.git")
+	runGitWithDir(testInstance, "", "init", "--bare", remotePath)
+
+	repositoryPath := filepath.Join(workspacePath, "repository")
+	runGitWithDir(testInstance, "", "init", "--initial-branch=master", repositoryPath)
+	configureGitIdentity(testInstance, repositoryPath)
+	runGit(testInstance, repositoryPath, "remote", "add", "origin", remotePath)
+
+	readmePath := filepath.Join(repositoryPath, "README.md")
+	require.NoError(testInstance, os.WriteFile(readmePath, []byte("initial\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "README.md")
+	runGit(testInstance, repositoryPath, "commit", "-m", "initial commit")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", "master")
+
+	runGit(testInstance, repositoryPath, "switch", "-c", cdWorktreeAdoptionBranchName)
+	featurePath := filepath.Join(repositoryPath, "feature.txt")
+	require.NoError(testInstance, os.WriteFile(featurePath, []byte("feature base\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "feature.txt")
+	runGit(testInstance, repositoryPath, "commit", "-m", "feature base")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", cdWorktreeAdoptionBranchName)
+	runGit(testInstance, repositoryPath, "switch", "master")
+
+	siblingPath := filepath.Join(workspacePath, "repository-feature")
+	runGit(testInstance, repositoryPath, "worktree", "add", siblingPath, cdWorktreeAdoptionBranchName)
+
+	return cdWorktreeAdoptionFixture{
+		RemotePath:     remotePath,
+		RepositoryPath: repositoryPath,
+		SiblingPath:    siblingPath,
+		BranchName:     cdWorktreeAdoptionBranchName,
+	}
+}
+
+func writeCdWorktreeAdoptionConfiguration(testInstance *testing.T, baseURL string) string {
+	testInstance.Helper()
+
+	configurationPath := filepath.Join(testInstance.TempDir(), "config.yaml")
+	messageConfiguration := ""
+	if strings.TrimSpace(baseURL) != "" {
+		messageConfiguration = fmt.Sprintf(`
+  - command: ["message", "commit"]
+    with:
+      api_key_env: %s
+      base_url: %q
+      model: mock-model
+      diff_source: staged
+      max_completion_tokens: 64
+      temperature: 0
+      timeout_seconds: 5
+`, cdWorktreeAdoptionAPIKeyVariable, baseURL)
+	}
+	configurationContent := fmt.Sprintf(`common:
+  log_level: error
+  log_format: console
+operations:
+  - command: ["cd"]
+    with:
+      remote: origin
+      require_clean: true
+%s`, messageConfiguration)
+	require.NoError(testInstance, os.WriteFile(configurationPath, []byte(configurationContent), 0o600))
+	return configurationPath
+}
+
+func configureGitIdentity(testInstance *testing.T, repositoryPath string) {
+	testInstance.Helper()
+	runGit(testInstance, repositoryPath, "config", "user.name", "Cd Worktree")
+	runGit(testInstance, repositoryPath, "config", "user.email", "cd-worktree@example.com")
+}
+
+func runGit(testInstance *testing.T, repositoryPath string, arguments ...string) string {
+	testInstance.Helper()
+	return runGitWithDir(testInstance, repositoryPath, append([]string{"-C", repositoryPath}, arguments...)...)
+}
+
+func runGitWithDir(testInstance *testing.T, workingDirectory string, arguments ...string) string {
+	testInstance.Helper()
+	command := exec.Command("git", arguments...)
+	if strings.TrimSpace(workingDirectory) != "" {
+		command.Dir = workingDirectory
+	}
+	command.Env = buildGitCommandEnvironment(nil)
+	outputBytes, commandError := command.CombinedOutput()
+	require.NoError(testInstance, commandError, string(outputBytes))
+	return string(outputBytes)
+}
+
+func readFile(testInstance *testing.T, path string) string {
+	testInstance.Helper()
+	content, readError := os.ReadFile(path)
+	require.NoError(testInstance, readError)
+	return string(content)
+}


### PR DESCRIPTION
## Summary

- Teach `gix cd` to recover when Git reports the target branch is already checked out in a sibling worktree.
- Preserve sibling worktree changes by staging dirty changes, generating a commit message, committing, pushing, removing the sibling worktree, pruning metadata, and retrying the normal switch/pull flow.
- Push clean-ahead sibling worktrees before removal, and keep preservation/removal/prune failures fatal.
- Replace the catch-all `.gitignore` with explicit project ignores so new source and test files appear in normal `git status`.

## Root Cause

`gix cd` delegated branch switching directly to Git. When the requested branch was checked out in another worktree, Git refused the switch and `gix` had no adoption path for the disposable sibling checkout. The repo `.gitignore` also hid new source files by default, making this kind of implementation easy to leave unstaged accidentally.

## Validation

- `git diff --check`
- `make ci`