### PR TITLE
Improve I007 sync pull request descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Improvements ⚙️
+- Make `gix sync` pull request descriptions explain the branch review path and remote-owned base branch instead of how the PR was created.
+
+### Testing 🧪
+- Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches.
+
 ## [v0.5.0] - 2026-06-02
 
 ### Features ✨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Improvements ⚙️
 - Make `gix sync` pull request descriptions come from the branch diff through the configured LLM path instead of predefined body text.
+- Generate the sync PR body before pushing new PR branches so body-generation failures do not leave remote branches without pull requests.
 
 ### Testing 🧪
-- Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator.
+- Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator and failure-before-push ordering.
 
 ## [v0.5.0] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Improvements ⚙️
 - Make `gix sync` pull request descriptions come from the branch diff through the configured LLM path instead of predefined body text.
 - Generate the sync PR body before pushing new PR branches so body-generation failures do not leave remote branches without pull requests.
+- Expose sync-created pull request `title` and `body` controls through `gix sync --title/--body` and `sync.pull_request`, with explicit bodies bypassing generated descriptions.
 
 ### Testing 🧪
 - Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator and failure-before-push ordering.
+- Add sync command and strict action coverage for explicit PR title/body controls.
 
 ## [v0.5.0] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [Unreleased]
 
 ### Improvements ⚙️
-- Make `gix sync` pull request descriptions explain the branch review path and remote-owned base branch instead of how the PR was created.
+- Make `gix sync` pull request descriptions come from the branch diff through the configured LLM path instead of predefined body text.
 
 ### Testing 🧪
-- Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches.
+- Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator.
 
 ## [v0.5.0] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gix makes one pull-request-centered Git workflow mechanical: `master` belongs to
 | `gix sync <branch>` | Require or create a remote branch with an open PR into `master`, commit dirty work when present, merge `origin/master`, then push. |
 | `gix sync` | Apply the same rule to the current branch. |
 
-By default, a dirty `gix sync` clusters changed paths by top-level area, stages and commits each cluster with a Conventional Commit message from the configured `github.com/tyemirov/utils/llm` client, then continues the no-rebase sync and push. `--stash` temporarily shelves dirty work instead of committing it, `--commit` explicitly selects the auto-commit policy for scripts that already pass it, and `--require-clean` by itself opts back into failing when the worktree is dirty.
+By default, a dirty `gix sync` clusters changed paths by top-level area, stages and commits each cluster with a Conventional Commit message from the configured `github.com/tyemirov/utils/llm` client, then continues the no-rebase sync and push. When sync creates a pull request, its body is generated from the branch diff unless `--body` or `sync.pull_request.body` supplies explicit text; the title defaults to the branch unless `--title` or `sync.pull_request.title` supplies it. `--stash` temporarily shelves dirty work instead of committing it, `--commit` explicitly selects the auto-commit policy for scripts that already pass it, and `--require-clean` by itself opts back into failing when the worktree is dirty.
 
 Merge conflicts stop before push and leave the repository in Git's normal conflict state. The PR branch is "ours"; `origin/master` is "theirs".
 
@@ -546,8 +546,8 @@ Top-level commands and their subcommands. Aliases are shown in parentheses.
  - Drafts Conventional Commit subjects and optional bullets using the configured LLM.
 - `gix default <target-branch> [--roots <dir>...] [-y]`
  - Promotes the default branch across repositories.
-- `gix sync [remote-url|branch] [--remote <name>] [--stash | --commit] [--require-clean] [--roots <dir>...]` (alias `switch`)
- - Synchronizes the current workspace through the Gix flow: remote attach/clone, remote-owned `master`, or PR-backed work branches. Dirty work is clustered, LLM-described, committed, and pushed by default; dirty `master` sync creates a generated PR work branch. Sync never rebases or force-pushes. `--stash` temporarily shelves dirty work, `--commit` explicitly selects the auto-commit policy, and `--require-clean` requires a clean worktree only when no dirty-work policy is selected.
+- `gix sync [remote-url|branch] [--remote <name>] [--title <text>] [--body <markdown>] [--stash | --commit] [--require-clean] [--roots <dir>...]` (alias `switch`)
+ - Synchronizes the current workspace through the Gix flow: remote attach/clone, remote-owned `master`, or PR-backed work branches. Dirty work is clustered, LLM-described, committed, and pushed by default; dirty `master` sync creates a generated PR work branch. Sync never rebases or force-pushes. PR body text is generated from the branch diff unless `--body` or `sync.pull_request.body` is set; PR title defaults to the branch unless `--title` or `sync.pull_request.title` is set. `--stash` temporarily shelves dirty work, `--commit` explicitly selects the auto-commit policy, and `--require-clean` requires a clean worktree only when no dirty-work policy is selected.
 ## Configuration essentials
 
 - `gix --init LOCAL` writes an embeddable starter `config.yaml` to the current directory; `gix --init user` places it under `$XDG_CONFIG_HOME/gix` or `$HOME/.gix`.

--- a/cmd/cli/application_constants.go
+++ b/cmd/cli/application_constants.go
@@ -127,7 +127,7 @@ const (
 	branchSyncCommandUseNameConstant                                 = "sync"
 	branchSyncCommandUsageTemplateConstant                           = branchSyncCommandUseNameConstant + " [remote-url|branch]"
 	branchSyncCommandAliasConstant                                   = "switch"
-	branchSyncLongDescriptionConstant                                = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. Dirty work is clustered, described with the configured LLM client, committed, then pushed through the PR workflow. With master, clean sync restores local master from origin/master; dirty sync creates a PR work branch. Sync never rebases or force-pushes."
+	branchSyncLongDescriptionConstant                                = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. Dirty work is clustered, described with the configured LLM client, committed, then pushed through the PR workflow. With master, clean sync restores local master from origin/master; dirty sync creates a PR work branch. Sync never rebases or force-pushes. When sync creates a pull request, the body is generated from the branch diff unless --body or sync.pull_request.body supplies explicit text; title defaults to the branch unless --title or sync.pull_request.title supplies it."
 	messageNamespaceUseNameConstant                                  = "message"
 	messageNamespaceAliasConstant                                    = "msg"
 	messageNamespaceShortDescriptionConstant                         = "Message assistance commands"

--- a/internal/branches/syncflow/command.go
+++ b/internal/branches/syncflow/command.go
@@ -22,7 +22,7 @@ const (
 	commandUsageTemplateConstant            = commandUseNameConstant + " [remote-url|branch]"
 	commandExampleTemplateConstant          = "gix sync\ngix sync master\ngix sync feature/new-branch"
 	commandShortDescriptionConstant         = "Synchronize the current workspace through the Gix PR workflow"
-	commandLongDescriptionConstant          = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. Dirty work is clustered, described with the configured LLM client, committed, then pushed through the PR workflow. With master, clean sync restores local master from origin/master; dirty sync creates a PR work branch. Sync never rebases or force-pushes."
+	commandLongDescriptionConstant          = "sync keeps a workspace aligned with the remote-owned master branch and PR-backed work branches. With no branch argument, sync updates the current branch. Dirty work is clustered, described with the configured LLM client, committed, then pushed through the PR workflow. With master, clean sync restores local master from origin/master; dirty sync creates a PR work branch. Sync never rebases or force-pushes. When sync creates a pull request, the body is generated from the branch diff unless --body or sync.pull_request.body supplies explicit text; title defaults to the branch unless --title or sync.pull_request.title supplies it."
 	missingBranchMessageConstant            = "unable to determine branch; provide a branch argument or configure a default branch"
 	syncCreatedSuffixConstant               = " (created)"
 	stashFlagNameConstant                   = "stash"
@@ -31,6 +31,10 @@ const (
 	commitFlagDescriptionConstant           = "Commit local changes before syncing (default dirty-sync behavior)"
 	requireCleanFlagNameConstant            = "require-clean"
 	requireCleanFlagDescriptionConstant     = "Require a clean worktree instead of auto-committing dirty work"
+	pullRequestTitleFlagNameConstant        = taskOptionPullRequestTitle
+	pullRequestTitleFlagDescriptionConstant = "Set the title for a sync-created pull request"
+	pullRequestBodyFlagNameConstant         = taskOptionPullRequestBody
+	pullRequestBodyFlagDescriptionConstant  = "Set the body for a sync-created pull request"
 	conflictingRecoveryFlagsMessageConstant = "use at most one of --stash or --commit"
 	remoteTargetExtraArgsMessage            = "remote sync target does not accept repository root arguments"
 	remoteTargetDirtyDirectoryMessage       = "remote sync target requires an empty directory when cloning"
@@ -69,6 +73,8 @@ func (builder *CommandBuilder) Build() (*cobra.Command, error) {
 	flagutils.AddToggleFlag(command.Flags(), nil, stashFlagNameConstant, "", false, stashFlagDescriptionConstant)
 	flagutils.AddToggleFlag(command.Flags(), nil, commitFlagNameConstant, "", false, commitFlagDescriptionConstant)
 	flagutils.AddToggleFlag(command.Flags(), nil, requireCleanFlagNameConstant, "", false, requireCleanFlagDescriptionConstant)
+	command.Flags().String(pullRequestTitleFlagNameConstant, "", pullRequestTitleFlagDescriptionConstant)
+	command.Flags().String(pullRequestBodyFlagNameConstant, "", pullRequestBodyFlagDescriptionConstant)
 
 	return command, nil
 }
@@ -84,6 +90,8 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 	stashRequested := configuration.StashChanges
 	commitRequested := configuration.CommitChanges
 	requireClean := configuration.RequireClean
+	pullRequestTitle := strings.TrimSpace(configuration.PullRequest.Title)
+	pullRequestBody := strings.TrimSpace(configuration.PullRequest.Body)
 
 	if command != nil {
 		if flagValue, err := command.Flags().GetBool(stashFlagNameConstant); err == nil && command.Flags().Changed(stashFlagNameConstant) {
@@ -94,6 +102,12 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 		}
 		if flagValue, err := command.Flags().GetBool(requireCleanFlagNameConstant); err == nil && command.Flags().Changed(requireCleanFlagNameConstant) {
 			requireClean = flagValue
+		}
+		if flagValue, err := command.Flags().GetString(pullRequestTitleFlagNameConstant); err == nil && command.Flags().Changed(pullRequestTitleFlagNameConstant) {
+			pullRequestTitle = strings.TrimSpace(flagValue)
+		}
+		if flagValue, err := command.Flags().GetString(pullRequestBodyFlagNameConstant); err == nil && command.Flags().Changed(pullRequestBodyFlagNameConstant) {
+			pullRequestBody = strings.TrimSpace(flagValue)
 		}
 	}
 
@@ -166,6 +180,12 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 	}
 	if commitRequested {
 		actionOptions[taskOptionCommitChanges] = true
+	}
+	if len(pullRequestTitle) > 0 {
+		actionOptions[taskOptionPullRequestTitle] = pullRequestTitle
+	}
+	if len(pullRequestBody) > 0 {
+		actionOptions[taskOptionPullRequestBody] = pullRequestBody
 	}
 	actionOptions[taskOptionWorktreeCommitMessage] = worktreeAdoptionCommitMessageOptionsFromConfiguration(configuration.CommitMessage)
 

--- a/internal/branches/syncflow/command_test.go
+++ b/internal/branches/syncflow/command_test.go
@@ -93,6 +93,72 @@ func TestCommandExecutesAcrossRoots(t *testing.T) {
 	require.Equal(t, "master", action.Options[taskOptionBaseBranch])
 }
 
+func TestCommandPropagatesPullRequestTitleAndBodyOptions(t *testing.T) {
+	temporaryRoot := t.TempDir()
+	runner := &recordingTaskRunner{}
+	builder := CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() CommandConfiguration {
+			return CommandConfiguration{RepositoryRoots: []string{temporaryRoot}, RemoteName: "origin"}
+		},
+		GitExecutor: &stubGitExecutor{},
+		TaskRunnerFactory: func(deps workflow.Dependencies) TaskRunnerExecutor {
+			runner.dependencies = deps
+			return runner
+		},
+	}
+	command, err := builder.Build()
+	require.NoError(t, err)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+
+	require.NoError(t, command.Flags().Set(taskOptionPullRequestTitle, "docs: explain sync"))
+	require.NoError(t, command.Flags().Set(taskOptionPullRequestBody, "Explain the reviewer-facing reason."))
+
+	contextAccessor := utils.NewCommandContextAccessor()
+	command.SetContext(contextAccessor.WithExecutionFlags(context.Background(), utils.ExecutionFlags{}))
+
+	require.NoError(t, command.RunE(command, []string{"feature/foo"}))
+	require.Len(t, runner.definitions, 1)
+	action := runner.definitions[0].Actions[0]
+	require.Equal(t, "docs: explain sync", action.Options[taskOptionPullRequestTitle])
+	require.Equal(t, "Explain the reviewer-facing reason.", action.Options[taskOptionPullRequestBody])
+}
+
+func TestCommandPropagatesConfiguredPullRequestTitleAndBodyOptions(t *testing.T) {
+	temporaryRoot := t.TempDir()
+	runner := &recordingTaskRunner{}
+	builder := CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() CommandConfiguration {
+			return CommandConfiguration{
+				RepositoryRoots: []string{temporaryRoot},
+				RemoteName:      "origin",
+				PullRequest: PullRequestConfiguration{
+					Title: "docs: explain configured sync",
+					Body:  "Explain the configured reviewer-facing reason.",
+				},
+			}
+		},
+		GitExecutor: &stubGitExecutor{},
+		TaskRunnerFactory: func(deps workflow.Dependencies) TaskRunnerExecutor {
+			runner.dependencies = deps
+			return runner
+		},
+	}
+	command, err := builder.Build()
+	require.NoError(t, err)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+
+	contextAccessor := utils.NewCommandContextAccessor()
+	command.SetContext(contextAccessor.WithExecutionFlags(context.Background(), utils.ExecutionFlags{}))
+
+	require.NoError(t, command.RunE(command, []string{"feature/foo"}))
+	require.Len(t, runner.definitions, 1)
+	action := runner.definitions[0].Actions[0]
+	require.Equal(t, "docs: explain configured sync", action.Options[taskOptionPullRequestTitle])
+	require.Equal(t, "Explain the configured reviewer-facing reason.", action.Options[taskOptionPullRequestBody])
+}
+
 func TestCommandStashFlagEnablesRefreshAndPropagatesOptions(t *testing.T) {
 	temporaryRoot := t.TempDir()
 	executor := &stubGitExecutor{}

--- a/internal/branches/syncflow/configuration.go
+++ b/internal/branches/syncflow/configuration.go
@@ -24,6 +24,12 @@ type CommitMessageConfiguration struct {
 	TimeoutSeconds int     `mapstructure:"timeout_seconds"`
 }
 
+// PullRequestConfiguration captures optional PR metadata overrides for sync-created pull requests.
+type PullRequestConfiguration struct {
+	Title string `mapstructure:"title"`
+	Body  string `mapstructure:"body"`
+}
+
 // CommandConfiguration captures configuration values for the sync command.
 type CommandConfiguration struct {
 	RepositoryRoots []string                   `mapstructure:"roots"`
@@ -34,6 +40,7 @@ type CommandConfiguration struct {
 	StashChanges    bool                       `mapstructure:"stash"`
 	CommitChanges   bool                       `mapstructure:"commit"`
 	CommitMessage   CommitMessageConfiguration `mapstructure:"commit_message"`
+	PullRequest     PullRequestConfiguration   `mapstructure:"pull_request"`
 }
 
 // DefaultCommandConfiguration returns the baseline configuration for sync.
@@ -60,6 +67,15 @@ func (configuration CommandConfiguration) Sanitize() CommandConfiguration {
 	sanitized.DefaultBranch = strings.TrimSpace(configuration.DefaultBranch)
 	sanitized.RemoteName = strings.TrimSpace(configuration.RemoteName)
 	sanitized.CommitMessage = configuration.CommitMessage.Sanitize()
+	sanitized.PullRequest = configuration.PullRequest.Sanitize()
+	return sanitized
+}
+
+// Sanitize normalizes pull request configuration values.
+func (configuration PullRequestConfiguration) Sanitize() PullRequestConfiguration {
+	sanitized := configuration
+	sanitized.Title = strings.TrimSpace(configuration.Title)
+	sanitized.Body = strings.TrimSpace(configuration.Body)
 	return sanitized
 }
 

--- a/internal/branches/syncflow/pull_request_body.go
+++ b/internal/branches/syncflow/pull_request_body.go
@@ -1,0 +1,177 @@
+package syncflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/tyemirov/gix/internal/execshell"
+	"github.com/tyemirov/gix/internal/repos/shared"
+	"github.com/tyemirov/utils/llm"
+)
+
+const (
+	strictSyncPullRequestDescriptionMaxTokens       = 768
+	strictSyncPullRequestDescriptionFragmentLimit   = 16000
+	strictSyncPullRequestDescriptionNoDiffMessage   = "strict sync pull request description.empty_diff: branch diff is empty for %s"
+	strictSyncPullRequestDescriptionEmptyResponse   = "strict sync pull request description.empty_response: llm returned an empty pull request description"
+	strictSyncPullRequestDescriptionLLMTemplate     = "strict sync pull request description.llm: %w"
+	strictSyncPullRequestDescriptionGitTemplate     = "strict sync pull request description.%s: %w"
+	strictSyncPullRequestDescriptionSystemPrompt    = "You are an expert maintainer writing pull request descriptions from code differences. Explain why the change exists using only the provided git diff context. Do not mention gix, automation, command names, or how the PR was created. Do not quote diff excerpts or include code fences."
+	strictSyncPullRequestDescriptionUserPrompt      = "Repository: %s\nBase branch: %s\nHead branch: %s\nComparison range: %s\nCommit range: %s\n\nCommit subjects:\n%s\n\nChange summary:\n%s\n\nPatch:\n%s\n\nReturn only a concise Markdown pull request description generated from this code difference."
+	strictSyncPullRequestDescriptionNoCommitSubject = "No unique commit subjects."
+	gitLogSubcommandConstant                        = "log"
+	gitLogSubjectFormatFlagConstant                 = "--format=%s"
+	gitDiffSubcommandConstant                       = "diff"
+	gitDiffStatFlagConstant                         = "--stat"
+	gitDiffUnifiedFlagConstant                      = "--unified=3"
+)
+
+type strictSyncPullRequestDescriptionOptions struct {
+	RepositoryPath string
+	RemoteName     string
+	BaseBranch     string
+	BranchName     string
+	CommitMessages worktreeAdoptionCommitMessageOptions
+}
+
+type strictSyncPullRequestDescriptionContext struct {
+	RepositoryLabel string
+	BaseReference   string
+	BaseBranch      string
+	BranchName      string
+	ComparisonRange string
+	CommitRange     string
+	CommitSubjects  string
+	DiffStat        string
+	Patch           string
+}
+
+func generateStrictSyncPullRequestBody(ctx context.Context, executor shared.GitExecutor, options strictSyncPullRequestDescriptionOptions) (string, error) {
+	descriptionContext, contextErr := collectStrictSyncPullRequestDescriptionContext(ctx, executor, options)
+	if contextErr != nil {
+		return "", contextErr
+	}
+	client, clientErr := resolveCommitMessageClient(options.CommitMessages)
+	if clientErr != nil {
+		return "", clientErr
+	}
+	request := buildStrictSyncPullRequestDescriptionRequest(descriptionContext, options.CommitMessages)
+	response, responseErr := client.Chat(ctx, request)
+	if responseErr != nil {
+		return "", fmt.Errorf(strictSyncPullRequestDescriptionLLMTemplate, responseErr)
+	}
+	trimmedResponse := strings.TrimSpace(response)
+	if trimmedResponse == "" {
+		return "", errors.New(strictSyncPullRequestDescriptionEmptyResponse)
+	}
+	return trimmedResponse, nil
+}
+
+func collectStrictSyncPullRequestDescriptionContext(ctx context.Context, executor shared.GitExecutor, options strictSyncPullRequestDescriptionOptions) (strictSyncPullRequestDescriptionContext, error) {
+	baseReference := fmt.Sprintf("%s/%s", options.RemoteName, options.BaseBranch)
+	comparisonRange := fmt.Sprintf("%s...%s", baseReference, options.BranchName)
+	commitRange := fmt.Sprintf("%s..%s", baseReference, options.BranchName)
+
+	commitSubjects, commitErr := strictSyncPullRequestDescriptionGitOutput(ctx, executor, options.RepositoryPath, []string{gitLogSubcommandConstant, gitLogSubjectFormatFlagConstant, commitRange}, "commit_log")
+	if commitErr != nil {
+		return strictSyncPullRequestDescriptionContext{}, commitErr
+	}
+	diffStat, statErr := strictSyncPullRequestDescriptionGitOutput(ctx, executor, options.RepositoryPath, []string{gitDiffSubcommandConstant, gitDiffStatFlagConstant, comparisonRange}, "diff_stat")
+	if statErr != nil {
+		return strictSyncPullRequestDescriptionContext{}, statErr
+	}
+	patch, patchErr := strictSyncPullRequestDescriptionGitOutput(ctx, executor, options.RepositoryPath, []string{gitDiffSubcommandConstant, gitDiffUnifiedFlagConstant, comparisonRange}, "patch")
+	if patchErr != nil {
+		return strictSyncPullRequestDescriptionContext{}, patchErr
+	}
+
+	trimmedCommitSubjects := truncateStrictSyncPullRequestDescriptionFragment(commitSubjects)
+	trimmedDiffStat := truncateStrictSyncPullRequestDescriptionFragment(diffStat)
+	trimmedPatch := truncateStrictSyncPullRequestDescriptionFragment(patch)
+	if trimmedCommitSubjects == "" && trimmedDiffStat == "" && trimmedPatch == "" {
+		return strictSyncPullRequestDescriptionContext{}, fmt.Errorf(strictSyncPullRequestDescriptionNoDiffMessage, comparisonRange)
+	}
+
+	repositoryLabel := filepath.Base(filepath.Clean(options.RepositoryPath))
+	if repositoryLabel == "." || repositoryLabel == string(filepath.Separator) {
+		repositoryLabel = options.RepositoryPath
+	}
+
+	return strictSyncPullRequestDescriptionContext{
+		RepositoryLabel: repositoryLabel,
+		BaseReference:   baseReference,
+		BaseBranch:      options.BaseBranch,
+		BranchName:      options.BranchName,
+		ComparisonRange: comparisonRange,
+		CommitRange:     commitRange,
+		CommitSubjects:  trimmedCommitSubjects,
+		DiffStat:        trimmedDiffStat,
+		Patch:           trimmedPatch,
+	}, nil
+}
+
+func strictSyncPullRequestDescriptionGitOutput(ctx context.Context, executor shared.GitExecutor, repositoryPath string, arguments []string, operation string) (string, error) {
+	result, executionErr := executor.ExecuteGit(ctx, execshell.CommandDetails{
+		Arguments:        arguments,
+		WorkingDirectory: repositoryPath,
+	})
+	if executionErr != nil {
+		return "", fmt.Errorf(strictSyncPullRequestDescriptionGitTemplate, operation, executionErr)
+	}
+	return result.StandardOutput, nil
+}
+
+func buildStrictSyncPullRequestDescriptionRequest(descriptionContext strictSyncPullRequestDescriptionContext, options worktreeAdoptionCommitMessageOptions) llm.ChatRequest {
+	var temperature *float64
+	if options.Temperature != 0 {
+		temperatureValue := options.Temperature
+		temperature = &temperatureValue
+	}
+	maxTokens := options.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = strictSyncPullRequestDescriptionMaxTokens
+	}
+	return llm.ChatRequest{
+		Messages: []llm.Message{
+			{
+				Role:    "system",
+				Content: strictSyncPullRequestDescriptionSystemPrompt,
+			},
+			{
+				Role: "user",
+				Content: fmt.Sprintf(
+					strictSyncPullRequestDescriptionUserPrompt,
+					descriptionContext.RepositoryLabel,
+					descriptionContext.BaseBranch,
+					descriptionContext.BranchName,
+					descriptionContext.ComparisonRange,
+					descriptionContext.CommitRange,
+					fallbackStrictSyncPullRequestDescriptionText(descriptionContext.CommitSubjects, strictSyncPullRequestDescriptionNoCommitSubject),
+					descriptionContext.DiffStat,
+					descriptionContext.Patch,
+				),
+			},
+		},
+		MaxTokens:   maxTokens,
+		Temperature: temperature,
+	}
+}
+
+func truncateStrictSyncPullRequestDescriptionFragment(value string) string {
+	trimmedValue := strings.TrimSpace(value)
+	runes := []rune(trimmedValue)
+	if len(runes) <= strictSyncPullRequestDescriptionFragmentLimit {
+		return trimmedValue
+	}
+	return string(runes[:strictSyncPullRequestDescriptionFragmentLimit])
+}
+
+func fallbackStrictSyncPullRequestDescriptionText(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/branches/syncflow/pull_request_body.go
+++ b/internal/branches/syncflow/pull_request_body.go
@@ -37,6 +37,20 @@ type strictSyncPullRequestDescriptionOptions struct {
 	CommitMessages worktreeAdoptionCommitMessageOptions
 }
 
+type strictSyncPullRequestMetadata struct {
+	Title string
+	Body  string
+}
+
+type strictSyncPullRequestMetadataOptions struct {
+	RepositoryPath string
+	RemoteName     string
+	BaseBranch     string
+	BranchName     string
+	PullRequest    strictSyncPullRequestMetadata
+	CommitMessages worktreeAdoptionCommitMessageOptions
+}
+
 type strictSyncPullRequestDescriptionContext struct {
 	RepositoryLabel string
 	BaseReference   string
@@ -47,6 +61,50 @@ type strictSyncPullRequestDescriptionContext struct {
 	CommitSubjects  string
 	DiffStat        string
 	Patch           string
+}
+
+func strictSyncPullRequestMetadataFromParameters(parameters map[string]any) (strictSyncPullRequestMetadata, error) {
+	title, titleErr := optionalStringOption(parameters, taskOptionPullRequestTitle)
+	if titleErr != nil {
+		return strictSyncPullRequestMetadata{}, titleErr
+	}
+	body, bodyErr := optionalStringOption(parameters, taskOptionPullRequestBody)
+	if bodyErr != nil {
+		return strictSyncPullRequestMetadata{}, bodyErr
+	}
+	return strictSyncPullRequestMetadata{
+		Title: title,
+		Body:  body,
+	}, nil
+}
+
+func resolveStrictSyncPullRequestMetadata(ctx context.Context, executor shared.GitExecutor, options strictSyncPullRequestMetadataOptions) (strictSyncPullRequestMetadata, error) {
+	title := strings.TrimSpace(options.PullRequest.Title)
+	if title == "" {
+		title = strings.TrimSpace(options.BranchName)
+	}
+	body := strings.TrimSpace(options.PullRequest.Body)
+	if body != "" {
+		return strictSyncPullRequestMetadata{
+			Title: title,
+			Body:  body,
+		}, nil
+	}
+
+	generatedBody, bodyErr := generateStrictSyncPullRequestBody(ctx, executor, strictSyncPullRequestDescriptionOptions{
+		RepositoryPath: options.RepositoryPath,
+		RemoteName:     options.RemoteName,
+		BaseBranch:     options.BaseBranch,
+		BranchName:     options.BranchName,
+		CommitMessages: options.CommitMessages,
+	})
+	if bodyErr != nil {
+		return strictSyncPullRequestMetadata{}, bodyErr
+	}
+	return strictSyncPullRequestMetadata{
+		Title: title,
+		Body:  generatedBody,
+	}, nil
 }
 
 func generateStrictSyncPullRequestBody(ctx context.Context, executor shared.GitExecutor, options strictSyncPullRequestDescriptionOptions) (string, error) {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -540,10 +540,9 @@ type strictPullRequestBranchOptions struct {
 
 type strictPullRequestCreateOptions struct {
 	RepositoryIdentifier string
-	RemoteName           string
 	BaseBranch           string
 	BranchName           string
-	CommitMessages       worktreeAdoptionCommitMessageOptions
+	Body                 string
 }
 
 func syncBaseBranch(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string) error {
@@ -638,15 +637,24 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 		if mergeErr := mergeBaseIntoBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName); mergeErr != nil {
 			return false, mergeErr
 		}
+		body, bodyErr := generateStrictSyncPullRequestBody(ctx, environment.GitExecutor, strictSyncPullRequestDescriptionOptions{
+			RepositoryPath: repository.Path,
+			RemoteName:     options.RemoteName,
+			BaseBranch:     options.BaseBranch,
+			BranchName:     options.BranchName,
+			CommitMessages: options.CommitMessages,
+		})
+		if bodyErr != nil {
+			return false, bodyErr
+		}
 		if pushErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, gitPushSetUpstreamFlagConstant, options.RemoteName, options.BranchName}); pushErr != nil {
 			return false, pushErr
 		}
-		if pullRequestErr := createPullRequest(ctx, environment, repository, strictPullRequestCreateOptions{
+		if pullRequestErr := createPullRequest(ctx, environment, strictPullRequestCreateOptions{
 			RepositoryIdentifier: repositoryIdentifier,
-			RemoteName:           options.RemoteName,
 			BaseBranch:           options.BaseBranch,
 			BranchName:           options.BranchName,
-			CommitMessages:       options.CommitMessages,
+			Body:                 body,
 		}); pullRequestErr != nil {
 			return false, pullRequestErr
 		}
@@ -664,15 +672,24 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 	if createErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, options.BranchName, baseReference}); createErr != nil {
 		return false, createErr
 	}
+	body, bodyErr := generateStrictSyncPullRequestBody(ctx, environment.GitExecutor, strictSyncPullRequestDescriptionOptions{
+		RepositoryPath: repository.Path,
+		RemoteName:     options.RemoteName,
+		BaseBranch:     options.BaseBranch,
+		BranchName:     options.BranchName,
+		CommitMessages: options.CommitMessages,
+	})
+	if bodyErr != nil {
+		return false, bodyErr
+	}
 	if pushErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, gitPushSetUpstreamFlagConstant, options.RemoteName, options.BranchName}); pushErr != nil {
 		return false, pushErr
 	}
-	if pullRequestErr := createPullRequest(ctx, environment, repository, strictPullRequestCreateOptions{
+	if pullRequestErr := createPullRequest(ctx, environment, strictPullRequestCreateOptions{
 		RepositoryIdentifier: repositoryIdentifier,
-		RemoteName:           options.RemoteName,
 		BaseBranch:           options.BaseBranch,
 		BranchName:           options.BranchName,
-		CommitMessages:       options.CommitMessages,
+		Body:                 body,
 	}); pullRequestErr != nil {
 		return false, pullRequestErr
 	}
@@ -733,24 +750,14 @@ func branchHasOpenPullRequest(ctx context.Context, environment *workflow.Environ
 	return false, nil
 }
 
-func createPullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, options strictPullRequestCreateOptions) error {
+func createPullRequest(ctx context.Context, environment *workflow.Environment, options strictPullRequestCreateOptions) error {
 	if environment.GitHubClient == nil {
 		return errors.New(strictSyncMissingGitHubClientMessage)
-	}
-	body, bodyErr := generateStrictSyncPullRequestBody(ctx, environment.GitExecutor, strictSyncPullRequestDescriptionOptions{
-		RepositoryPath: repository.Path,
-		RemoteName:     options.RemoteName,
-		BaseBranch:     options.BaseBranch,
-		BranchName:     options.BranchName,
-		CommitMessages: options.CommitMessages,
-	})
-	if bodyErr != nil {
-		return bodyErr
 	}
 	return environment.GitHubClient.CreatePullRequest(ctx, githubcli.PullRequestCreateOptions{
 		Repository: options.RepositoryIdentifier,
 		Title:      options.BranchName,
-		Body:       body,
+		Body:       options.Body,
 		Base:       options.BaseBranch,
 		Head:       options.BranchName,
 	})

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -65,7 +65,6 @@ const (
 	strictSyncMissingPullRequestTemplate         = "branch %q does not have an open pull request into %s"
 	strictSyncConflictTemplate                   = "merge from %s/%s into %s stopped with conflicts; resolve them before pushing"
 	strictSyncFastForwardTemplate                = "fast-forward from %s/%s into %s stopped; commit, stash, or clean local changes before syncing"
-	strictSyncPullRequestBodyTemplate            = "This PR is the review path for `%s` before those changes land in `%s`.\n\nKeep `%s` remote-owned; review and merge this branch when the changes are ready."
 )
 
 func init() {
@@ -521,6 +520,7 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 		BaseBranch:       baseBranch,
 		AllowAheadCommit: checkpointCommitted,
 		DirtyWorktree:    dirty,
+		CommitMessages:   options.CommitMessages,
 	})
 	if syncErr != nil {
 		return syncErr
@@ -535,6 +535,15 @@ type strictPullRequestBranchOptions struct {
 	BaseBranch       string
 	AllowAheadCommit bool
 	DirtyWorktree    bool
+	CommitMessages   worktreeAdoptionCommitMessageOptions
+}
+
+type strictPullRequestCreateOptions struct {
+	RepositoryIdentifier string
+	RemoteName           string
+	BaseBranch           string
+	BranchName           string
+	CommitMessages       worktreeAdoptionCommitMessageOptions
 }
 
 func syncBaseBranch(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string) error {
@@ -632,7 +641,13 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 		if pushErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, gitPushSetUpstreamFlagConstant, options.RemoteName, options.BranchName}); pushErr != nil {
 			return false, pushErr
 		}
-		if pullRequestErr := createPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName); pullRequestErr != nil {
+		if pullRequestErr := createPullRequest(ctx, environment, repository, strictPullRequestCreateOptions{
+			RepositoryIdentifier: repositoryIdentifier,
+			RemoteName:           options.RemoteName,
+			BaseBranch:           options.BaseBranch,
+			BranchName:           options.BranchName,
+			CommitMessages:       options.CommitMessages,
+		}); pullRequestErr != nil {
 			return false, pullRequestErr
 		}
 		return true, nil
@@ -652,7 +667,13 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 	if pushErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, gitPushSetUpstreamFlagConstant, options.RemoteName, options.BranchName}); pushErr != nil {
 		return false, pushErr
 	}
-	if pullRequestErr := createPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName); pullRequestErr != nil {
+	if pullRequestErr := createPullRequest(ctx, environment, repository, strictPullRequestCreateOptions{
+		RepositoryIdentifier: repositoryIdentifier,
+		RemoteName:           options.RemoteName,
+		BaseBranch:           options.BaseBranch,
+		BranchName:           options.BranchName,
+		CommitMessages:       options.CommitMessages,
+	}); pullRequestErr != nil {
 		return false, pullRequestErr
 	}
 	return true, nil
@@ -712,21 +733,27 @@ func branchHasOpenPullRequest(ctx context.Context, environment *workflow.Environ
 	return false, nil
 }
 
-func createPullRequest(ctx context.Context, environment *workflow.Environment, repositoryIdentifier string, baseBranch string, branchName string) error {
+func createPullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, options strictPullRequestCreateOptions) error {
 	if environment.GitHubClient == nil {
 		return errors.New(strictSyncMissingGitHubClientMessage)
 	}
-	return environment.GitHubClient.CreatePullRequest(ctx, githubcli.PullRequestCreateOptions{
-		Repository: repositoryIdentifier,
-		Title:      branchName,
-		Body:       strictSyncPullRequestBody(baseBranch, branchName),
-		Base:       baseBranch,
-		Head:       branchName,
+	body, bodyErr := generateStrictSyncPullRequestBody(ctx, environment.GitExecutor, strictSyncPullRequestDescriptionOptions{
+		RepositoryPath: repository.Path,
+		RemoteName:     options.RemoteName,
+		BaseBranch:     options.BaseBranch,
+		BranchName:     options.BranchName,
+		CommitMessages: options.CommitMessages,
 	})
-}
-
-func strictSyncPullRequestBody(baseBranch string, branchName string) string {
-	return fmt.Sprintf(strictSyncPullRequestBodyTemplate, branchName, baseBranch, baseBranch)
+	if bodyErr != nil {
+		return bodyErr
+	}
+	return environment.GitHubClient.CreatePullRequest(ctx, githubcli.PullRequestCreateOptions{
+		Repository: options.RepositoryIdentifier,
+		Title:      options.BranchName,
+		Body:       body,
+		Base:       options.BaseBranch,
+		Head:       options.BranchName,
+	})
 }
 
 func strictSyncRepositoryIdentifier(repository *workflow.RepositoryState) string {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -65,7 +65,7 @@ const (
 	strictSyncMissingPullRequestTemplate         = "branch %q does not have an open pull request into %s"
 	strictSyncConflictTemplate                   = "merge from %s/%s into %s stopped with conflicts; resolve them before pushing"
 	strictSyncFastForwardTemplate                = "fast-forward from %s/%s into %s stopped; commit, stash, or clean local changes before syncing"
-	strictSyncCreatedPRBody                      = "Created by gix sync."
+	strictSyncPullRequestBodyTemplate            = "This PR is the review path for `%s` before those changes land in `%s`.\n\nKeep `%s` remote-owned; review and merge this branch when the changes are ready."
 )
 
 func init() {
@@ -719,10 +719,14 @@ func createPullRequest(ctx context.Context, environment *workflow.Environment, r
 	return environment.GitHubClient.CreatePullRequest(ctx, githubcli.PullRequestCreateOptions{
 		Repository: repositoryIdentifier,
 		Title:      branchName,
-		Body:       strictSyncCreatedPRBody,
+		Body:       strictSyncPullRequestBody(baseBranch, branchName),
 		Base:       baseBranch,
 		Head:       branchName,
 	})
+}
+
+func strictSyncPullRequestBody(baseBranch string, branchName string) string {
+	return fmt.Sprintf(strictSyncPullRequestBodyTemplate, branchName, baseBranch, baseBranch)
 }
 
 func strictSyncRepositoryIdentifier(repository *workflow.RepositoryState) string {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -27,6 +27,8 @@ const (
 	taskOptionWorktreeCommitMessage   = "worktree_commit_message"
 	taskOptionRequirePullRequest      = "require_pull_request"
 	taskOptionBaseBranch              = "base_branch"
+	taskOptionPullRequestTitle        = "title"
+	taskOptionPullRequestBody         = "body"
 
 	branchResolutionSourceExplicit      = "explicit"
 	branchResolutionSourceRemoteDefault = "remote_default"
@@ -204,6 +206,10 @@ func handleBranchSyncAction(ctx context.Context, environment *workflow.Environme
 		if commitMessageErr != nil {
 			return commitMessageErr
 		}
+		pullRequestMetadata, pullRequestMetadataErr := strictSyncPullRequestMetadataFromParameters(parameters)
+		if pullRequestMetadataErr != nil {
+			return pullRequestMetadataErr
+		}
 		return handleStrictSyncAction(ctx, environment, repository, strictSyncOptions{
 			BranchName:       resolvedBranchName,
 			RemoteName:       remoteName,
@@ -212,6 +218,7 @@ func handleBranchSyncAction(ctx context.Context, environment *workflow.Environme
 			StashChanges:     stashChanges,
 			CommitChanges:    commitChanges,
 			CommitMessages:   commitMessageOptions,
+			PullRequest:      pullRequestMetadata,
 			ResolutionSource: resolutionSource,
 		})
 	}
@@ -432,6 +439,7 @@ type strictSyncOptions struct {
 	StashChanges     bool
 	CommitChanges    bool
 	CommitMessages   worktreeAdoptionCommitMessageOptions
+	PullRequest      strictSyncPullRequestMetadata
 	ResolutionSource string
 }
 
@@ -521,6 +529,7 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 		AllowAheadCommit: checkpointCommitted,
 		DirtyWorktree:    dirty,
 		CommitMessages:   options.CommitMessages,
+		PullRequest:      options.PullRequest,
 	})
 	if syncErr != nil {
 		return syncErr
@@ -536,12 +545,14 @@ type strictPullRequestBranchOptions struct {
 	AllowAheadCommit bool
 	DirtyWorktree    bool
 	CommitMessages   worktreeAdoptionCommitMessageOptions
+	PullRequest      strictSyncPullRequestMetadata
 }
 
 type strictPullRequestCreateOptions struct {
 	RepositoryIdentifier string
 	BaseBranch           string
 	BranchName           string
+	Title                string
 	Body                 string
 }
 
@@ -637,25 +648,7 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 		if mergeErr := mergeBaseIntoBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName); mergeErr != nil {
 			return false, mergeErr
 		}
-		body, bodyErr := generateStrictSyncPullRequestBody(ctx, environment.GitExecutor, strictSyncPullRequestDescriptionOptions{
-			RepositoryPath: repository.Path,
-			RemoteName:     options.RemoteName,
-			BaseBranch:     options.BaseBranch,
-			BranchName:     options.BranchName,
-			CommitMessages: options.CommitMessages,
-		})
-		if bodyErr != nil {
-			return false, bodyErr
-		}
-		if pushErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, gitPushSetUpstreamFlagConstant, options.RemoteName, options.BranchName}); pushErr != nil {
-			return false, pushErr
-		}
-		if pullRequestErr := createPullRequest(ctx, environment, strictPullRequestCreateOptions{
-			RepositoryIdentifier: repositoryIdentifier,
-			BaseBranch:           options.BaseBranch,
-			BranchName:           options.BranchName,
-			Body:                 body,
-		}); pullRequestErr != nil {
+		if pullRequestErr := pushAndCreatePullRequest(ctx, environment, repository, repositoryIdentifier, options); pullRequestErr != nil {
 			return false, pullRequestErr
 		}
 		return true, nil
@@ -672,28 +665,34 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 	if createErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, options.BranchName, baseReference}); createErr != nil {
 		return false, createErr
 	}
-	body, bodyErr := generateStrictSyncPullRequestBody(ctx, environment.GitExecutor, strictSyncPullRequestDescriptionOptions{
+	if pullRequestErr := pushAndCreatePullRequest(ctx, environment, repository, repositoryIdentifier, options); pullRequestErr != nil {
+		return false, pullRequestErr
+	}
+	return true, nil
+}
+
+func pushAndCreatePullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) error {
+	pullRequestMetadata, pullRequestMetadataErr := resolveStrictSyncPullRequestMetadata(ctx, environment.GitExecutor, strictSyncPullRequestMetadataOptions{
 		RepositoryPath: repository.Path,
 		RemoteName:     options.RemoteName,
 		BaseBranch:     options.BaseBranch,
 		BranchName:     options.BranchName,
+		PullRequest:    options.PullRequest,
 		CommitMessages: options.CommitMessages,
 	})
-	if bodyErr != nil {
-		return false, bodyErr
+	if pullRequestMetadataErr != nil {
+		return pullRequestMetadataErr
 	}
 	if pushErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, gitPushSetUpstreamFlagConstant, options.RemoteName, options.BranchName}); pushErr != nil {
-		return false, pushErr
+		return pushErr
 	}
-	if pullRequestErr := createPullRequest(ctx, environment, strictPullRequestCreateOptions{
+	return createPullRequest(ctx, environment, strictPullRequestCreateOptions{
 		RepositoryIdentifier: repositoryIdentifier,
 		BaseBranch:           options.BaseBranch,
 		BranchName:           options.BranchName,
-		Body:                 body,
-	}); pullRequestErr != nil {
-		return false, pullRequestErr
-	}
-	return true, nil
+		Title:                pullRequestMetadata.Title,
+		Body:                 pullRequestMetadata.Body,
+	})
 }
 
 func switchToLocalOrRemoteBranch(ctx context.Context, executor shared.GitExecutor, repositoryPath string, remoteName string, branchName string) error {
@@ -756,7 +755,7 @@ func createPullRequest(ctx context.Context, environment *workflow.Environment, o
 	}
 	return environment.GitHubClient.CreatePullRequest(ctx, githubcli.PullRequestCreateOptions{
 		Repository: options.RepositoryIdentifier,
-		Title:      options.BranchName,
+		Title:      options.Title,
 		Body:       options.Body,
 		Base:       options.BaseBranch,
 		Head:       options.BranchName,

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -612,6 +612,58 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRe
 	require.Contains(t, chatClient.requests[0].Messages[1].Content, "diff --git a/README.md b/README.md")
 }
 
+func TestHandleBranchSyncActionStrictPRBranchUsesExplicitPullRequestMetadata(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		missingReferences: map[string]bool{
+			"origin/feature/foo":     true,
+			"refs/heads/feature/foo": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{response: "generated body should not be used"}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+		taskOptionPullRequestTitle:   "docs: explain sync",
+		taskOptionPullRequestBody:    "Explain the reviewer-facing reason.",
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c feature/foo origin/master")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin feature/foo")
+	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master...feature/foo")
+	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "diff --unified=3 origin/master...feature/foo")
+	require.Len(t, githubExecutor.commands, 1)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "feature/foo", "--title", "docs: explain sync", "--body", "Explain the reviewer-facing reason."}, githubExecutor.commands[0].Arguments)
+	require.Len(t, chatClient.requests, 0)
+}
+
 func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMaster(t *testing.T) {
 	pullRequestBody := "## Summary\n- Updates README content from the dirty master branch."
 	gitExecutor := &strictSyncGitExecutor{

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -182,12 +182,17 @@ func (executor *strictSyncGitHubExecutor) ExecuteGitHubCLI(_ context.Context, de
 }
 
 type strictSyncChatClient struct {
-	response string
-	requests []llm.ChatRequest
+	response  string
+	responses []string
+	requests  []llm.ChatRequest
 }
 
 func (client *strictSyncChatClient) Chat(_ context.Context, request llm.ChatRequest) (string, error) {
 	client.requests = append(client.requests, request)
+	responseIndex := len(client.requests) - 1
+	if responseIndex < len(client.responses) {
+		return client.responses[responseIndex], nil
+	}
 	if client.response == "" {
 		return "feat: sync dirty work", nil
 	}
@@ -553,6 +558,7 @@ func TestHandleBranchSyncActionStrictPRBranchCommitFlagUsesDirtySyncCommitWithRe
 }
 
 func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRequest(t *testing.T) {
+	pullRequestBody := "## Summary\n- Updates README rendering from the branch diff."
 	gitExecutor := &strictSyncGitExecutor{
 		missingReferences: map[string]bool{
 			"origin/feature/foo":     true,
@@ -564,6 +570,7 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRe
 	githubExecutor := &strictSyncGitHubExecutor{}
 	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
 	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{responses: []string{pullRequestBody}}
 	environment := &workflow.Environment{
 		GitExecutor:       gitExecutor,
 		RepositoryManager: gitManager,
@@ -586,16 +593,26 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRe
 		taskOptionRequirePullRequest: true,
 		taskOptionBaseBranch:         "master",
 		taskOptionRequireClean:       true,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
 	}
 
 	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c feature/foo origin/master")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin feature/foo")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master...feature/foo")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --unified=3 origin/master...feature/foo")
 	require.Len(t, githubExecutor.commands, 1)
-	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "feature/foo", "--title", "feature/foo", "--body", "This PR is the review path for `feature/foo` before those changes land in `master`.\n\nKeep `master` remote-owned; review and merge this branch when the changes are ready."}, githubExecutor.commands[0].Arguments)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "feature/foo", "--title", "feature/foo", "--body", pullRequestBody}, githubExecutor.commands[0].Arguments)
+	require.Len(t, chatClient.requests, 1)
+	require.Contains(t, chatClient.requests[0].Messages[1].Content, "Comparison range: origin/master...feature/foo")
+	require.Contains(t, chatClient.requests[0].Messages[1].Content, "README.md | 1 +")
+	require.Contains(t, chatClient.requests[0].Messages[1].Content, "diff --git a/README.md b/README.md")
 }
 
 func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMaster(t *testing.T) {
+	pullRequestBody := "## Summary\n- Updates README content from the dirty master branch."
 	gitExecutor := &strictSyncGitExecutor{
 		statusOutput: " M README.md\n",
 		missingReferences: map[string]bool{
@@ -608,7 +625,7 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	githubExecutor := &strictSyncGitHubExecutor{}
 	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
 	require.NoError(t, githubClientError)
-	chatClient := &strictSyncChatClient{response: "docs: update readme"}
+	chatClient := &strictSyncChatClient{responses: []string{"docs: update readme", pullRequestBody}}
 	environment := &workflow.Environment{
 		GitExecutor:       gitExecutor,
 		RepositoryManager: gitManager,
@@ -642,9 +659,14 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "commit -m docs: update readme")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin sync/project/readme")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master...sync/project/readme")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --unified=3 origin/master...sync/project/readme")
 	require.Len(t, githubExecutor.commands, 1)
-	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "sync/project/readme", "--title", "sync/project/readme", "--body", "This PR is the review path for `sync/project/readme` before those changes land in `master`.\n\nKeep `master` remote-owned; review and merge this branch when the changes are ready."}, githubExecutor.commands[0].Arguments)
-	require.Len(t, chatClient.requests, 1)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "sync/project/readme", "--title", "sync/project/readme", "--body", pullRequestBody}, githubExecutor.commands[0].Arguments)
+	require.Len(t, chatClient.requests, 2)
+	require.Contains(t, chatClient.requests[1].Messages[1].Content, "Comparison range: origin/master...sync/project/readme")
+	require.Contains(t, chatClient.requests[1].Messages[1].Content, "README.md | 1 +")
+	require.Contains(t, chatClient.requests[1].Messages[1].Content, "diff --git a/README.md b/README.md")
 }
 
 func TestHandleBranchSyncActionStrictPRBranchStopsBeforePushOnMergeConflict(t *testing.T) {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -592,7 +592,7 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRe
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c feature/foo origin/master")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin feature/foo")
 	require.Len(t, githubExecutor.commands, 1)
-	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "feature/foo", "--title", "feature/foo", "--body", strictSyncCreatedPRBody}, githubExecutor.commands[0].Arguments)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "feature/foo", "--title", "feature/foo", "--body", "This PR is the review path for `feature/foo` before those changes land in `master`.\n\nKeep `master` remote-owned; review and merge this branch when the changes are ready."}, githubExecutor.commands[0].Arguments)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMaster(t *testing.T) {
@@ -643,7 +643,7 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin sync/project/readme")
 	require.Len(t, githubExecutor.commands, 1)
-	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "sync/project/readme", "--title", "sync/project/readme", "--body", strictSyncCreatedPRBody}, githubExecutor.commands[0].Arguments)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "sync/project/readme", "--title", "sync/project/readme", "--body", "This PR is the review path for `sync/project/readme` before those changes land in `master`.\n\nKeep `master` remote-owned; review and merge this branch when the changes are ready."}, githubExecutor.commands[0].Arguments)
 	require.Len(t, chatClient.requests, 1)
 }
 

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -603,6 +603,7 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesMissingRemoteBranchAndPullRe
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master...feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --unified=3 origin/master...feature/foo")
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "diff --stat origin/master...feature/foo"), recordedGitCommandIndex(gitExecutor.commands, "push -u origin feature/foo"))
 	require.Len(t, githubExecutor.commands, 1)
 	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "feature/foo", "--title", "feature/foo", "--body", pullRequestBody}, githubExecutor.commands[0].Arguments)
 	require.Len(t, chatClient.requests, 1)
@@ -661,12 +662,63 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin sync/project/readme")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master...sync/project/readme")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --unified=3 origin/master...sync/project/readme")
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "diff --stat origin/master...sync/project/readme"), recordedGitCommandIndex(gitExecutor.commands, "push -u origin sync/project/readme"))
 	require.Len(t, githubExecutor.commands, 1)
 	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "sync/project/readme", "--title", "sync/project/readme", "--body", pullRequestBody}, githubExecutor.commands[0].Arguments)
 	require.Len(t, chatClient.requests, 2)
 	require.Contains(t, chatClient.requests[1].Messages[1].Content, "Comparison range: origin/master...sync/project/readme")
 	require.Contains(t, chatClient.requests[1].Messages[1].Content, "README.md | 1 +")
 	require.Contains(t, chatClient.requests[1].Messages[1].Content, "diff --git a/README.md b/README.md")
+}
+
+func TestHandleBranchSyncActionStrictPRBranchDoesNotPushWhenPullRequestBodyGenerationFails(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		missingReferences: map[string]bool{
+			"origin/feature/foo":     true,
+			"refs/heads/feature/foo": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{responses: []string{""}}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	syncError := handleBranchSyncAction(context.Background(), environment, repository, parameters)
+	require.Error(t, syncError)
+	require.Contains(t, syncError.Error(), "empty_response")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c feature/foo origin/master")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master...feature/foo")
+	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "push -u origin feature/foo")
+	require.Len(t, githubExecutor.commands, 0)
+	require.Len(t, chatClient.requests, 1)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchStopsBeforePushOnMergeConflict(t *testing.T) {
@@ -714,6 +766,15 @@ func recordedGitCommands(commands []execshell.CommandDetails) string {
 		lines = append(lines, strings.Join(command.Arguments, " "))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func recordedGitCommandIndex(commands []execshell.CommandDetails, target string) int {
+	for commandIndex := range commands {
+		if strings.Join(commands[commandIndex].Arguments, " ") == target {
+			return commandIndex
+		}
+	}
+	return -1
 }
 
 func commandHasArgument(arguments []string, target string) bool {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -763,3 +763,17 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Preserved `--stash`, kept `--commit` accepted, and made `--require-clean` the opt-in dirty-work guard.
   - Updated README/help/config defaults and added black-box coverage for dirty PR branches, dirty `master`, generated branches, and the clean-worktree guard.
   - `make test`, `make lint`, and `make ci` passed locally.
+
+- [x] [I007] Make `gix sync` pull request descriptions explain why the PR exists.
+  Requested on 2026-06-03.
+  ### Summary
+  `gix sync` currently opens pull requests with the body `Created by gix sync.`, which describes the tool path rather than the reason a reviewer should care about the PR.
+  ### Plan
+  - Locate the sync PR creation path and any workflow-level PR body defaults that can leak this placeholder into user-visible GitHub descriptions.
+  - Add failing observable coverage for the sync-generated PR body.
+  - Replace the placeholder with purpose-oriented body text tied to the sync target and branch context.
+  - Run the required Makefile validation targets.
+  ### Resolution
+  - Replaced the static `Created by gix sync.` body with PR text that explains the review path from the head branch into the remote-owned base branch.
+  - Updated strict-sync PR creation coverage for both explicit work branches and generated dirty-`master` branches.
+  - `make test`, `make lint`, and `make ci` passed locally.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -784,3 +784,6 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Threaded the existing sync LLM configuration into PR creation so `gh pr create --body` receives generated text from the code difference.
   - Updated strict-sync coverage to assert both the diff commands and the generated body passed to GitHub.
   - `make test`, `make lint`, and `make ci` passed locally after the follow-up.
+  ### Review Fix
+  - Moved PR body generation before `git push -u` on new PR branches so body-generation failures do not leave remote branches without pull requests.
+  - Added strict-sync coverage for command ordering and the failure path where empty generated PR text stops before push.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -777,3 +777,10 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Replaced the static `Created by gix sync.` body with PR text that explains the review path from the head branch into the remote-owned base branch.
   - Updated strict-sync PR creation coverage for both explicit work branches and generated dirty-`master` branches.
   - `make test`, `make lint`, and `make ci` passed locally.
+  ### Follow-up
+  The first resolution still used predefined body text. The PR description must be generated from the branch code difference itself, using the configured LLM path and git diff context.
+  ### Follow-up Resolution
+  - Added a branch-diff PR body generator that collects commit subjects, `git diff --stat`, and patch context for `<remote>/<base>...<branch>`.
+  - Threaded the existing sync LLM configuration into PR creation so `gh pr create --body` receives generated text from the code difference.
+  - Updated strict-sync coverage to assert both the diff commands and the generated body passed to GitHub.
+  - `make test`, `make lint`, and `make ci` passed locally after the follow-up.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -787,3 +787,8 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   ### Review Fix
   - Moved PR body generation before `git push -u` on new PR branches so body-generation failures do not leave remote branches without pull requests.
   - Added strict-sync coverage for command ordering and the failure path where empty generated PR text stops before push.
+  ### Control Follow-up
+  - Unified sync-created PR metadata resolution around `title` and `body` option keys.
+  - Exposed explicit metadata controls through `gix sync --title/--body` and `sync.pull_request.title/body`.
+  - Kept branch-diff body generation as the default and made explicit body text bypass generation.
+  - `make test`, `make lint`, and `make ci` passed locally after the control follow-up.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -3,4 +3,6 @@
 - Add failing observable coverage proving newly opened sync PRs receive body text returned from real branch diff context.
 - Ensure generated body failures stop before pushing newly created PR branches.
 - Reuse the existing configured LLM client path so the generated body explains the code difference instead of the tool path.
+- Unify sync-created PR metadata resolution around the same `title` and `body` option names used by workflow pull request tasks.
+- Expose explicit `title` and `body` controls through sync CLI flags and `sync.pull_request` configuration while keeping branch-diff body generation as the default.
 - Validate through Makefile targets: format, test, lint, and ci.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,5 +1,5 @@
-- Add I007 as the active implementation scope for purposeful `gix sync` pull request descriptions.
-- Locate the sync PR creation path that currently emits `Created by gix sync.` as the body.
-- Add failing observable coverage proving newly opened sync PRs include useful why-oriented body text.
-- Replace the placeholder body with a description tied to the sync target and dirty-work branch purpose.
+- Keep I007 as the active implementation scope for purposeful `gix sync` pull request descriptions.
+- Replace the static sync PR body formatter with a branch-diff description generator.
+- Add failing observable coverage proving newly opened sync PRs receive body text returned from real branch diff context.
+- Reuse the existing configured LLM client path so the generated body explains the code difference instead of the tool path.
 - Validate through Makefile targets: format, test, lint, and ci.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,5 +1,6 @@
 - Keep I007 as the active implementation scope for purposeful `gix sync` pull request descriptions.
 - Replace the static sync PR body formatter with a branch-diff description generator.
 - Add failing observable coverage proving newly opened sync PRs receive body text returned from real branch diff context.
+- Ensure generated body failures stop before pushing newly created PR branches.
 - Reuse the existing configured LLM client path so the generated body explains the code difference instead of the tool path.
 - Validate through Makefile targets: format, test, lint, and ci.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,15 +1,5 @@
-- Add I006 as the active implementation scope for the new `gix sync` semantics.
-- Remove the old `cd` implementation naming and any legacy `branch-cd` surface.
-- Implement `gix sync` as the canonical synchronization command:
-  - `gix sync <remote-url|owner/repo>` attaches or clones a workspace.
-  - `gix sync master` restores local `master` from `origin/master`.
-  - `gix sync <branch>` switches to or creates a PR-backed work branch.
-  - `gix sync` syncs the current branch.
-- Preserve dirty-work modifiers as explicit sync policies:
-  - default clean-worktree requirement;
-  - `--stash` around safe sync operations;
-  - `--commit` for PR-backed work branch checkpoint commits;
-  - `--require-clean=false` only where non-destructive sync can safely proceed.
-- Use merge, not rebase, to bring `origin/master` into work branches; stop before push on conflicts.
-- Update README/help/config/tests so the public flow emphasizes the simplified sync contract.
+- Add I007 as the active implementation scope for purposeful `gix sync` pull request descriptions.
+- Locate the sync PR creation path that currently emits `Created by gix sync.` as the body.
+- Add failing observable coverage proving newly opened sync PRs include useful why-oriented body text.
+- Replace the placeholder body with a description tied to the sync target and dirty-work branch purpose.
 - Validate through Makefile targets: format, test, lint, and ci.


### PR DESCRIPTION
## Summary
- Resolves I007.
- Replaces predefined `gix sync` PR body text with a branch-diff description generator.
- The generated PR body is produced through the configured LLM path from commit subjects, `git diff --stat`, and patch context for `<remote>/<base>...<branch>`.
- Unifies sync-created PR metadata through the same `title` and `body` option keys used by workflow PR tasks.
- Exposes explicit metadata controls through `gix sync --title/--body` and `sync.pull_request.title/body`; explicit body text bypasses generated descriptions.
- Generates the PR body before pushing new PR branches so body-generation failures do not leave remote branches without pull requests.
- Updates strict-sync coverage for explicit work branches, generated dirty-`master` branches, command ordering, failure-before-push behavior, and explicit PR title/body controls.

## Validation
- `timeout -k 350s -s SIGKILL 350s make test`
- `timeout -k 350s -s SIGKILL 350s make lint`
- `timeout -k 350s -s SIGKILL 350s make ci`

## Policy Checks
- No static PR description fallback remains in the syncflow path.
- PR creation now fails instead of fabricating a body when branch diff context or configured LLM generation is unavailable.
- Existing sync LLM configuration is reused rather than introducing another provider path.
- Explicit PR metadata uses the same `title` and `body` option names as workflow PR tasks.
