### PR TITLE
Unify workflow action option builders

### DIFF
--- a/cmd/cli/application_web_workflow_primitives.go
+++ b/cmd/cli/application_web_workflow_primitives.go
@@ -15,16 +15,16 @@ import (
 )
 
 const (
-	webWorkflowPrimitiveCanonicalRemoteConstant    = "repo.remote.update"
-	webWorkflowPrimitiveProtocolConversionConstant = "repo.remote.convert-protocol"
-	webWorkflowPrimitiveRenameFolderConstant       = "repo.folder.rename"
-	webWorkflowPrimitiveDefaultBranchConstant      = "branch.default"
-	webWorkflowPrimitiveReleaseTagConstant         = "repo.release.tag"
-	webWorkflowPrimitiveReleaseRetagConstant       = "repo.release.retag"
-	webWorkflowPrimitiveAuditReportConstant        = "audit.report"
-	webWorkflowPrimitiveHistoryPurgeConstant       = "repo.history.purge"
-	webWorkflowPrimitiveFileReplaceConstant        = "repo.files.replace"
-	webWorkflowPrimitiveNamespaceRewriteConstant   = "repo.namespace.rewrite"
+	webWorkflowPrimitiveCanonicalRemoteConstant    = workflow.TaskActionCanonicalRemoteType
+	webWorkflowPrimitiveProtocolConversionConstant = workflow.TaskActionProtocolConversionType
+	webWorkflowPrimitiveRenameFolderConstant       = workflow.TaskActionRenameDirectoriesType
+	webWorkflowPrimitiveDefaultBranchConstant      = workflow.TaskActionBranchDefaultType
+	webWorkflowPrimitiveReleaseTagConstant         = workflow.TaskActionReleaseTagType
+	webWorkflowPrimitiveReleaseRetagConstant       = workflow.TaskActionReleaseRetagType
+	webWorkflowPrimitiveAuditReportConstant        = workflow.TaskActionAuditReportType
+	webWorkflowPrimitiveHistoryPurgeConstant       = workflow.TaskActionHistoryPurgeType
+	webWorkflowPrimitiveFileReplaceConstant        = workflow.TaskActionFileReplaceType
+	webWorkflowPrimitiveNamespaceRewriteConstant   = workflow.TaskActionNamespaceRewriteType
 
 	webWorkflowPrimitiveQueuedActionsRequiredConstant       = "at least one queued workflow action is required"
 	webWorkflowPrimitiveRepositoryPathRequiredConstant      = "workflow action repository path is required"
@@ -246,9 +246,7 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if ownerError != nil {
 					return nil, ownerError
 				}
-				return workflowPrimitiveOptions(map[string]string{
-					webWorkflowPrimitiveParameterOwnerConstant: owner,
-				}), nil
+				return workflow.CanonicalRemoteActionOptions{Owner: owner}.Options(), nil
 			},
 		},
 		{
@@ -298,10 +296,10 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if toError != nil {
 					return nil, toError
 				}
-				return workflowPrimitiveOptions(map[string]string{
-					webWorkflowPrimitiveParameterFromConstant: fromProtocol,
-					webWorkflowPrimitiveParameterToConstant:   toProtocol,
-				}), nil
+				return workflow.ProtocolConversionActionOptions{
+					From: shared.RemoteProtocol(fromProtocol),
+					To:   shared.RemoteProtocol(toProtocol),
+				}.Options(), nil
 			},
 		},
 		{
@@ -333,10 +331,10 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if requireCleanError != nil {
 					return nil, requireCleanError
 				}
-				return map[string]any{
-					webWorkflowPrimitiveParameterIncludeOwnerConstant: includeOwner,
-					webWorkflowPrimitiveParameterRequireCleanConstant: requireClean,
-				}, nil
+				return workflow.RenameDirectoriesActionOptions{
+					RequireClean: requireClean,
+					IncludeOwner: includeOwner,
+				}.Options(), nil
 			},
 		},
 		{
@@ -404,13 +402,13 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if deleteError != nil {
 					return nil, deleteError
 				}
-				return map[string]any{
-					webWorkflowPrimitiveParameterSourceConstant:             sourceBranch,
-					webWorkflowPrimitiveParameterTargetConstant:             targetBranch,
-					webWorkflowPrimitiveParameterRemoteConstant:             remoteName,
-					webWorkflowPrimitiveParameterPushConstant:               pushToRemote,
-					webWorkflowPrimitiveParameterDeleteSourceBranchConstant: deleteSourceBranch,
-				}, nil
+				return workflow.BranchDefaultActionOptions{
+					RemoteName:         remoteName,
+					SourceBranch:       sourceBranch,
+					TargetBranch:       targetBranch,
+					PushToRemote:       pushToRemote,
+					DeleteSourceBranch: deleteSourceBranch,
+				}.Options(), nil
 			},
 		},
 		{
@@ -458,11 +456,11 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if remoteError != nil {
 					return nil, remoteError
 				}
-				return workflowPrimitiveOptions(map[string]string{
-					webWorkflowPrimitiveParameterTagConstant:     tagName,
-					webWorkflowPrimitiveParameterMessageConstant: message,
-					webWorkflowPrimitiveParameterRemoteConstant:  remoteName,
-				}), nil
+				return workflow.ReleaseTagActionOptions{
+					TagName:    tagName,
+					Message:    message,
+					RemoteName: remoteName,
+				}.Options(), nil
 			},
 		},
 		{
@@ -498,13 +496,10 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if mappingsError != nil {
 					return nil, mappingsError
 				}
-				options := map[string]any{
-					webWorkflowPrimitiveParameterMappingsConstant: mappings,
-				}
-				if len(remoteName) > 0 {
-					options[webWorkflowPrimitiveParameterRemoteConstant] = remoteName
-				}
-				return options, nil
+				return workflow.ReleaseRetagActionOptions{
+					RemoteName: remoteName,
+					Mappings:   mappings,
+				}.Options(), nil
 			},
 		},
 		{
@@ -573,13 +568,12 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if outputError != nil {
 					return nil, outputError
 				}
-				return workflowPrimitiveOptions(map[string]string{
-					webWorkflowPrimitiveParameterDepthConstant:  inspectionDepth,
-					webWorkflowPrimitiveParameterOutputConstant: outputPath,
-				}, map[string]bool{
-					webWorkflowPrimitiveParameterIncludeAllConstant: includeAll,
-					webWorkflowPrimitiveParameterDebugConstant:      debugOutput,
-				}), nil
+				return workflow.AuditReportActionOptions{
+					IncludeAll: includeAll,
+					Debug:      debugOutput,
+					Depth:      audit.InspectionDepth(inspectionDepth),
+					OutputPath: outputPath,
+				}.Options(), nil
 			},
 		},
 		{
@@ -645,16 +639,13 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if pushMissingError != nil {
 					return nil, pushMissingError
 				}
-				options := map[string]any{
-					webWorkflowPrimitiveParameterPathsConstant:       paths,
-					webWorkflowPrimitiveParameterPushConstant:        pushEnabled,
-					webWorkflowPrimitiveParameterRestoreConstant:     restoreEnabled,
-					webWorkflowPrimitiveParameterPushMissingConstant: pushMissing,
-				}
-				if len(remoteName) > 0 {
-					options[webWorkflowPrimitiveParameterRemoteConstant] = remoteName
-				}
-				return options, nil
+				return workflow.HistoryPurgeActionOptions{
+					Paths:       paths,
+					RemoteName:  remoteName,
+					Push:        pushEnabled,
+					Restore:     restoreEnabled,
+					PushMissing: pushMissing,
+				}.Options(), nil
 			},
 		},
 		{
@@ -714,15 +705,12 @@ func (application *Application) webWorkflowPrimitiveDefinitions() []webWorkflowP
 				if commandError != nil {
 					return nil, commandError
 				}
-				options := map[string]any{
-					webWorkflowPrimitiveParameterPatternsConstant: patterns,
-					webWorkflowPrimitiveParameterFindConstant:     findValue,
-					webWorkflowPrimitiveParameterReplaceConstant:  replaceValue,
-				}
-				if len(commandValue) > 0 {
-					options[webWorkflowPrimitiveParameterCommandConstant] = commandValue
-				}
-				return options, nil
+				return workflow.FileReplaceActionOptions{
+					Patterns: patterns,
+					Find:     findValue,
+					Replace:  replaceValue,
+					Command:  strings.Fields(commandValue),
+				}.Options(), nil
 			},
 		},
 		{
@@ -986,7 +974,7 @@ func readWebWorkflowStringListParameter(parameters map[string]any, primitiveID s
 	return collected, nil
 }
 
-func readWebWorkflowRetagMappingsParameter(parameters map[string]any) ([]map[string]any, error) {
+func readWebWorkflowRetagMappingsParameter(parameters map[string]any) ([]workflow.ReleaseRetagMappingOptions, error) {
 	rawMappings, mappingsError := readWebWorkflowStringParameter(parameters, webWorkflowPrimitiveReleaseRetagConstant, webWorkflowPrimitiveParameterMappingsConstant, true, "")
 	if mappingsError != nil {
 		return nil, mappingsError
@@ -999,7 +987,7 @@ func readWebWorkflowRetagMappingsParameter(parameters map[string]any) ([]map[str
 		return nil, fmt.Errorf("%s: %w", webWorkflowPrimitiveRetagMappingsFormatConstant, readError)
 	}
 
-	mappings := make([]map[string]any, 0, len(records))
+	mappings := make([]workflow.ReleaseRetagMappingOptions, 0, len(records))
 	for _, record := range records {
 		trimmedRecord := make([]string, 0, len(record))
 		for _, column := range record {
@@ -1020,12 +1008,12 @@ func readWebWorkflowRetagMappingsParameter(parameters map[string]any) ([]map[str
 			return nil, errors.New(webWorkflowPrimitiveRetagMappingsFormatConstant)
 		}
 
-		mapping := map[string]any{
-			webWorkflowPrimitiveParameterTagConstant:    trimmedRecord[0],
-			webWorkflowPrimitiveParameterTargetConstant: trimmedRecord[1],
+		mapping := workflow.ReleaseRetagMappingOptions{
+			TagName:         trimmedRecord[0],
+			TargetReference: trimmedRecord[1],
 		}
 		if len(trimmedRecord) == 3 && len(trimmedRecord[2]) > 0 {
-			mapping[webWorkflowPrimitiveParameterMessageConstant] = trimmedRecord[2]
+			mapping.Message = trimmedRecord[2]
 		}
 		mappings = append(mappings, mapping)
 	}

--- a/cmd/cli/repos/protocol.go
+++ b/cmd/cli/repos/protocol.go
@@ -109,11 +109,10 @@ func (builder *ProtocolCommandBuilder) run(command *cobra.Command, arguments []s
 				if workflow.CommandPathKey(ctx.Configuration.Steps[index].Command) != protocolCommandKey {
 					continue
 				}
-				if ctx.Configuration.Steps[index].Options == nil {
-					ctx.Configuration.Steps[index].Options = make(map[string]any)
-				}
-				ctx.Configuration.Steps[index].Options["from"] = string(fromProtocol)
-				ctx.Configuration.Steps[index].Options["to"] = string(toProtocol)
+				ctx.Configuration.Steps[index].Options = workflow.MergeOptions(
+					ctx.Configuration.Steps[index].Options,
+					workflow.ProtocolConversionActionOptions{From: fromProtocol, To: toProtocol}.Options(),
+				)
 			}
 
 			return workflowcmd.PresetCommandResult{

--- a/cmd/cli/repos/release/command.go
+++ b/cmd/cli/repos/release/command.go
@@ -111,23 +111,18 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 			if trimmedTag != "" {
 				displayName = fmt.Sprintf("Create release tag %s", trimmedTag)
 			}
-			actionOptions := map[string]any{
-				"tag": trimmedTag,
-			}
-			if trimmedMessage := strings.TrimSpace(messageValue); trimmedMessage != "" {
-				actionOptions["message"] = trimmedMessage
-			}
-			if trimmedRemote := strings.TrimSpace(resolvedRemote); trimmedRemote != "" {
-				actionOptions["remote"] = trimmedRemote
-			}
 
 			taskDefinition := workflow.TaskDefinition{
 				Name:        displayName,
 				EnsureClean: false,
 				Actions: []workflow.TaskActionDefinition{
 					{
-						Type:    "repo.release.tag",
-						Options: actionOptions,
+						Type: workflow.TaskActionReleaseTagType,
+						Options: workflow.ReleaseTagActionOptions{
+							TagName:    trimmedTag,
+							Message:    messageValue,
+							RemoteName: resolvedRemote,
+						}.Options(),
 					},
 				},
 			}

--- a/cmd/cli/repos/remotes.go
+++ b/cmd/cli/repos/remotes.go
@@ -84,10 +84,10 @@ func (builder *RemotesCommandBuilder) run(command *cobra.Command, arguments []st
 				if workflow.CommandPathKey(ctx.Configuration.Steps[index].Command) != remoteCanonicalCommandKey {
 					continue
 				}
-				if ctx.Configuration.Steps[index].Options == nil {
-					ctx.Configuration.Steps[index].Options = make(map[string]any)
-				}
-				ctx.Configuration.Steps[index].Options["owner"] = trimmedOwner
+				ctx.Configuration.Steps[index].Options = workflow.MergeOptions(
+					ctx.Configuration.Steps[index].Options,
+					workflow.CanonicalRemoteActionOptions{Owner: trimmedOwner}.Options(),
+				)
 			}
 
 			return workflowcmd.PresetCommandResult{

--- a/cmd/cli/repos/remove.go
+++ b/cmd/cli/repos/remove.go
@@ -144,14 +144,14 @@ func (builder *RemoveCommandBuilder) run(command *cobra.Command, arguments []str
 				EnsureClean: true,
 				Actions: []workflow.TaskActionDefinition{
 					{
-						Type: "repo.history.purge",
-						Options: map[string]any{
-							"paths":        append([]string{}, normalizedPaths...),
-							"remote":       strings.TrimSpace(remoteName),
-							"push":         pushEnabled,
-							"restore":      restoreEnabled,
-							"push_missing": pushMissing,
-						},
+						Type: workflow.TaskActionHistoryPurgeType,
+						Options: workflow.HistoryPurgeActionOptions{
+							Paths:       normalizedPaths,
+							RemoteName:  remoteName,
+							Push:        pushEnabled,
+							Restore:     restoreEnabled,
+							PushMissing: pushMissing,
+						}.Options(),
 					},
 				},
 			}

--- a/cmd/cli/repos/rename.go
+++ b/cmd/cli/repos/rename.go
@@ -97,11 +97,13 @@ func (builder *RenameCommandBuilder) run(command *cobra.Command, arguments []str
 				if workflow.CommandPathKey(ctx.Configuration.Steps[index].Command) != folderRenameCommandKey {
 					continue
 				}
-				if ctx.Configuration.Steps[index].Options == nil {
-					ctx.Configuration.Steps[index].Options = make(map[string]any)
-				}
-				ctx.Configuration.Steps[index].Options["require_clean"] = requireClean
-				ctx.Configuration.Steps[index].Options["include_owner"] = includeOwner
+				ctx.Configuration.Steps[index].Options = workflow.MergeOptions(
+					ctx.Configuration.Steps[index].Options,
+					workflow.RenameDirectoriesActionOptions{
+						RequireClean: requireClean,
+						IncludeOwner: includeOwner,
+					}.Options(),
+				)
 			}
 
 			runtimeOptions := ctx.RuntimeOptions()

--- a/cmd/cli/repos/replace.go
+++ b/cmd/cli/repos/replace.go
@@ -150,26 +150,25 @@ func (builder *ReplaceCommandBuilder) run(command *cobra.Command, _ []string) er
 		PresetLoadErrorTemplate: replacePresetLoadError,
 		BuildErrorTemplate:      replaceBuildWorkflowError,
 		Configure: func(ctx workflowcmd.PresetCommandContext) (workflowcmd.PresetCommandResult, error) {
-			params := filesReplacePresetOptions{
-				Patterns:     patterns,
-				Find:         findValue,
-				Replace:      replaceValue,
-				Command:      commandArguments,
-				RequireClean: requireClean,
-				Branch:       branchValue,
-				RequirePaths: requiredPaths,
-			}
-
 			taskDefinition := workflow.TaskDefinition{
 				Name:        "Replace repository file content",
 				EnsureClean: requireClean,
 				Actions: []workflow.TaskActionDefinition{
 					{
-						Type:    "repo.files.replace",
-						Options: buildFilesReplaceActionOptions(params),
+						Type: workflow.TaskActionFileReplaceType,
+						Options: workflow.FileReplaceActionOptions{
+							Patterns: patterns,
+							Find:     findValue,
+							Replace:  replaceValue,
+							Command:  commandArguments,
+						}.Options(),
 					},
 				},
-				Safeguards: buildFilesReplaceSafeguards(params),
+				Safeguards: workflow.FileReplaceSafeguardOptions{
+					RequireClean: requireClean,
+					Branch:       branchValue,
+					Paths:        requiredPaths,
+				}.Options(),
 			}
 
 			for index := range ctx.Configuration.Steps {
@@ -224,61 +223,4 @@ func sanitizeCommandArguments(arguments []string) []string {
 		return nil
 	}
 	return sanitized
-}
-
-type filesReplacePresetOptions struct {
-	Patterns     []string
-	Find         string
-	Replace      string
-	Command      []string
-	RequireClean bool
-	Branch       string
-	RequirePaths []string
-}
-
-func buildFilesReplaceActionOptions(params filesReplacePresetOptions) map[string]any {
-	options := map[string]any{
-		"find":    params.Find,
-		"replace": params.Replace,
-	}
-
-	if len(params.Patterns) == 1 {
-		options["pattern"] = params.Patterns[0]
-	} else if len(params.Patterns) > 1 {
-		options["patterns"] = append([]string{}, params.Patterns...)
-	}
-
-	if len(params.Command) > 0 {
-		options["command"] = append([]string{}, params.Command...)
-	}
-
-	return options
-}
-
-func buildFilesReplaceSafeguards(params filesReplacePresetOptions) map[string]any {
-	hardSafeguards := map[string]any{}
-	if params.RequireClean {
-		hardSafeguards["require_clean"] = true
-	}
-
-	softSafeguards := map[string]any{}
-	if len(strings.TrimSpace(params.Branch)) > 0 {
-		softSafeguards["branch"] = params.Branch
-	}
-	if len(params.RequirePaths) > 0 {
-		softSafeguards["paths"] = append([]string{}, params.RequirePaths...)
-	}
-
-	if len(hardSafeguards) == 0 && len(softSafeguards) == 0 {
-		return nil
-	}
-
-	safeguardOptions := make(map[string]any)
-	if len(hardSafeguards) > 0 {
-		safeguardOptions["hard_stop"] = hardSafeguards
-	}
-	if len(softSafeguards) > 0 {
-		safeguardOptions["soft_skip"] = softSafeguards
-	}
-	return safeguardOptions
 }

--- a/cmd/cli/workflow/run.go
+++ b/cmd/cli/workflow/run.go
@@ -327,37 +327,20 @@ func applyVariableOverrides(configuration *workflow.Configuration, variables map
 				continue
 			}
 
-			historyOptions, ok := historyActionOptions(configuration.Steps[stepIndex].Options)
-			if !ok {
-				continue
-			}
-
-			pushValue := historyPush
-			if !historyPushProvided {
-				pushValue = readHistoryBooleanOption(historyOptions, "push", true)
-			}
-			restoreValue := historyRestore
-			if !historyRestoreProvided {
-				restoreValue = readHistoryBooleanOption(historyOptions, "restore", true)
-			}
-			pushMissingValue := historyPushMissing
-			if !historyPushMissingProvided {
-				pushMissingValue = readHistoryBooleanOption(historyOptions, "push_missing", false)
-			}
-
-			selectedPaths := historyPaths
-			if len(selectedPaths) == 0 {
-				selectedPaths = readHistoryPathsOption(historyOptions)
-			}
-
-			configuration.Steps[stepIndex].Options = applyHistoryVariableOverrides(
+			updatedOptions, _, historyOverrideError := workflow.ApplyHistoryPurgeActionOverrides(
 				configuration.Steps[stepIndex].Options,
-				selectedPaths,
-				historyRemote,
-				pushValue,
-				restoreValue,
-				pushMissingValue,
+				workflow.HistoryPurgeActionOverrides{
+					Paths:       historyPaths,
+					RemoteName:  historyRemote,
+					Push:        workflowBooleanOverride(historyPush, historyPushProvided),
+					Restore:     workflowBooleanOverride(historyRestore, historyRestoreProvided),
+					PushMissing: workflowBooleanOverride(historyPushMissing, historyPushMissingProvided),
+				},
 			)
+			if historyOverrideError != nil {
+				return historyOverrideError
+			}
+			configuration.Steps[stepIndex].Options = updatedOptions
 		}
 	}
 
@@ -398,116 +381,11 @@ func parseWorkflowBooleanVariable(rawValue string) (bool, bool) {
 	return parsed, true
 }
 
-func historyActionOptions(options map[string]any) (map[string]any, bool) {
-	if options == nil {
-		return nil, false
-	}
-	tasksValue, ok := options["tasks"].([]any)
-	if !ok || len(tasksValue) == 0 {
-		return nil, false
-	}
-	taskEntry, ok := tasksValue[0].(map[string]any)
-	if !ok {
-		return nil, false
-	}
-	actionsValue, ok := taskEntry["actions"].([]any)
-	if !ok || len(actionsValue) == 0 {
-		return nil, false
-	}
-	actionEntry, ok := actionsValue[0].(map[string]any)
-	if !ok {
-		return nil, false
-	}
-	actionType, ok := actionEntry["type"].(string)
-	if !ok || !strings.EqualFold(strings.TrimSpace(actionType), "repo.history.purge") {
-		return nil, false
-	}
-	actionOptions, ok := actionEntry["options"].(map[string]any)
-	if !ok {
-		actionOptions = make(map[string]any)
-	}
-	return actionOptions, true
-}
-
-func readHistoryBooleanOption(options map[string]any, key string, fallback bool) bool {
-	if options == nil {
-		return fallback
-	}
-	if rawValue, ok := options[key]; ok {
-		if parsed, ok := rawValue.(bool); ok {
-			return parsed
-		}
-	}
-	return fallback
-}
-
-func readHistoryPathsOption(options map[string]any) []string {
-	if options == nil {
+func workflowBooleanOverride(value bool, provided bool) *bool {
+	if !provided {
 		return nil
 	}
-	if rawValue, ok := options["paths"].([]any); ok {
-		paths := make([]string, 0, len(rawValue))
-		for _, entry := range rawValue {
-			if text, ok := entry.(string); ok && len(strings.TrimSpace(text)) > 0 {
-				paths = append(paths, strings.TrimSpace(text))
-			}
-		}
-		return paths
-	}
-	if rawValue, ok := options["paths"].([]string); ok {
-		paths := make([]string, 0, len(rawValue))
-		for _, entry := range rawValue {
-			trimmed := strings.TrimSpace(entry)
-			if len(trimmed) == 0 {
-				continue
-			}
-			paths = append(paths, trimmed)
-		}
-		return paths
-	}
-	return nil
-}
-
-func applyHistoryVariableOverrides(options map[string]any, paths []string, remote string, push bool, restore bool, pushMissing bool) map[string]any {
-	if options == nil {
-		options = make(map[string]any)
-	}
-	tasksValue, ok := options["tasks"].([]any)
-	if !ok || len(tasksValue) == 0 {
-		return options
-	}
-	taskEntry, ok := tasksValue[0].(map[string]any)
-	if !ok {
-		return options
-	}
-	actionsValue, ok := taskEntry["actions"].([]any)
-	if !ok || len(actionsValue) == 0 {
-		return options
-	}
-	actionEntry, ok := actionsValue[0].(map[string]any)
-	if !ok {
-		return options
-	}
-	actionOptions, _ := actionEntry["options"].(map[string]any)
-	if actionOptions == nil {
-		actionOptions = make(map[string]any)
-	}
-	if len(paths) > 0 {
-		actionOptions["paths"] = append([]string{}, paths...)
-	}
-	if len(strings.TrimSpace(remote)) > 0 {
-		actionOptions["remote"] = strings.TrimSpace(remote)
-	}
-	actionOptions["push"] = push
-	actionOptions["restore"] = restore
-	actionOptions["push_missing"] = pushMissing
-
-	actionEntry["options"] = actionOptions
-	actionsValue[0] = actionEntry
-	taskEntry["actions"] = actionsValue
-	tasksValue[0] = taskEntry
-	options["tasks"] = tasksValue
-	return options
+	return &value
 }
 
 func (builder *CommandBuilder) resolvePresetCatalog() PresetCatalog {

--- a/internal/workflow/action_options_builder.go
+++ b/internal/workflow/action_options_builder.go
@@ -1,0 +1,448 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tyemirov/gix/internal/audit"
+	"github.com/tyemirov/gix/internal/repos/shared"
+)
+
+const (
+	// Task action identifiers shared by CLI commands, web primitives, and workflow builders.
+	TaskActionCanonicalRemoteType    = taskActionCanonicalRemote
+	TaskActionProtocolConversionType = taskActionProtocolConversion
+	TaskActionRenameDirectoriesType  = taskActionRenameDirectories
+	TaskActionBranchDefaultType      = taskActionBranchDefault
+	TaskActionReleaseTagType         = taskActionReleaseTag
+	TaskActionReleaseRetagType       = taskActionReleaseRetag
+	TaskActionAuditReportType        = taskActionAuditReport
+	TaskActionHistoryPurgeType       = taskActionHistoryPurge
+	TaskActionFileReplaceType        = taskActionFileReplace
+	TaskActionNamespaceRewriteType   = taskActionNamespaceRewrite
+)
+
+const (
+	actionOptionSourceKeyConstant             = "source"
+	actionOptionTargetKeyConstant             = "target"
+	actionOptionRemoteKeyConstant             = "remote"
+	actionOptionPushKeyConstant               = "push"
+	actionOptionDeleteSourceBranchKeyConstant = "delete_source_branch"
+	actionOptionTagKeyConstant                = "tag"
+	actionOptionMessageKeyConstant            = "message"
+	actionOptionMappingsKeyConstant           = "mappings"
+	actionOptionIncludeAllKeyConstant         = "include_all"
+	actionOptionDebugKeyConstant              = "debug"
+	actionOptionDepthKeyConstant              = "depth"
+	actionOptionRestoreKeyConstant            = "restore"
+	actionOptionPushMissingKeyConstant        = "push_missing"
+	safeguardHardStopKeyConstant              = "hard_stop"
+	safeguardSoftSkipKeyConstant              = "soft_skip"
+	safeguardBranchKeyConstant                = "branch"
+)
+
+// CanonicalRemoteActionOptions serializes repo.remote.update options.
+type CanonicalRemoteActionOptions struct {
+	Owner string
+}
+
+// Options returns workflow action options for canonical remote updates.
+func (options CanonicalRemoteActionOptions) Options() map[string]any {
+	return map[string]any{
+		optionOwnerKeyConstant: strings.TrimSpace(options.Owner),
+	}
+}
+
+// ProtocolConversionActionOptions serializes repo.remote.convert-protocol options.
+type ProtocolConversionActionOptions struct {
+	From shared.RemoteProtocol
+	To   shared.RemoteProtocol
+}
+
+// Options returns workflow action options for remote protocol conversion.
+func (options ProtocolConversionActionOptions) Options() map[string]any {
+	return compactStringOptions(map[string]string{
+		optionFromKeyConstant: string(options.From),
+		optionToKeyConstant:   string(options.To),
+	})
+}
+
+// RenameDirectoriesActionOptions serializes repo.folder.rename options.
+type RenameDirectoriesActionOptions struct {
+	RequireClean bool
+	IncludeOwner bool
+}
+
+// Options returns workflow action options for repository folder renames.
+func (options RenameDirectoriesActionOptions) Options() map[string]any {
+	return map[string]any{
+		optionRequireCleanKeyConstant: options.RequireClean,
+		optionIncludeOwnerKeyConstant: options.IncludeOwner,
+	}
+}
+
+// BranchDefaultActionOptions serializes branch.default action options.
+type BranchDefaultActionOptions struct {
+	RemoteName         string
+	SourceBranch       string
+	TargetBranch       string
+	PushToRemote       bool
+	DeleteSourceBranch bool
+}
+
+// Options returns workflow action options for default branch promotion.
+func (options BranchDefaultActionOptions) Options() map[string]any {
+	serialized := compactStringOptions(map[string]string{
+		actionOptionRemoteKeyConstant: options.RemoteName,
+		actionOptionSourceKeyConstant: options.SourceBranch,
+		actionOptionTargetKeyConstant: options.TargetBranch,
+	})
+	serialized[actionOptionPushKeyConstant] = options.PushToRemote
+	serialized[actionOptionDeleteSourceBranchKeyConstant] = options.DeleteSourceBranch
+	return serialized
+}
+
+// ReleaseTagActionOptions serializes repo.release.tag options.
+type ReleaseTagActionOptions struct {
+	TagName    string
+	Message    string
+	RemoteName string
+}
+
+// Options returns workflow action options for release tag creation.
+func (options ReleaseTagActionOptions) Options() map[string]any {
+	return compactStringOptions(map[string]string{
+		actionOptionTagKeyConstant:     options.TagName,
+		actionOptionMessageKeyConstant: options.Message,
+		actionOptionRemoteKeyConstant:  options.RemoteName,
+	})
+}
+
+// ReleaseRetagMappingOptions describes one repo.release.retag mapping.
+type ReleaseRetagMappingOptions struct {
+	TagName         string
+	TargetReference string
+	Message         string
+}
+
+// ReleaseRetagActionOptions serializes repo.release.retag options.
+type ReleaseRetagActionOptions struct {
+	RemoteName string
+	Mappings   []ReleaseRetagMappingOptions
+}
+
+// Options returns workflow action options for release retagging.
+func (options ReleaseRetagActionOptions) Options() map[string]any {
+	serialized := compactStringOptions(map[string]string{
+		actionOptionRemoteKeyConstant: options.RemoteName,
+	})
+	if len(options.Mappings) > 0 {
+		mappings := make([]map[string]any, 0, len(options.Mappings))
+		for mappingIndex := range options.Mappings {
+			mapping := options.Mappings[mappingIndex]
+			mappingOptions := compactStringOptions(map[string]string{
+				actionOptionTagKeyConstant:     mapping.TagName,
+				actionOptionTargetKeyConstant:  mapping.TargetReference,
+				actionOptionMessageKeyConstant: mapping.Message,
+			})
+			mappings = append(mappings, mappingOptions)
+		}
+		serialized[actionOptionMappingsKeyConstant] = mappings
+	}
+	return serialized
+}
+
+// AuditReportActionOptions serializes audit.report options.
+type AuditReportActionOptions struct {
+	IncludeAll bool
+	Debug      bool
+	Depth      audit.InspectionDepth
+	OutputPath string
+}
+
+// Options returns workflow action options for audit report generation.
+func (options AuditReportActionOptions) Options() map[string]any {
+	serialized := compactStringOptions(map[string]string{
+		actionOptionDepthKeyConstant: string(options.Depth),
+		optionOutputPathKeyConstant:  options.OutputPath,
+	})
+	serialized[actionOptionIncludeAllKeyConstant] = options.IncludeAll
+	serialized[actionOptionDebugKeyConstant] = options.Debug
+	return serialized
+}
+
+// HistoryPurgeActionOptions serializes repo.history.purge options.
+type HistoryPurgeActionOptions struct {
+	Paths       []string
+	RemoteName  string
+	Push        bool
+	Restore     bool
+	PushMissing bool
+}
+
+// Options returns workflow action options for repository history purges.
+func (options HistoryPurgeActionOptions) Options() map[string]any {
+	serialized := map[string]any{
+		optionPathsKeyConstant:             cloneStringSlice(options.Paths),
+		actionOptionPushKeyConstant:        options.Push,
+		actionOptionRestoreKeyConstant:     options.Restore,
+		actionOptionPushMissingKeyConstant: options.PushMissing,
+	}
+	if trimmedRemote := strings.TrimSpace(options.RemoteName); trimmedRemote != "" {
+		serialized[actionOptionRemoteKeyConstant] = trimmedRemote
+	}
+	return serialized
+}
+
+// FileReplaceActionOptions serializes repo.files.replace options.
+type FileReplaceActionOptions struct {
+	Patterns []string
+	Find     string
+	Replace  string
+	Command  []string
+}
+
+// Options returns workflow action options for repository file replacement.
+func (options FileReplaceActionOptions) Options() map[string]any {
+	serialized := map[string]any{
+		fileReplaceFindOptionKey:    strings.TrimSpace(options.Find),
+		fileReplaceReplaceOptionKey: options.Replace,
+	}
+
+	normalizedPatterns := compactStringSlice(options.Patterns)
+	switch len(normalizedPatterns) {
+	case 0:
+	case 1:
+		serialized[fileReplacePatternOptionKey] = normalizedPatterns[0]
+	default:
+		serialized[fileReplacePatternsOptionKey] = normalizedPatterns
+	}
+
+	command := compactStringSlice(options.Command)
+	if len(command) > 0 {
+		serialized[fileReplaceCommandOptionKey] = command
+	}
+
+	return serialized
+}
+
+// FileReplaceSafeguardOptions serializes safeguards for repo.files.replace presets.
+type FileReplaceSafeguardOptions struct {
+	RequireClean bool
+	Branch       string
+	Paths        []string
+}
+
+// Options returns task safeguard options for repository file replacement.
+func (options FileReplaceSafeguardOptions) Options() map[string]any {
+	hardStop := map[string]any{}
+	if options.RequireClean {
+		hardStop[optionRequireCleanKeyConstant] = true
+	}
+
+	softSkip := compactStringOptions(map[string]string{
+		safeguardBranchKeyConstant: options.Branch,
+	})
+	if paths := compactStringSlice(options.Paths); len(paths) > 0 {
+		softSkip[optionPathsKeyConstant] = paths
+	}
+
+	serialized := map[string]any{}
+	if len(hardStop) > 0 {
+		serialized[safeguardHardStopKeyConstant] = hardStop
+	}
+	if len(softSkip) > 0 {
+		serialized[safeguardSoftSkipKeyConstant] = softSkip
+	}
+	if len(serialized) == 0 {
+		return nil
+	}
+	return serialized
+}
+
+// HistoryPurgeActionOverrides describes variable-driven updates to a history purge action.
+type HistoryPurgeActionOverrides struct {
+	Paths       []string
+	RemoteName  string
+	Push        *bool
+	Restore     *bool
+	PushMissing *bool
+}
+
+// Empty reports whether the override carries no action changes.
+func (overrides HistoryPurgeActionOverrides) Empty() bool {
+	return len(overrides.Paths) == 0 &&
+		strings.TrimSpace(overrides.RemoteName) == "" &&
+		overrides.Push == nil &&
+		overrides.Restore == nil &&
+		overrides.PushMissing == nil
+}
+
+// ApplyHistoryPurgeActionOverrides updates the first history purge action embedded in tasks.apply options.
+func ApplyHistoryPurgeActionOverrides(options map[string]any, overrides HistoryPurgeActionOverrides) (map[string]any, bool, error) {
+	if len(options) == 0 || overrides.Empty() {
+		return options, false, nil
+	}
+
+	tasksValue, tasksExist := options[optionTasksKeyConstant].([]any)
+	if !tasksExist {
+		return options, false, nil
+	}
+
+	for taskIndex := range tasksValue {
+		taskEntry, taskOk := tasksValue[taskIndex].(map[string]any)
+		if !taskOk {
+			continue
+		}
+
+		actionsValue, actionsExist := taskEntry[optionTaskActionsKeyConstant].([]any)
+		if !actionsExist {
+			continue
+		}
+
+		for actionIndex := range actionsValue {
+			actionEntry, actionOk := actionsValue[actionIndex].(map[string]any)
+			if !actionOk {
+				continue
+			}
+
+			actionType, typeOk := actionEntry[optionTaskActionTypeKeyConstant].(string)
+			if !typeOk || !strings.EqualFold(strings.TrimSpace(actionType), taskActionHistoryPurge) {
+				continue
+			}
+
+			actionOptions, mergeError := mergeHistoryPurgeActionOptions(actionEntry[optionTaskActionOptionsKeyConstant], overrides)
+			if mergeError != nil {
+				return options, false, mergeError
+			}
+
+			actionEntry[optionTaskActionOptionsKeyConstant] = actionOptions
+			actionsValue[actionIndex] = actionEntry
+			taskEntry[optionTaskActionsKeyConstant] = actionsValue
+			tasksValue[taskIndex] = taskEntry
+			options[optionTasksKeyConstant] = tasksValue
+			return options, true, nil
+		}
+	}
+
+	return options, false, nil
+}
+
+func mergeHistoryPurgeActionOptions(rawOptions any, overrides HistoryPurgeActionOverrides) (map[string]any, error) {
+	currentOptions := map[string]any{}
+	if rawOptions != nil {
+		var optionsOk bool
+		currentOptions, optionsOk = rawOptions.(map[string]any)
+		if !optionsOk {
+			return nil, fmt.Errorf("history purge action options must be a map")
+		}
+	}
+
+	merged, readError := readHistoryPurgeActionOptions(currentOptions)
+	if readError != nil {
+		return nil, readError
+	}
+	if len(overrides.Paths) > 0 {
+		merged.Paths = compactStringSlice(overrides.Paths)
+	}
+	if remoteName := strings.TrimSpace(overrides.RemoteName); remoteName != "" {
+		merged.RemoteName = remoteName
+	}
+	if overrides.Push != nil {
+		merged.Push = *overrides.Push
+	}
+	if overrides.Restore != nil {
+		merged.Restore = *overrides.Restore
+	}
+	if overrides.PushMissing != nil {
+		merged.PushMissing = *overrides.PushMissing
+	}
+
+	return merged.Options(), nil
+}
+
+func readHistoryPurgeActionOptions(options map[string]any) (HistoryPurgeActionOptions, error) {
+	reader := newOptionReader(options)
+	merged := HistoryPurgeActionOptions{
+		Push:    true,
+		Restore: true,
+	}
+
+	if rawPaths, pathsExist := options[optionPathsKeyConstant]; pathsExist {
+		paths, pathsError := readHistoryPaths(rawPaths)
+		if pathsError != nil {
+			return HistoryPurgeActionOptions{}, pathsError
+		}
+		merged.Paths = paths
+	}
+
+	remoteName, _, remoteError := reader.stringValue(actionOptionRemoteKeyConstant)
+	if remoteError != nil {
+		return HistoryPurgeActionOptions{}, remoteError
+	}
+	merged.RemoteName = remoteName
+
+	if push, pushExists, pushError := reader.boolValue(actionOptionPushKeyConstant); pushError != nil {
+		return HistoryPurgeActionOptions{}, pushError
+	} else if pushExists {
+		merged.Push = push
+	}
+	if restore, restoreExists, restoreError := reader.boolValue(actionOptionRestoreKeyConstant); restoreError != nil {
+		return HistoryPurgeActionOptions{}, restoreError
+	} else if restoreExists {
+		merged.Restore = restore
+	}
+	if pushMissing, pushMissingExists, pushMissingError := reader.boolValue(actionOptionPushMissingKeyConstant); pushMissingError != nil {
+		return HistoryPurgeActionOptions{}, pushMissingError
+	} else if pushMissingExists {
+		merged.PushMissing = pushMissing
+	}
+
+	return merged, nil
+}
+
+func compactStringOptions(options map[string]string) map[string]any {
+	serialized := map[string]any{}
+	for key, value := range options {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			serialized[key] = trimmed
+		}
+	}
+	return serialized
+}
+
+func compactStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	serialized := make([]string, 0, len(values))
+	for valueIndex := range values {
+		trimmed := strings.TrimSpace(values[valueIndex])
+		if trimmed != "" {
+			serialized = append(serialized, trimmed)
+		}
+	}
+	if len(serialized) == 0 {
+		return nil
+	}
+	return serialized
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return append([]string{}, values...)
+}
+
+// MergeOptions returns a new workflow options map with override values applied.
+func MergeOptions(base map[string]any, overrides map[string]any) map[string]any {
+	merged := cloneStringAnyMap(base)
+	if merged == nil {
+		merged = map[string]any{}
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
+}

--- a/internal/workflow/action_options_builder_test.go
+++ b/internal/workflow/action_options_builder_test.go
@@ -1,0 +1,179 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tyemirov/gix/internal/audit"
+	"github.com/tyemirov/gix/internal/repos/shared"
+)
+
+func TestActionOptionBuildersSerializeWorkflowContracts(testingInstance *testing.T) {
+	testCases := []struct {
+		name     string
+		options  map[string]any
+		expected map[string]any
+	}{
+		{
+			name: "protocol conversion options",
+			options: ProtocolConversionActionOptions{
+				From: shared.RemoteProtocolHTTPS,
+				To:   shared.RemoteProtocolSSH,
+			}.Options(),
+			expected: map[string]any{
+				optionFromKeyConstant: string(shared.RemoteProtocolHTTPS),
+				optionToKeyConstant:   string(shared.RemoteProtocolSSH),
+			},
+		},
+		{
+			name: "history purge options",
+			options: HistoryPurgeActionOptions{
+				Paths:       []string{"secret.txt", "nested/token.env"},
+				RemoteName:  "origin",
+				Push:        false,
+				Restore:     true,
+				PushMissing: true,
+			}.Options(),
+			expected: map[string]any{
+				optionPathsKeyConstant:             []string{"secret.txt", "nested/token.env"},
+				actionOptionRemoteKeyConstant:      "origin",
+				actionOptionPushKeyConstant:        false,
+				actionOptionRestoreKeyConstant:     true,
+				actionOptionPushMissingKeyConstant: true,
+			},
+		},
+		{
+			name: "file replace options",
+			options: FileReplaceActionOptions{
+				Patterns: []string{"README.md", "docs/*.md"},
+				Find:     "old",
+				Replace:  "new",
+				Command:  []string{"go", "test", "./..."},
+			}.Options(),
+			expected: map[string]any{
+				fileReplacePatternsOptionKey: []string{"README.md", "docs/*.md"},
+				fileReplaceFindOptionKey:     "old",
+				fileReplaceReplaceOptionKey:  "new",
+				fileReplaceCommandOptionKey:  []string{"go", "test", "./..."},
+			},
+		},
+		{
+			name: "audit report options",
+			options: AuditReportActionOptions{
+				IncludeAll: true,
+				Debug:      true,
+				Depth:      audit.InspectionDepthMinimal,
+				OutputPath: "audit.csv",
+			}.Options(),
+			expected: map[string]any{
+				actionOptionIncludeAllKeyConstant: true,
+				actionOptionDebugKeyConstant:      true,
+				actionOptionDepthKeyConstant:      string(audit.InspectionDepthMinimal),
+				optionOutputPathKeyConstant:       "audit.csv",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subtest *testing.T) {
+			require.Equal(subtest, testCase.expected, testCase.options)
+		})
+	}
+}
+
+func TestFileReplaceSafeguardOptionsSerializeHardAndSoftSets(testingInstance *testing.T) {
+	options := FileReplaceSafeguardOptions{
+		RequireClean: true,
+		Branch:       "main",
+		Paths:        []string{"go.mod", "cmd/root.go"},
+	}.Options()
+
+	require.Equal(testingInstance, map[string]any{
+		safeguardHardStopKeyConstant: map[string]any{
+			optionRequireCleanKeyConstant: true,
+		},
+		safeguardSoftSkipKeyConstant: map[string]any{
+			safeguardBranchKeyConstant: "main",
+			optionPathsKeyConstant:     []string{"go.mod", "cmd/root.go"},
+		},
+	}, options)
+}
+
+func TestReleaseRetagActionOptionsSerializeTypedMappings(testingInstance *testing.T) {
+	options := ReleaseRetagActionOptions{
+		RemoteName: "origin",
+		Mappings: []ReleaseRetagMappingOptions{
+			{TagName: "v1.2.3", TargetReference: "main", Message: "Retag main"},
+			{TagName: "v1.2.4", TargetReference: "release"},
+		},
+	}.Options()
+
+	require.Equal(testingInstance, "origin", options[actionOptionRemoteKeyConstant])
+	entries, exists, readError := newOptionReader(options).mapSlice(actionOptionMappingsKeyConstant)
+	require.NoError(testingInstance, readError)
+	require.True(testingInstance, exists)
+	require.Equal(testingInstance, []map[string]any{
+		{
+			actionOptionTagKeyConstant:     "v1.2.3",
+			actionOptionTargetKeyConstant:  "main",
+			actionOptionMessageKeyConstant: "Retag main",
+		},
+		{
+			actionOptionTagKeyConstant:    "v1.2.4",
+			actionOptionTargetKeyConstant: "release",
+		},
+	}, entries)
+}
+
+func TestApplyHistoryPurgeActionOverridesMergesFirstHistoryAction(testingInstance *testing.T) {
+	options := TasksApplyDefinition{
+		Tasks: []TaskDefinition{
+			{
+				Name: "Mixed actions",
+				Actions: []TaskActionDefinition{
+					{
+						Type: TaskActionNamespaceRewriteType,
+						Options: map[string]any{
+							actionOptionPushKeyConstant: "{{ .Environment.namespace_push }}",
+						},
+					},
+					{
+						Type: TaskActionHistoryPurgeType,
+						Options: HistoryPurgeActionOptions{
+							Paths:       []string{"secret.txt"},
+							RemoteName:  "origin",
+							Push:        true,
+							Restore:     true,
+							PushMissing: false,
+						}.Options(),
+					},
+				},
+			},
+		},
+	}.Options()
+
+	pushOverride := false
+	updated, applied, applyError := ApplyHistoryPurgeActionOverrides(options, HistoryPurgeActionOverrides{
+		Paths: []string{"public.txt"},
+		Push:  &pushOverride,
+	})
+
+	require.NoError(testingInstance, applyError)
+	require.True(testingInstance, applied)
+
+	tasks := updated[optionTasksKeyConstant].([]any)
+	taskEntry := tasks[0].(map[string]any)
+	actions := taskEntry[optionTaskActionsKeyConstant].([]any)
+	namespaceAction := actions[0].(map[string]any)
+	namespaceOptions := namespaceAction[optionTaskActionOptionsKeyConstant].(map[string]any)
+	require.Equal(testingInstance, "{{ .Environment.namespace_push }}", namespaceOptions[actionOptionPushKeyConstant])
+
+	historyAction := actions[1].(map[string]any)
+	historyOptions := historyAction[optionTaskActionOptionsKeyConstant].(map[string]any)
+	require.Equal(testingInstance, []string{"public.txt"}, historyOptions[optionPathsKeyConstant])
+	require.Equal(testingInstance, "origin", historyOptions[actionOptionRemoteKeyConstant])
+	require.Equal(testingInstance, false, historyOptions[actionOptionPushKeyConstant])
+	require.Equal(testingInstance, true, historyOptions[actionOptionRestoreKeyConstant])
+	require.Equal(testingInstance, false, historyOptions[actionOptionPushMissingKeyConstant])
+}

--- a/internal/workflow/options_reader.go
+++ b/internal/workflow/options_reader.go
@@ -76,6 +76,12 @@ func (reader optionReader) mapSlice(key string) ([]map[string]any, bool, error) 
 	if !exists {
 		return nil, false, nil
 	}
+	typedMaps, mapsOk := value.([]map[string]any)
+	if mapsOk {
+		maps := make([]map[string]any, 0, len(typedMaps))
+		maps = append(maps, typedMaps...)
+		return maps, true, nil
+	}
 	listValue, ok := value.([]any)
 	if !ok {
 		return nil, true, fmt.Errorf("option %s must be a list", key)

--- a/internal/workflow/task_actions.go
+++ b/internal/workflow/task_actions.go
@@ -88,7 +88,7 @@ func RegisterTaskAction(actionType string, handler taskActionHandlerFunc) {
 
 func handleCanonicalRemoteAction(ctx context.Context, environment *Environment, repository *RepositoryState, parameters map[string]any) error {
 	reader := newOptionReader(parameters)
-	ownerConstraint, _, ownerError := reader.stringValue("owner")
+	ownerConstraint, _, ownerError := reader.stringValue(optionOwnerKeyConstant)
 	if ownerError != nil {
 		return ownerError
 	}
@@ -101,7 +101,7 @@ func handleCanonicalRemoteAction(ctx context.Context, environment *Environment, 
 func handleProtocolConversionAction(ctx context.Context, environment *Environment, repository *RepositoryState, parameters map[string]any) error {
 	reader := newOptionReader(parameters)
 
-	targetValue, targetExists, targetError := reader.stringValue("to")
+	targetValue, targetExists, targetError := reader.stringValue(optionToKeyConstant)
 	if targetError != nil {
 		return targetError
 	}
@@ -115,7 +115,7 @@ func handleProtocolConversionAction(ctx context.Context, environment *Environmen
 	}
 
 	fromProtocol := shared.RemoteProtocol(strings.TrimSpace(string(repository.Inspection.RemoteProtocol)))
-	sourceValue, sourceExists, sourceError := reader.stringValue("from")
+	sourceValue, sourceExists, sourceError := reader.stringValue(optionFromKeyConstant)
 	if sourceError != nil {
 		return sourceError
 	}
@@ -137,7 +137,7 @@ func handleRenameDirectoriesAction(ctx context.Context, environment *Environment
 
 	requireClean := true
 	requireCleanExplicit := false
-	if value, exists, err := reader.boolValue("require_clean"); err != nil {
+	if value, exists, err := reader.boolValue(optionRequireCleanKeyConstant); err != nil {
 		return err
 	} else if exists {
 		requireClean = value
@@ -145,7 +145,7 @@ func handleRenameDirectoriesAction(ctx context.Context, environment *Environment
 	}
 
 	includeOwner := false
-	if value, exists, err := reader.boolValue("include_owner"); err != nil {
+	if value, exists, err := reader.boolValue(optionIncludeOwnerKeyConstant); err != nil {
 		return err
 	} else if exists {
 		includeOwner = value
@@ -163,17 +163,17 @@ func handleRenameDirectoriesAction(ctx context.Context, environment *Environment
 func handleBranchDefaultAction(ctx context.Context, environment *Environment, repository *RepositoryState, parameters map[string]any) error {
 	reader := newOptionReader(parameters)
 
-	targetBranchValue, _, targetBranchError := reader.stringValue("target")
+	targetBranchValue, _, targetBranchError := reader.stringValue(actionOptionTargetKeyConstant)
 	if targetBranchError != nil {
 		return targetBranchError
 	}
 
-	sourceBranchValue, _, sourceBranchError := reader.stringValue("source")
+	sourceBranchValue, _, sourceBranchError := reader.stringValue(actionOptionSourceKeyConstant)
 	if sourceBranchError != nil {
 		return sourceBranchError
 	}
 
-	remoteNameValue, remoteNameExists, remoteNameError := reader.stringValue("remote")
+	remoteNameValue, remoteNameExists, remoteNameError := reader.stringValue(actionOptionRemoteKeyConstant)
 	if remoteNameError != nil {
 		return remoteNameError
 	}
@@ -183,14 +183,14 @@ func handleBranchDefaultAction(ctx context.Context, environment *Environment, re
 	}
 
 	pushToRemote := true
-	if value, exists, err := reader.boolValue("push"); err != nil {
+	if value, exists, err := reader.boolValue(actionOptionPushKeyConstant); err != nil {
 		return err
 	} else if exists {
 		pushToRemote = value
 	}
 
 	deleteSource := false
-	if value, exists, err := reader.boolValue("delete_source_branch"); err != nil {
+	if value, exists, err := reader.boolValue(actionOptionDeleteSourceBranchKeyConstant); err != nil {
 		return err
 	} else if exists {
 		deleteSource = value
@@ -216,7 +216,7 @@ func handleReleaseTagAction(ctx context.Context, environment *Environment, repos
 
 	reader := newOptionReader(parameters)
 
-	tagValue, tagExists, tagError := reader.stringValue("tag")
+	tagValue, tagExists, tagError := reader.stringValue(actionOptionTagKeyConstant)
 	if tagError != nil {
 		return tagError
 	}
@@ -224,12 +224,12 @@ func handleReleaseTagAction(ctx context.Context, environment *Environment, repos
 		return errors.New("release action requires 'tag'")
 	}
 
-	messageValue, _, messageError := reader.stringValue("message")
+	messageValue, _, messageError := reader.stringValue(actionOptionMessageKeyConstant)
 	if messageError != nil {
 		return messageError
 	}
 
-	remoteValue, _, remoteError := reader.stringValue("remote")
+	remoteValue, _, remoteError := reader.stringValue(actionOptionRemoteKeyConstant)
 	if remoteError != nil {
 		return remoteError
 	}
@@ -263,12 +263,12 @@ func handleReleaseRetagAction(ctx context.Context, environment *Environment, rep
 
 	reader := newOptionReader(parameters)
 
-	remoteValue, _, remoteError := reader.stringValue("remote")
+	remoteValue, _, remoteError := reader.stringValue(actionOptionRemoteKeyConstant)
 	if remoteError != nil {
 		return remoteError
 	}
 
-	mappingEntries, mappingsExist, mappingsError := reader.mapSlice("mappings")
+	mappingEntries, mappingsExist, mappingsError := reader.mapSlice(actionOptionMappingsKeyConstant)
 	if mappingsError != nil {
 		return mappingsError
 	}
@@ -280,7 +280,7 @@ func handleReleaseRetagAction(ctx context.Context, environment *Environment, rep
 	for _, entry := range mappingEntries {
 		entryReader := newOptionReader(entry)
 
-		tagValue, tagExists, tagError := entryReader.stringValue("tag")
+		tagValue, tagExists, tagError := entryReader.stringValue(actionOptionTagKeyConstant)
 		if tagError != nil {
 			return tagError
 		}
@@ -288,7 +288,7 @@ func handleReleaseRetagAction(ctx context.Context, environment *Environment, rep
 			return errors.New("retag mapping requires 'tag'")
 		}
 
-		targetValue, targetExists, targetError := entryReader.stringValue("target")
+		targetValue, targetExists, targetError := entryReader.stringValue(actionOptionTargetKeyConstant)
 		if targetError != nil {
 			return targetError
 		}
@@ -296,7 +296,7 @@ func handleReleaseRetagAction(ctx context.Context, environment *Environment, rep
 			return errors.New("retag mapping requires 'target'")
 		}
 
-		messageValue, _, messageError := entryReader.stringValue("message")
+		messageValue, _, messageError := entryReader.stringValue(actionOptionMessageKeyConstant)
 		if messageError != nil {
 			return messageError
 		}
@@ -337,16 +337,16 @@ func handleAuditReportAction(ctx context.Context, environment *Environment, repo
 	}
 
 	reader := newOptionReader(parameters)
-	includeAll, _, includeAllError := reader.boolValue("include_all")
+	includeAll, _, includeAllError := reader.boolValue(actionOptionIncludeAllKeyConstant)
 	if includeAllError != nil {
 		return includeAllError
 	}
-	debugOutput, _, debugError := reader.boolValue("debug")
+	debugOutput, _, debugError := reader.boolValue(actionOptionDebugKeyConstant)
 	if debugError != nil {
 		return debugError
 	}
 
-	depthValue, _, depthError := reader.stringValue("depth")
+	depthValue, _, depthError := reader.stringValue(actionOptionDepthKeyConstant)
 	if depthError != nil {
 		return depthError
 	}
@@ -361,7 +361,7 @@ func handleAuditReportAction(ctx context.Context, environment *Environment, repo
 		return nil
 	}
 
-	outputValue, outputExists, outputError := reader.stringValue("output")
+	outputValue, outputExists, outputError := reader.stringValue(optionOutputPathKeyConstant)
 	if outputError != nil {
 		return outputError
 	}
@@ -467,7 +467,7 @@ func handleHistoryPurgeAction(ctx context.Context, environment *Environment, rep
 		return nil
 	}
 
-	rawPaths, exists := parameters["paths"]
+	rawPaths, exists := parameters[optionPathsKeyConstant]
 	if !exists {
 		return errors.New("history purge action requires 'paths'")
 	}
@@ -483,27 +483,27 @@ func handleHistoryPurgeAction(ctx context.Context, environment *Environment, rep
 
 	reader := newOptionReader(parameters)
 
-	remoteName, _, remoteError := reader.stringValue("remote")
+	remoteName, _, remoteError := reader.stringValue(actionOptionRemoteKeyConstant)
 	if remoteError != nil {
 		return remoteError
 	}
 
 	pushEnabled := true
-	if value, exists, err := reader.boolValue("push"); err != nil {
+	if value, exists, err := reader.boolValue(actionOptionPushKeyConstant); err != nil {
 		return err
 	} else if exists {
 		pushEnabled = value
 	}
 
 	restoreEnabled := true
-	if value, exists, err := reader.boolValue("restore"); err != nil {
+	if value, exists, err := reader.boolValue(actionOptionRestoreKeyConstant); err != nil {
 		return err
 	} else if exists {
 		restoreEnabled = value
 	}
 
 	pushMissing := false
-	if value, exists, err := reader.boolValue("push_missing"); err != nil {
+	if value, exists, err := reader.boolValue(actionOptionPushMissingKeyConstant); err != nil {
 		return err
 	} else if exists {
 		pushMissing = value

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -792,3 +792,23 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - Exposed explicit metadata controls through `gix sync --title/--body` and `sync.pull_request.title/body`.
   - Kept branch-diff body generation as the default and made explicit body text bypass generation.
   - `make test`, `make lint`, and `make ci` passed locally after the control follow-up.
+
+- [x] [I008] Unify duplicated workflow implementation paths behind shared typed builders and services.
+  Requested on 2026-06-03.
+  ### Summary
+  The implementation has parallel CLI, web, workflow, and sync branches that construct equivalent workflow actions and Git operations with duplicated `map[string]any` mutation and helper logic. The code should converge on centralized typed builders and reusable services so each command surface delegates to one canonical implementation path.
+  ### Plan
+  - Introduce typed workflow option/spec builders for common operations and task actions.
+  - Replace CLI preset wrappers and workflow variable override code that currently mutates nested action maps by hand.
+  - Reuse the same builders from web workflow primitive construction where the web API creates equivalent operation options.
+  - Extract shared branch/PR/dirty-work helpers once the builder path is stable.
+  - Add focused tests that prove the shared builders serialize the existing command contracts without changing observable behavior.
+  ### Resolution
+  - Added workflow-owned typed option builders for common task actions, file replacement safeguards, release retag mappings, and history purge variable overrides.
+  - Exported built-in task action identifiers so CLI and web surfaces stop repeating action type strings in implementation code.
+  - Migrated web workflow primitives, CLI preset wrappers, and workflow history variable overrides to the shared builder path.
+  - Reused the centralized option key constants inside workflow action handlers and taught option map-slice reading to accept typed mapping slices.
+  - Added focused builder and override tests in `internal/workflow`.
+  - `make format`, `make test`, `make lint`, and `make ci` passed locally.
+  ### Follow-up
+  Branch/PR/dirty-work helper extraction remains a later unification slice now that the typed option builder path is stable.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,8 +1,7 @@
-- Keep I007 as the active implementation scope for purposeful `gix sync` pull request descriptions.
-- Replace the static sync PR body formatter with a branch-diff description generator.
-- Add failing observable coverage proving newly opened sync PRs receive body text returned from real branch diff context.
-- Ensure generated body failures stop before pushing newly created PR branches.
-- Reuse the existing configured LLM client path so the generated body explains the code difference instead of the tool path.
-- Unify sync-created PR metadata resolution around the same `title` and `body` option names used by workflow pull request tasks.
-- Expose explicit `title` and `body` controls through sync CLI flags and `sync.pull_request` configuration while keeping branch-diff body generation as the default.
-- Validate through Makefile targets: format, test, lint, and ci.
+- I008 is implemented and locally validated.
+- Added typed workflow option/spec builders for duplicated action maps and file replacement safeguards.
+- Migrated CLI preset wrappers, web workflow primitive builders, and history variable overrides away from hand-written nested `map[string]any` mutation.
+- Reused centralized workflow option key constants in action handlers.
+- Added focused tests proving equivalent serialized workflow options and history override behavior.
+- Validated through `make format`, `make test`, `make lint`, and `make ci`.
+- Remaining follow-up: extract branch/PR/dirty-work helpers in a later slice if the duplicated sync internals continue to grow.


### PR DESCRIPTION
## Summary
- Add workflow-owned typed option builders for common task actions, release retag mappings, file replacement safeguards, and history purge overrides.
- Migrate CLI preset wrappers, web workflow primitives, and workflow variable overrides away from hand-written nested option maps.
- Reuse centralized workflow option key constants in action handlers and support typed mapping slices in option reading.
- Mark I008 resolved in the issue artifacts.

## Validation
- `make format`
- `make test`
- `make lint`
- `make ci`