### PR TITLE
Implement dirty gix sync semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Improvements ⚙️
 - Rename the public branch-change command from `gix cd` to `gix sync` while preserving the existing behavior and `switch` alias.
+- Make dirty `gix sync` the default workflow: cluster changed paths, generate commit messages with the configured LLM client, commit the clusters, then sync and push through the PR flow.
+- Route dirty `master` syncs to generated `sync/<repo>/<path>` work branches while keeping clean `master` sync remote-owned.
+- Change `sync.require_clean` to an opt-in guard while preserving `--stash` and accepting `--commit`.
 
 ### Testing 🧪
 - Add CLI coverage that rejects the removed `cd` command and update branch-change integration tests to invoke `sync`.
+- Add strict-sync coverage for dirty PR branches, dirty `master` generated branches, missing remote branch PR creation, and `--require-clean` rejection.
 
 ### Docs 📚
 - Update README, architecture notes, the docs site, and the command warning matrix to use `gix sync`.
+- Document the new dirty-sync flow and LLM client configuration used for automatic commit messages.
 
 ## [v0.4.0] - 2026-05-22
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gix makes one pull-request-centered Git workflow mechanical: `master` belongs to
 | `gix sync <branch>` | Require or create a remote branch with an open PR into `master`, commit dirty work when present, merge `origin/master`, then push. |
 | `gix sync` | Apply the same rule to the current branch. |
 
-By default, a dirty `gix sync` clusters changed paths by top-level area, stages and commits each cluster with a Conventional Commit message from the configured `github.com/tyemirov/utils/llm` client, then continues the no-rebase sync and push. `--stash` temporarily shelves dirty work instead of committing it, `--commit` remains accepted for scripts that already pass it, and `--require-clean` opts back into failing when the worktree is dirty.
+By default, a dirty `gix sync` clusters changed paths by top-level area, stages and commits each cluster with a Conventional Commit message from the configured `github.com/tyemirov/utils/llm` client, then continues the no-rebase sync and push. `--stash` temporarily shelves dirty work instead of committing it, `--commit` explicitly selects the auto-commit policy for scripts that already pass it, and `--require-clean` by itself opts back into failing when the worktree is dirty.
 
 Merge conflicts stop before push and leave the repository in Git's normal conflict state. The PR branch is "ours"; `origin/master` is "theirs".
 
@@ -547,7 +547,7 @@ Top-level commands and their subcommands. Aliases are shown in parentheses.
 - `gix default <target-branch> [--roots <dir>...] [-y]`
  - Promotes the default branch across repositories.
 - `gix sync [remote-url|branch] [--remote <name>] [--stash | --commit] [--require-clean] [--roots <dir>...]` (alias `switch`)
- - Synchronizes the current workspace through the Gix flow: remote attach/clone, remote-owned `master`, or PR-backed work branches. Dirty work is clustered, LLM-described, committed, and pushed by default; dirty `master` sync creates a generated PR work branch. Sync never rebases or force-pushes. `--stash` temporarily shelves dirty work, `--commit` remains accepted, and `--require-clean` requires a clean worktree instead of auto-committing.
+ - Synchronizes the current workspace through the Gix flow: remote attach/clone, remote-owned `master`, or PR-backed work branches. Dirty work is clustered, LLM-described, committed, and pushed by default; dirty `master` sync creates a generated PR work branch. Sync never rebases or force-pushes. `--stash` temporarily shelves dirty work, `--commit` explicitly selects the auto-commit policy, and `--require-clean` requires a clean worktree only when no dirty-work policy is selected.
 ## Configuration essentials
 
 - `gix --init LOCAL` writes an embeddable starter `config.yaml` to the current directory; `gix --init user` places it under `$XDG_CONFIG_HOME/gix` or `$HOME/.gix`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ gix makes one pull-request-centered Git workflow mechanical: `master` belongs to
 
 - Return to remote-owned `master`, resume a PR branch, or create a new PR branch with one command.
 - Merge `origin/master` into work branches and push the result without rewriting shared history.
-- Keep dirty-work handling explicit with `--stash`, `--commit`, and `--require-clean`.
+- Save dirty work automatically by clustering changed paths, drafting commit messages through the configured LLM client, and pushing through the PR flow.
 - Reuse discovery, prompting, and logging whether you call a single command or an entire workflow file.
 
 ## Quick Start
@@ -26,11 +26,11 @@ gix makes one pull-request-centered Git workflow mechanical: `master` belongs to
 | Command | Meaning |
 | --- | --- |
 | `gix sync <remote-url>` | Clone into an empty directory or verify the current workspace already points at that remote. |
-| `gix sync master` | Fetch `origin`, reject unsafe local state, and restore local `master` from `origin/master`. |
-| `gix sync <branch>` | Require or create a remote branch with an open PR into `master`, merge `origin/master`, then push. |
+| `gix sync master` | Clean tree: restore local `master` from `origin/master`. Dirty tree: create a generated PR work branch, commit the dirty work, then push. |
+| `gix sync <branch>` | Require or create a remote branch with an open PR into `master`, commit dirty work when present, merge `origin/master`, then push. |
 | `gix sync` | Apply the same rule to the current branch. |
 
-By default, sync stops when the worktree is dirty or the branch has local-only commits. Use `--stash` to temporarily stash local edits, `--commit` to checkpoint dirty work on a PR-backed branch before syncing, or `--require-clean=false` only for non-destructive same-branch syncs.
+By default, a dirty `gix sync` clusters changed paths by top-level area, stages and commits each cluster with a Conventional Commit message from the configured `github.com/tyemirov/utils/llm` client, then continues the no-rebase sync and push. `--stash` temporarily shelves dirty work instead of committing it, `--commit` remains accepted for scripts that already pass it, and `--require-clean` opts back into failing when the worktree is dirty.
 
 Merge conflicts stop before push and leave the repository in Git's normal conflict state. The PR branch is "ours"; `origin/master` is "theirs".
 
@@ -91,7 +91,7 @@ gix message commit --roots .
 gix message changelog --since-tag v1.2.0 --version v1.3.0
 ```
 
-Use the reusable LLM client (`github.com/tyemirov/utils/llm`) to summarise staged changes or recent history.
+Use the reusable LLM client (`github.com/tyemirov/utils/llm`) to summarise staged changes or recent history. `gix sync` uses the same configured client for automatic dirty-work commit messages, including `model`, `base_url`, `api_key_env`, `max_completion_tokens`, `temperature`, and `timeout_seconds`.
 
 ## Automate sequences with workflows
 
@@ -547,7 +547,7 @@ Top-level commands and their subcommands. Aliases are shown in parentheses.
 - `gix default <target-branch> [--roots <dir>...] [-y]`
  - Promotes the default branch across repositories.
 - `gix sync [remote-url|branch] [--remote <name>] [--stash | --commit] [--require-clean] [--roots <dir>...]` (alias `switch`)
- - Synchronizes the current workspace through the Gix flow: remote attach/clone, remote-owned `master`, or PR-backed work branches. Work branches merge `origin/master` and push normally; sync never rebases or force-pushes. `--stash` temporarily shelves dirty work, `--commit` checkpoints dirty work on a PR branch, and `--require-clean` keeps the default dirty-work guard enabled.
+ - Synchronizes the current workspace through the Gix flow: remote attach/clone, remote-owned `master`, or PR-backed work branches. Dirty work is clustered, LLM-described, committed, and pushed by default; dirty `master` sync creates a generated PR work branch. Sync never rebases or force-pushes. `--stash` temporarily shelves dirty work, `--commit` remains accepted, and `--require-clean` requires a clean worktree instead of auto-committing.
 ## Configuration essentials
 
 - `gix --init LOCAL` writes an embeddable starter `config.yaml` to the current directory; `gix --init user` places it under `$XDG_CONFIG_HOME/gix` or `$HOME/.gix`.

--- a/cmd/cli/application_constants.go
+++ b/cmd/cli/application_constants.go
@@ -127,7 +127,7 @@ const (
 	branchSyncCommandUseNameConstant                                 = "sync"
 	branchSyncCommandUsageTemplateConstant                           = branchSyncCommandUseNameConstant + " [remote-url|branch]"
 	branchSyncCommandAliasConstant                                   = "switch"
-	branchSyncLongDescriptionConstant                                = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. With master, sync restores local master from origin/master. With any other branch, sync requires or creates a remote branch with an open pull request into master, merges origin/master into it, and pushes the result without rebasing or force-pushing."
+	branchSyncLongDescriptionConstant                                = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. Dirty work is clustered, described with the configured LLM client, committed, then pushed through the PR workflow. With master, clean sync restores local master from origin/master; dirty sync creates a PR work branch. Sync never rebases or force-pushes."
 	messageNamespaceUseNameConstant                                  = "message"
 	messageNamespaceAliasConstant                                    = "msg"
 	messageNamespaceShortDescriptionConstant                         = "Message assistance commands"

--- a/cmd/cli/default_config.yaml
+++ b/cmd/cli/default_config.yaml
@@ -59,7 +59,6 @@ operations:
       roots:
         - .
       remote: origin
-      require_clean: true
   - command: ["message", "commit"]
     with:
       roots:

--- a/internal/branches/syncflow/command.go
+++ b/internal/branches/syncflow/command.go
@@ -22,15 +22,15 @@ const (
 	commandUsageTemplateConstant            = commandUseNameConstant + " [remote-url|branch]"
 	commandExampleTemplateConstant          = "gix sync\ngix sync master\ngix sync feature/new-branch"
 	commandShortDescriptionConstant         = "Synchronize the current workspace through the Gix PR workflow"
-	commandLongDescriptionConstant          = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. With master, sync restores local master from origin/master. With any other branch, sync requires or creates a remote branch with an open pull request into master, merges origin/master into it, and pushes the result without rebasing or force-pushing."
+	commandLongDescriptionConstant          = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. Dirty work is clustered, described with the configured LLM client, committed, then pushed through the PR workflow. With master, clean sync restores local master from origin/master; dirty sync creates a PR work branch. Sync never rebases or force-pushes."
 	missingBranchMessageConstant            = "unable to determine branch; provide a branch argument or configure a default branch"
 	syncCreatedSuffixConstant               = " (created)"
 	stashFlagNameConstant                   = "stash"
 	stashFlagDescriptionConstant            = "Stash local changes before syncing"
 	commitFlagNameConstant                  = "commit"
-	commitFlagDescriptionConstant           = "Commit local changes before syncing a PR branch"
+	commitFlagDescriptionConstant           = "Commit local changes before syncing (default dirty-sync behavior)"
 	requireCleanFlagNameConstant            = "require-clean"
-	requireCleanFlagDescriptionConstant     = "Require a clean worktree when syncing"
+	requireCleanFlagDescriptionConstant     = "Require a clean worktree instead of auto-committing dirty work"
 	conflictingRecoveryFlagsMessageConstant = "use at most one of --stash or --commit"
 	remoteTargetExtraArgsMessage            = "remote sync target does not accept repository root arguments"
 	remoteTargetDirtyDirectoryMessage       = "remote sync target requires an empty directory when cloning"
@@ -68,7 +68,7 @@ func (builder *CommandBuilder) Build() (*cobra.Command, error) {
 
 	flagutils.AddToggleFlag(command.Flags(), nil, stashFlagNameConstant, "", false, stashFlagDescriptionConstant)
 	flagutils.AddToggleFlag(command.Flags(), nil, commitFlagNameConstant, "", false, commitFlagDescriptionConstant)
-	flagutils.AddToggleFlag(command.Flags(), nil, requireCleanFlagNameConstant, "", true, requireCleanFlagDescriptionConstant)
+	flagutils.AddToggleFlag(command.Flags(), nil, requireCleanFlagNameConstant, "", false, requireCleanFlagDescriptionConstant)
 
 	return command, nil
 }

--- a/internal/branches/syncflow/configuration.go
+++ b/internal/branches/syncflow/configuration.go
@@ -40,7 +40,6 @@ type CommandConfiguration struct {
 func DefaultCommandConfiguration() CommandConfiguration {
 	return CommandConfiguration{
 		CreateIfMissing: true,
-		RequireClean:    true,
 		CommitMessage:   DefaultCommitMessageConfiguration(),
 	}
 }

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -1,0 +1,290 @@
+package syncflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/tyemirov/gix/internal/commitmsg"
+	"github.com/tyemirov/gix/internal/repos/shared"
+	"github.com/tyemirov/gix/internal/repos/worktree"
+	"github.com/tyemirov/gix/internal/workflow"
+)
+
+const (
+	gitPathspecSeparatorConstant          = "--"
+	strictSyncConflictWorktreeMessage     = "worktree has unresolved conflicts; resolve them before syncing"
+	strictSyncDirtyCommitFailureTemplate  = "failed to save dirty work before syncing: %w"
+	strictSyncDirtyStageFailureTemplate   = "failed to stage dirty sync cluster %q: %w"
+	strictSyncDirtyMessageFailureTemplate = "failed to generate dirty sync commit message for %q: %w"
+	strictSyncDirtyClusterFailureTemplate = "failed to commit dirty sync cluster %q: %w"
+	strictSyncGeneratedBranchPrefix       = "sync"
+	strictSyncGeneratedRepositoryFallback = "repository"
+	strictSyncGeneratedPathFallback       = "work"
+)
+
+type syncCommitCluster struct {
+	Root  string
+	Paths []string
+}
+
+func saveDirtyWorkClusters(ctx context.Context, executor shared.GitExecutor, repositoryPath string, statusEntries []string, options worktreeAdoptionCommitMessageOptions) (int, error) {
+	clusters := buildSyncCommitClusters(statusEntries)
+	if len(clusters) == 0 {
+		return 0, nil
+	}
+
+	client, clientErr := resolveCommitMessageClient(options)
+	if clientErr != nil {
+		return 0, clientErr
+	}
+
+	var temperature *float64
+	if options.Temperature != 0 {
+		temperatureValue := options.Temperature
+		temperature = &temperatureValue
+	}
+
+	generator := commitmsg.Generator{
+		GitExecutor: executor,
+		Client:      client,
+	}
+
+	committedClusters := 0
+	for clusterIndex := range clusters {
+		cluster := clusters[clusterIndex]
+		if resetErr := executeGit(ctx, executor, repositoryPath, []string{gitResetSubcommandConstant}); resetErr != nil {
+			return committedClusters, resetErr
+		}
+		stageArguments := []string{gitAddSubcommandConstant, gitAddAllFlagConstant, gitPathspecSeparatorConstant}
+		stageArguments = append(stageArguments, cluster.Paths...)
+		if stageErr := executeGit(ctx, executor, repositoryPath, stageArguments); stageErr != nil {
+			return committedClusters, fmt.Errorf(strictSyncDirtyStageFailureTemplate, cluster.Root, stageErr)
+		}
+		result, generateErr := generator.Generate(ctx, commitmsg.Options{
+			RepositoryPath: repositoryPath,
+			Source:         commitmsg.DiffSourceStaged,
+			MaxTokens:      options.MaxTokens,
+			Temperature:    temperature,
+		})
+		if generateErr != nil {
+			return committedClusters, fmt.Errorf(strictSyncDirtyMessageFailureTemplate, cluster.Root, generateErr)
+		}
+		if commitErr := executeGit(ctx, executor, repositoryPath, []string{gitCommitSubcommandConstant, gitCommitMessageFlagConstant, result.Message}); commitErr != nil {
+			return committedClusters, fmt.Errorf(strictSyncDirtyClusterFailureTemplate, cluster.Root, commitErr)
+		}
+		committedClusters++
+	}
+
+	return committedClusters, nil
+}
+
+func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string, branchName string) error {
+	remoteReference := fmt.Sprintf("%s/%s", remoteName, branchName)
+	remoteExists, remoteExistsErr := remoteReferenceExists(ctx, environment.GitExecutor, repository.Path, remoteReference)
+	if remoteExistsErr != nil {
+		return remoteExistsErr
+	}
+
+	if remoteExists {
+		repositoryIdentifier := strictSyncRepositoryIdentifier(repository)
+		if repositoryIdentifier == "" {
+			return errors.New(strictSyncMissingRepositoryMessage)
+		}
+		openPullRequest, pullRequestErr := branchHasOpenPullRequest(ctx, environment, repositoryIdentifier, baseBranch, branchName)
+		if pullRequestErr != nil {
+			return pullRequestErr
+		}
+		if !openPullRequest {
+			return fmt.Errorf(strictSyncMissingPullRequestTemplate, branchName, baseBranch)
+		}
+		return switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, remoteName, branchName)
+	}
+
+	localExists, localExistsErr := localBranchExists(ctx, environment.GitExecutor, repository.Path, branchName)
+	if localExistsErr != nil {
+		return localExistsErr
+	}
+	if localExists {
+		return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, branchName})
+	}
+
+	baseReference := fmt.Sprintf("%s/%s", remoteName, baseBranch)
+	baseExists, baseExistsErr := remoteReferenceExists(ctx, environment.GitExecutor, repository.Path, baseReference)
+	if baseExistsErr != nil {
+		return baseExistsErr
+	}
+	if !baseExists {
+		return fmt.Errorf("remote base branch %q does not exist", baseReference)
+	}
+	return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName, baseReference})
+}
+
+func buildSyncCommitClusters(statusEntries []string) []syncCommitCluster {
+	if len(statusEntries) == 0 {
+		return nil
+	}
+
+	clusterIndexes := map[string]int{}
+	seenPaths := map[string]map[string]struct{}{}
+	clusters := []syncCommitCluster{}
+	for entryIndex := range statusEntries {
+		entry := strings.TrimSpace(statusEntries[entryIndex])
+		if entry == "" {
+			continue
+		}
+		statusPath := normalizeSyncStatusPath(worktree.StatusEntryPath(entry))
+		if statusPath == "" {
+			continue
+		}
+		clusterRoot := syncCommitClusterRoot(statusPath)
+		clusterIndex, exists := clusterIndexes[clusterRoot]
+		if !exists {
+			clusterIndex = len(clusters)
+			clusterIndexes[clusterRoot] = clusterIndex
+			seenPaths[clusterRoot] = map[string]struct{}{}
+			clusters = append(clusters, syncCommitCluster{Root: clusterRoot})
+		}
+
+		paths := syncStatusEntryPaths(entry)
+		for pathIndex := range paths {
+			normalizedPath := normalizeSyncStatusPath(paths[pathIndex])
+			if normalizedPath == "" {
+				continue
+			}
+			if _, exists := seenPaths[clusterRoot][normalizedPath]; exists {
+				continue
+			}
+			seenPaths[clusterRoot][normalizedPath] = struct{}{}
+			clusters[clusterIndex].Paths = append(clusters[clusterIndex].Paths, normalizedPath)
+		}
+	}
+
+	return clusters
+}
+
+func generatedSyncBranchName(repository *workflow.RepositoryState, statusEntries []string) string {
+	repositoryName := strictSyncGeneratedRepositoryFallback
+	if repository != nil {
+		candidate := filepath.Base(filepath.Clean(strings.TrimSpace(repository.Path)))
+		if slug := syncBranchSlug(candidate); slug != "" {
+			repositoryName = slug
+		}
+	}
+
+	pathName := strictSyncGeneratedPathFallback
+	clusters := buildSyncCommitClusters(statusEntries)
+	if len(clusters) > 0 {
+		rootLabel := syncGeneratedBranchPathLabel(clusters[0].Root)
+		if slug := syncBranchSlug(rootLabel); slug != "" {
+			pathName = slug
+		}
+	}
+
+	return strings.Join([]string{strictSyncGeneratedBranchPrefix, repositoryName, pathName}, "/")
+}
+
+func syncStatusEntriesHaveConflicts(statusEntries []string) bool {
+	for entryIndex := range statusEntries {
+		if syncStatusEntryHasConflict(statusEntries[entryIndex]) {
+			return true
+		}
+	}
+	return false
+}
+
+func syncStatusEntryHasConflict(statusEntry string) bool {
+	trimmed := strings.TrimSpace(statusEntry)
+	if len(trimmed) < 2 {
+		return false
+	}
+	indexStatus := trimmed[0]
+	worktreeStatus := trimmed[1]
+	return indexStatus == 'U' || worktreeStatus == 'U' || (indexStatus == 'A' && worktreeStatus == 'A') || (indexStatus == 'D' && worktreeStatus == 'D')
+}
+
+func syncStatusEntryPaths(statusEntry string) []string {
+	trimmed := strings.TrimSpace(statusEntry)
+	if len(trimmed) <= 2 {
+		return nil
+	}
+	pathPart := strings.TrimSpace(trimmed[2:])
+	if pathPart == "" {
+		return nil
+	}
+	if strings.Contains(pathPart, " -> ") {
+		sections := strings.Split(pathPart, " -> ")
+		paths := make([]string, 0, len(sections))
+		for sectionIndex := range sections {
+			paths = append(paths, strings.TrimSpace(sections[sectionIndex]))
+		}
+		return paths
+	}
+	return []string{pathPart}
+}
+
+func syncCommitClusterRoot(statusPath string) string {
+	normalized := normalizeSyncStatusPath(statusPath)
+	if normalized == "" {
+		return ""
+	}
+	sections := strings.Split(normalized, "/")
+	return strings.TrimSpace(sections[0])
+}
+
+func normalizeSyncStatusPath(path string) string {
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return ""
+	}
+	normalized := filepath.ToSlash(filepath.Clean(trimmedPath))
+	if normalized == "." {
+		return ""
+	}
+	return strings.TrimPrefix(normalized, "./")
+}
+
+func syncGeneratedBranchPathLabel(root string) string {
+	trimmedRoot := strings.TrimSpace(root)
+	if trimmedRoot == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmedRoot, ".") {
+		return strings.TrimLeft(trimmedRoot, ".")
+	}
+	extension := filepath.Ext(trimmedRoot)
+	if extension == "" {
+		return trimmedRoot
+	}
+	withoutExtension := strings.TrimSuffix(trimmedRoot, extension)
+	if withoutExtension == "" {
+		return trimmedRoot
+	}
+	return withoutExtension
+}
+
+func syncBranchSlug(value string) string {
+	lowerValue := strings.ToLower(strings.TrimSpace(value))
+	slugBuilder := strings.Builder{}
+	lastWasSeparator := false
+	for characterIndex := 0; characterIndex < len(lowerValue); characterIndex++ {
+		character := lowerValue[characterIndex]
+		if syncSlugCharacterAllowed(character) {
+			slugBuilder.WriteByte(character)
+			lastWasSeparator = false
+			continue
+		}
+		if slugBuilder.Len() == 0 || lastWasSeparator {
+			continue
+		}
+		slugBuilder.WriteByte('-')
+		lastWasSeparator = true
+	}
+	return strings.Trim(slugBuilder.String(), "-")
+}
+
+func syncSlugCharacterAllowed(character byte) bool {
+	return (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')
+}

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -211,6 +211,7 @@ func handleBranchSyncAction(ctx context.Context, environment *workflow.Environme
 			BaseBranch:       baseBranch,
 			RequireClean:     requireClean,
 			StashChanges:     stashChanges,
+			CommitChanges:    commitChanges,
 			CommitMessages:   commitMessageOptions,
 			ResolutionSource: resolutionSource,
 		})
@@ -430,6 +431,7 @@ type strictSyncOptions struct {
 	BaseBranch       string
 	RequireClean     bool
 	StashChanges     bool
+	CommitChanges    bool
 	CommitMessages   worktreeAdoptionCommitMessageOptions
 	ResolutionSource string
 }
@@ -477,7 +479,7 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 	}
 
 	checkpointCommitted := false
-	if dirty && options.RequireClean {
+	if dirty && options.RequireClean && !options.CommitChanges {
 		return errors.New(strictSyncDirtyWorktreeTemplate)
 	}
 

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -60,14 +60,11 @@ const (
 	stashExecutorMissingMessageConstant          = "git executor required to manage stash operations"
 	strictSyncMissingGitHubClientMessage         = "strict sync requires GitHub CLI access to verify pull requests"
 	strictSyncMissingRepositoryMessage           = "strict sync requires a GitHub repository remote"
-	strictSyncDirtyWorktreeTemplate              = "worktree is dirty; use --stash, --commit on a PR branch, or --require-clean=false for non-destructive same-branch sync"
-	strictSyncMasterCommitMessage                = "--commit cannot be used when syncing master"
-	strictSyncCommitBranchMismatchTemplate       = "--commit requires the current branch %q to match target branch %q"
+	strictSyncDirtyWorktreeTemplate              = "worktree is dirty; remove --require-clean or use --stash before syncing"
 	strictSyncLocalOnlyCommitTemplate            = "local branch %q has commits not on %s/%s"
 	strictSyncMissingPullRequestTemplate         = "branch %q does not have an open pull request into %s"
 	strictSyncConflictTemplate                   = "merge from %s/%s into %s stopped with conflicts; resolve them before pushing"
 	strictSyncFastForwardTemplate                = "fast-forward from %s/%s into %s stopped; commit, stash, or clean local changes before syncing"
-	strictSyncCheckpointCommitTemplate           = "chore: checkpoint before syncing %s"
 	strictSyncCreatedPRBody                      = "Created by gix sync."
 )
 
@@ -137,7 +134,7 @@ func handleBranchSyncAction(ctx context.Context, environment *workflow.Environme
 	if commitErr != nil {
 		return commitErr
 	}
-	requireClean, requireCleanErr := boolOptionDefault(parameters, taskOptionRequireClean, true)
+	requireClean, requireCleanErr := boolOptionDefault(parameters, taskOptionRequireClean, false)
 	if requireCleanErr != nil {
 		return requireCleanErr
 	}
@@ -204,13 +201,17 @@ func handleBranchSyncAction(ctx context.Context, environment *workflow.Environme
 	}
 
 	if requirePullRequest {
+		commitMessageOptions, commitMessageErr := worktreeAdoptionCommitMessageOptionsFromParameters(parameters)
+		if commitMessageErr != nil {
+			return commitMessageErr
+		}
 		return handleStrictSyncAction(ctx, environment, repository, strictSyncOptions{
 			BranchName:       resolvedBranchName,
 			RemoteName:       remoteName,
 			BaseBranch:       baseBranch,
 			RequireClean:     requireClean,
 			StashChanges:     stashChanges,
-			CommitChanges:    commitChanges,
+			CommitMessages:   commitMessageOptions,
 			ResolutionSource: resolutionSource,
 		})
 	}
@@ -429,7 +430,7 @@ type strictSyncOptions struct {
 	BaseBranch       string
 	RequireClean     bool
 	StashChanges     bool
-	CommitChanges    bool
+	CommitMessages   worktreeAdoptionCommitMessageOptions
 	ResolutionSource string
 }
 
@@ -475,39 +476,33 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 		dirty = false
 	}
 
-	currentBranch := strings.TrimSpace(repository.Inspection.LocalBranch)
-	if currentBranch == "" {
-		currentBranch, _ = environment.RepositoryManager.GetCurrentBranch(ctx, repository.Path)
-		currentBranch = strings.TrimSpace(currentBranch)
-	}
-
 	checkpointCommitted := false
-	if dirty && options.CommitChanges {
-		if branchName == baseBranch {
-			return errors.New(strictSyncMasterCommitMessage)
-		}
-		if currentBranch != branchName {
-			return fmt.Errorf(strictSyncCommitBranchMismatchTemplate, currentBranch, branchName)
-		}
-		if commitErr := commitWorkspaceChanges(ctx, environment.GitExecutor, repository.Path, branchName); commitErr != nil {
-			return commitErr
-		}
-		checkpointCommitted = true
-		dirty = false
-	}
-
 	if dirty && options.RequireClean {
-		return errors.New(strictSyncDirtyWorktreeTemplate)
-	}
-	if dirty && currentBranch != branchName {
-		return fmt.Errorf(strictSyncCommitBranchMismatchTemplate, currentBranch, branchName)
-	}
-	if dirty && branchName == baseBranch {
 		return errors.New(strictSyncDirtyWorktreeTemplate)
 	}
 
 	if fetchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName}); fetchErr != nil {
 		return fmt.Errorf(gitFetchFailureTemplateConstant, fetchErr)
+	}
+
+	if dirty {
+		if syncStatusEntriesHaveConflicts(statusEntries) {
+			return errors.New(strictSyncConflictWorktreeMessage)
+		}
+		commitBranchName := branchName
+		if commitBranchName == baseBranch {
+			commitBranchName = generatedSyncBranchName(repository, statusEntries)
+		}
+		if prepareErr := prepareStrictSyncBranchForDirtyWork(ctx, environment, repository, remoteName, baseBranch, commitBranchName); prepareErr != nil {
+			return prepareErr
+		}
+		committedClusters, commitErr := saveDirtyWorkClusters(ctx, environment.GitExecutor, repository.Path, statusEntries, options.CommitMessages)
+		if commitErr != nil {
+			return fmt.Errorf(strictSyncDirtyCommitFailureTemplate, commitErr)
+		}
+		checkpointCommitted = committedClusters > 0
+		branchName = commitBranchName
+		dirty = false
 	}
 
 	if branchName == baseBranch {
@@ -623,7 +618,22 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 		return false, localExistsErr
 	}
 	if localExists {
-		return false, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
+		if !options.AllowAheadCommit {
+			return false, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
+		}
+		if switchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, options.BranchName}); switchErr != nil {
+			return false, switchErr
+		}
+		if mergeErr := mergeBaseIntoBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName); mergeErr != nil {
+			return false, mergeErr
+		}
+		if pushErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, gitPushSetUpstreamFlagConstant, options.RemoteName, options.BranchName}); pushErr != nil {
+			return false, pushErr
+		}
+		if pullRequestErr := createPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName); pullRequestErr != nil {
+			return false, pullRequestErr
+		}
+		return true, nil
 	}
 
 	baseReference := fmt.Sprintf("%s/%s", options.RemoteName, options.BaseBranch)
@@ -783,14 +793,6 @@ func stashAllChanges(ctx context.Context, executor shared.GitExecutor, repositor
 		return fmt.Errorf(stashTrackedChangesFailureTemplateConstant, err)
 	}
 	return nil
-}
-
-func commitWorkspaceChanges(ctx context.Context, executor shared.GitExecutor, repositoryPath string, branchName string) error {
-	if stageErr := executeGit(ctx, executor, repositoryPath, []string{gitAddSubcommandConstant, gitAddAllFlagConstant}); stageErr != nil {
-		return stageErr
-	}
-	message := fmt.Sprintf(strictSyncCheckpointCommitTemplate, branchName)
-	return executeGit(ctx, executor, repositoryPath, []string{gitCommitSubcommandConstant, gitCommitMessageFlagConstant, message})
 }
 
 func reportStrictSync(repository *workflow.RepositoryState, environment *workflow.Environment, branchName string, source string, created bool, stashed bool) {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -503,7 +503,7 @@ func TestHandleBranchSyncActionStrictPRBranchRejectsMissingPullRequest(t *testin
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "push origin feature/foo")
 }
 
-func TestHandleBranchSyncActionStrictPRBranchCommitFlagUsesDirtySyncCommit(t *testing.T) {
+func TestHandleBranchSyncActionStrictPRBranchCommitFlagUsesDirtySyncCommitWithRequireClean(t *testing.T) {
 	gitExecutor := &strictSyncGitExecutor{
 		statusOutput:  " M README.md\n",
 		revListOutput: "1\n",
@@ -535,7 +535,7 @@ func TestHandleBranchSyncActionStrictPRBranchCommitFlagUsesDirtySyncCommit(t *te
 		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
 		taskOptionRequirePullRequest: true,
 		taskOptionBaseBranch:         "master",
-		taskOptionRequireClean:       false,
+		taskOptionRequireClean:       true,
 		taskOptionCommitChanges:      true,
 		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
 			Client: chatClient,

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tyemirov/gix/internal/gitrepo"
 	"github.com/tyemirov/gix/internal/repos/shared"
 	"github.com/tyemirov/gix/internal/workflow"
+	"github.com/tyemirov/utils/llm"
 )
 
 type recordingReporter struct {
@@ -109,6 +110,8 @@ func (executor *statefulBranchCaptureExecutor) ExecuteGitHubCLI(context.Context,
 type strictSyncGitExecutor struct {
 	commands          []execshell.CommandDetails
 	statusOutput      string
+	diffStatOutput    string
+	diffOutput        string
 	revListOutput     string
 	missingReferences map[string]bool
 	mergeError        error
@@ -122,6 +125,19 @@ func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details exe
 	switch details.Arguments[0] {
 	case "status":
 		return execshell.ExecutionResult{StandardOutput: executor.statusOutput}, nil
+	case "diff":
+		if commandHasArgument(details.Arguments, "--stat") {
+			output := executor.diffStatOutput
+			if output == "" {
+				output = " README.md | 1 +\n"
+			}
+			return execshell.ExecutionResult{StandardOutput: output}, nil
+		}
+		output := executor.diffOutput
+		if output == "" {
+			output = "diff --git a/README.md b/README.md\n+sync work\n"
+		}
+		return execshell.ExecutionResult{StandardOutput: output}, nil
 	case "rev-parse":
 		if len(details.Arguments) > 2 && details.Arguments[1] == "--verify" && executor.missingReferences[details.Arguments[2]] {
 			return execshell.ExecutionResult{}, commandFailedError("fatal: Needed a single revision")
@@ -138,6 +154,10 @@ func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details exe
 	case "merge":
 		if executor.mergeError != nil {
 			return execshell.ExecutionResult{}, executor.mergeError
+		}
+	case "switch":
+		if len(details.Arguments) > 2 && details.Arguments[1] == gitCreateBranchFlagConstant && executor.missingReferences != nil {
+			delete(executor.missingReferences, "refs/heads/"+details.Arguments[2])
 		}
 	}
 	return execshell.ExecutionResult{}, nil
@@ -159,6 +179,19 @@ func (executor *strictSyncGitHubExecutor) ExecuteGit(context.Context, execshell.
 func (executor *strictSyncGitHubExecutor) ExecuteGitHubCLI(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
 	executor.commands = append(executor.commands, details)
 	return execshell.ExecutionResult{StandardOutput: executor.output}, nil
+}
+
+type strictSyncChatClient struct {
+	response string
+	requests []llm.ChatRequest
+}
+
+func (client *strictSyncChatClient) Chat(_ context.Context, request llm.ChatRequest) (string, error) {
+	client.requests = append(client.requests, request)
+	if client.response == "" {
+		return "feat: sync dirty work", nil
+	}
+	return client.response, nil
 }
 
 func TestHandleBranchSyncActionUsesRepositoryDefault(t *testing.T) {
@@ -341,13 +374,17 @@ func TestHandleBranchSyncActionStrictPRBranchMergesBaseAndPushes(t *testing.T) {
 	require.Contains(t, githubExecutor.commands[0].Arguments, "list")
 }
 
-func TestHandleBranchSyncActionStrictPRBranchPreservesDirtySameBranchWhenRequireCleanDisabled(t *testing.T) {
-	gitExecutor := &strictSyncGitExecutor{statusOutput: " M README.md\n"}
+func TestHandleBranchSyncActionStrictPRBranchAutoCommitsDirtySameBranch(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput:  " M README.md\n",
+		revListOutput: "1\n",
+	}
 	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
 	require.NoError(t, managerError)
 	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Feature","headRefName":"feature/foo"}]`}
 	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
 	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{}
 	environment := &workflow.Environment{
 		GitExecutor:       gitExecutor,
 		RepositoryManager: gitManager,
@@ -370,13 +407,62 @@ func TestHandleBranchSyncActionStrictPRBranchPreservesDirtySameBranchWhenRequire
 		taskOptionRequirePullRequest: true,
 		taskOptionBaseBranch:         "master",
 		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
 	}
 
 	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --ff-only origin/feature/foo")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "reset")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "add --all -- README.md")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "commit -m feat: sync dirty work")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "reset --hard origin/feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push origin feature/foo")
+	require.Len(t, chatClient.requests, 1)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchRequireCleanRejectsDirtyWorktree(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{statusOutput: " M README.md\n"}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Feature","headRefName":"feature/foo"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	syncError := handleBranchSyncAction(context.Background(), environment, repository, parameters)
+	require.Error(t, syncError)
+	require.Contains(t, syncError.Error(), "worktree is dirty")
+	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "commit -m")
+	require.Len(t, chatClient.requests, 0)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchRejectsMissingPullRequest(t *testing.T) {
@@ -417,7 +503,7 @@ func TestHandleBranchSyncActionStrictPRBranchRejectsMissingPullRequest(t *testin
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "push origin feature/foo")
 }
 
-func TestHandleBranchSyncActionStrictPRBranchMergesRemoteAfterCheckpointCommit(t *testing.T) {
+func TestHandleBranchSyncActionStrictPRBranchCommitFlagUsesDirtySyncCommit(t *testing.T) {
 	gitExecutor := &strictSyncGitExecutor{
 		statusOutput:  " M README.md\n",
 		revListOutput: "1\n",
@@ -427,6 +513,7 @@ func TestHandleBranchSyncActionStrictPRBranchMergesRemoteAfterCheckpointCommit(t
 	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Feature","headRefName":"feature/foo"}]`}
 	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
 	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{response: "fix: describe dirty sync"}
 	environment := &workflow.Environment{
 		GitExecutor:       gitExecutor,
 		RepositoryManager: gitManager,
@@ -448,17 +535,21 @@ func TestHandleBranchSyncActionStrictPRBranchMergesRemoteAfterCheckpointCommit(t
 		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
 		taskOptionRequirePullRequest: true,
 		taskOptionBaseBranch:         "master",
-		taskOptionRequireClean:       true,
+		taskOptionRequireClean:       false,
 		taskOptionCommitChanges:      true,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
 	}
 
 	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "add --all")
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "commit -m chore: checkpoint before syncing feature/foo")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "add --all -- README.md")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "commit -m fix: describe dirty sync")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "reset --hard origin/feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push origin feature/foo")
+	require.Len(t, chatClient.requests, 1)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRequest(t *testing.T) {
@@ -502,6 +593,58 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRe
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin feature/foo")
 	require.Len(t, githubExecutor.commands, 1)
 	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "feature/foo", "--title", "feature/foo", "--body", strictSyncCreatedPRBody}, githubExecutor.commands[0].Arguments)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMaster(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: " M README.md\n",
+		missingReferences: map[string]bool{
+			"origin/sync/project/readme":     true,
+			"refs/heads/sync/project/readme": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{response: "docs: update readme"}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "master",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c sync/project/readme origin/master")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "add --all -- README.md")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "commit -m docs: update readme")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin sync/project/readme")
+	require.Len(t, githubExecutor.commands, 1)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "sync/project/readme", "--title", "sync/project/readme", "--body", strictSyncCreatedPRBody}, githubExecutor.commands[0].Arguments)
+	require.Len(t, chatClient.requests, 1)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchStopsBeforePushOnMergeConflict(t *testing.T) {
@@ -549,6 +692,15 @@ func recordedGitCommands(commands []execshell.CommandDetails) string {
 		lines = append(lines, strings.Join(command.Arguments, " "))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func commandHasArgument(arguments []string, target string) bool {
+	for argumentIndex := range arguments {
+		if arguments[argumentIndex] == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestHandleBranchSyncActionConfiguresTrackingRemoteWhenMissing(t *testing.T) {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -745,7 +745,7 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Updated embedded defaults, README, architecture notes, docs site examples, and warning matrix references.
   - Added command hierarchy and black-box CLI coverage proving `cd` is rejected while branch-change tests use `sync`.
 
-- [ ] [I006] Implement the new `gix sync` semantics and remove the old `cd` implementation.
+- [x] [I006] Implement the new `gix sync` semantics and remove the old `cd` implementation.
   Requested on 2026-06-01.
   ### Summary
   `gix sync` should become the canonical simplified workflow command instead of the renamed branch-change command.
@@ -755,3 +755,11 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Keep `--stash`, `--commit`, and `--require-clean` functioning as explicit dirty-work policies.
   - Use merge-based work-branch updates and conflict stop-before-push behavior; do not rebase.
   - Update README/help/config/tests around the simplified flow.
+  ### Resolution
+  - Removed the public `cd` command path and kept `sync` as the canonical command.
+  - Implemented strict sync targets for remote attach, remote-owned `master`, PR-backed branches, and the current branch without rebase or force-push.
+  - Made dirty `gix sync` the default: changed paths are clustered, staged, described through the configured `github.com/tyemirov/utils/llm` client, committed, then synced and pushed.
+  - Dirty `master` sync now creates a generated `sync/<repo>/<path>` work branch before committing and continuing through the PR flow.
+  - Preserved `--stash`, kept `--commit` accepted, and made `--require-clean` the opt-in dirty-work guard.
+  - Updated README/help/config defaults and added black-box coverage for dirty PR branches, dirty `master`, generated branches, and the clean-worktree guard.
+  - `make test`, `make lint`, and `make ci` passed locally.

--- a/tests/sync_refresh_integration_test.go
+++ b/tests/sync_refresh_integration_test.go
@@ -1,6 +1,9 @@
 package tests
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,9 +21,10 @@ const (
 	syncRefreshIntegrationLogLevelFlag     = "--log-level"
 	syncRefreshIntegrationErrorLogLevel    = "error"
 	syncRefreshIntegrationGitInvocationLog = "git-invocations.log"
+	syncRefreshIntegrationAPIKeyVariable   = "TEST_GIX_SYNC_REFRESH_LLM_KEY"
 )
 
-func TestSyncRejectsDirtyMasterWorktree(testInstance *testing.T) {
+func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T) {
 	testInstance.Helper()
 
 	repositoryRoot := integrationRepositoryRoot(testInstance)
@@ -103,9 +107,42 @@ func TestSyncRejectsDirtyMasterWorktree(testInstance *testing.T) {
 
 	require.NoError(testInstance, os.WriteFile(readmePath, []byte("modified locally\n"), 0o644))
 
+	llmServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/chat/completions" {
+			http.NotFound(responseWriter, request)
+			return
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"docs: sync dirty work"}}]}`))
+	}))
+	testInstance.Cleanup(llmServer.Close)
+
+	configurationPath := filepath.Join(testInstance.TempDir(), "config.yaml")
+	configurationContent := fmt.Sprintf(`common:
+  log_level: error
+  log_format: console
+  require_clean: false
+operations:
+  - command: ["sync"]
+    with:
+      remote: origin
+  - command: ["message", "commit"]
+    with:
+      api_key_env: %s
+      base_url: %q
+      model: mock-model
+      diff_source: staged
+      max_completion_tokens: 64
+      temperature: 0
+      timeout_seconds: 5
+`, syncRefreshIntegrationAPIKeyVariable, llmServer.URL)
+	require.NoError(testInstance, os.WriteFile(configurationPath, []byte(configurationContent), 0o600))
+
 	commandArguments := []string{
 		syncRefreshIntegrationRunCommand,
 		syncRefreshIntegrationModulePath,
+		"--config",
+		configurationPath,
 		syncRefreshIntegrationLogLevelFlag,
 		syncRefreshIntegrationErrorLogLevel,
 		"sync",
@@ -117,20 +154,33 @@ func TestSyncRejectsDirtyMasterWorktree(testInstance *testing.T) {
 	output, runError := runFailingIntegrationCommand(
 		testInstance,
 		repositoryRoot,
-		integrationCommandOptions{PathVariable: pathVariable},
+		integrationCommandOptions{
+			PathVariable: pathVariable,
+			EnvironmentOverrides: map[string]string{
+				syncRefreshIntegrationAPIKeyVariable: "test-key",
+			},
+		},
 		syncRefreshIntegrationTimeout,
 		commandArguments,
 	)
 	require.Error(testInstance, runError)
 	testInstance.Logf("sync output:\n%s", output)
-	require.Contains(testInstance, output, "worktree is dirty")
+	require.Contains(testInstance, output, "strict sync requires a GitHub repository remote")
+	require.NotContains(testInstance, output, "worktree is dirty")
 
 	invocationLogContents, readError := os.ReadFile(gitInvocationLog)
 	require.NoError(testInstance, readError)
+	invocationLog := string(invocationLogContents)
+	require.Contains(testInstance, invocationLog, "switch -c sync/worktree/readme origin/master")
+	require.Contains(testInstance, invocationLog, "add --all -- README.md")
+	require.Contains(testInstance, invocationLog, "commit -m docs: sync dirty work")
 	require.NotContains(testInstance, string(invocationLogContents), "pull --ff-only")
 	require.NotContains(testInstance, string(invocationLogContents), "pull --rebase")
 
 	localFileContents, localReadError := os.ReadFile(readmePath)
 	require.NoError(testInstance, localReadError)
 	require.Equal(testInstance, "modified locally\n", string(localFileContents))
+	require.Equal(testInstance, "sync/worktree/readme", strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
+	require.Empty(testInstance, strings.TrimSpace(runGit(testInstance, repositoryPath, "status", "--porcelain")))
+	require.Equal(testInstance, "docs: sync dirty work", strings.TrimSpace(runGit(testInstance, repositoryPath, "log", "-1", "--pretty=%s")))
 }


### PR DESCRIPTION
## Summary
- Make dirty `gix sync` cluster changed paths, generate commit messages through the configured `github.com/tyemirov/utils/llm` client, commit, then sync and push.
- Route dirty `master` syncs to generated `sync/<repo>/<path>` work branches while clean `master` remains remote-owned.
- Keep `--stash` functioning, keep `--commit` accepted, and make `--require-clean` the opt-in dirty guard.

## Validation
- `timeout -k 60s -s SIGKILL 60s make format`
- `timeout -k 350s -s SIGKILL 350s make test`
- `timeout -k 350s -s SIGKILL 350s make lint`
- `timeout -k 350s -s SIGKILL 350s make ci`