### PR TITLE
Fix B008 strict sync sibling worktree adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Make `gix sync` pull request descriptions come from the branch diff through the configured LLM path instead of predefined body text.
 - Generate the sync PR body before pushing new PR branches so body-generation failures do not leave remote branches without pull requests.
 - Expose sync-created pull request `title` and `body` controls through `gix sync --title/--body` and `sync.pull_request`, with explicit bodies bypassing generated descriptions.
+- Centralize strict and non-strict sync sibling-worktree retry handling behind the worktree adoption service.
 
 ### Bug Fixes 🐛
 - Restore strict `gix sync` adoption of dirty sibling worktrees when the requested branch is already checked out in another folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
 - Generate the sync PR body before pushing new PR branches so body-generation failures do not leave remote branches without pull requests.
 - Expose sync-created pull request `title` and `body` controls through `gix sync --title/--body` and `sync.pull_request`, with explicit bodies bypassing generated descriptions.
 
+### Bug Fixes 🐛
+- Restore strict `gix sync` adoption of dirty sibling worktrees when the requested branch is already checked out in another folder.
+
 ### Testing 🧪
 - Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator and failure-before-push ordering.
 - Add sync command and strict action coverage for explicit PR title/body controls.
+- Add strict-sync regression coverage for committing, pushing, removing, pruning, refetching, and retrying a dirty sibling worktree before switching to the requested branch.
 
 ## [v0.6.1] - 2026-06-03
 

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -81,7 +81,7 @@ func saveDirtyWorkClusters(ctx context.Context, executor shared.GitExecutor, rep
 	return committedClusters, nil
 }
 
-func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string, branchName string) error {
+func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string, branchName string, commitMessages worktreeAdoptionCommitMessageOptions) error {
 	remoteReference := fmt.Sprintf("%s/%s", remoteName, branchName)
 	remoteExists, remoteExistsErr := remoteReferenceExists(ctx, environment.GitExecutor, repository.Path, remoteReference)
 	if remoteExistsErr != nil {
@@ -100,7 +100,7 @@ func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workf
 		if !openPullRequest {
 			return fmt.Errorf(strictSyncMissingPullRequestTemplate, branchName, baseBranch)
 		}
-		return switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, remoteName, branchName)
+		return switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, remoteName, branchName, commitMessages)
 	}
 
 	localExists, localExistsErr := localBranchExists(ctx, environment.GitExecutor, repository.Path, branchName)
@@ -108,7 +108,7 @@ func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workf
 		return localExistsErr
 	}
 	if localExists {
-		return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, branchName})
+		return switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, remoteName, branchName, commitMessages)
 	}
 
 	baseReference := fmt.Sprintf("%s/%s", remoteName, baseBranch)

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -297,22 +297,21 @@ func handleBranchSyncAction(ctx context.Context, environment *workflow.Environme
 		CreateIfMissing: createIfMissing,
 		pullMode:        pullModeForRefreshState(refreshSkipped),
 	}
-	result, changeError := service.Change(ctx, changeOptions)
-	if changeError != nil && isBranchAlreadyUsedByWorktreeError(changeError) {
-		commitMessageOptions, commitMessageErr := worktreeAdoptionCommitMessageOptionsFromParameters(parameters)
-		if commitMessageErr != nil {
-			return commitMessageErr
-		}
-		adoptionOptions := worktreeAdoptionOptions{
-			BranchName:     resolvedBranchName,
-			RemoteName:     remoteName,
-			CommitMessages: commitMessageOptions,
-		}
-		if adoptionErr := adoptExistingBranchWorktree(ctx, environment, repository, adoptionOptions); adoptionErr != nil {
-			return adoptionErr
-		}
-		result, changeError = service.Change(ctx, changeOptions)
+	commitMessageOptions, commitMessageErr := worktreeAdoptionCommitMessageOptionsFromParameters(parameters)
+	if commitMessageErr != nil {
+		return commitMessageErr
 	}
+	var result Result
+	changeError := newWorktreeAdoptionService(environment, repository).Change(ctx, worktreeAdoptionChangeOptions{
+		BranchName:     resolvedBranchName,
+		RemoteName:     remoteName,
+		CommitMessages: commitMessageOptions,
+		Change: func() error {
+			var serviceChangeErr error
+			result, serviceChangeErr = service.Change(ctx, changeOptions)
+			return serviceChangeErr
+		},
+	})
 	if changeError != nil {
 		return changeError
 	}
@@ -706,25 +705,15 @@ func switchToLocalOrRemoteBranch(ctx context.Context, executor shared.GitExecuto
 }
 
 func switchToLocalOrRemoteBranchWithAdoption(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, branchName string, commitMessages worktreeAdoptionCommitMessageOptions) error {
-	switchErr := switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, remoteName, branchName)
-	if switchErr == nil {
-		return nil
-	}
-	if !isBranchAlreadyUsedByWorktreeError(switchErr) {
-		return switchErr
-	}
-
-	if adoptionErr := adoptExistingBranchWorktree(ctx, environment, repository, worktreeAdoptionOptions{
-		BranchName:     branchName,
-		RemoteName:     remoteName,
-		CommitMessages: commitMessages,
-	}); adoptionErr != nil {
-		return adoptionErr
-	}
-	if fetchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName}); fetchErr != nil {
-		return fmt.Errorf(gitFetchFailureTemplateConstant, fetchErr)
-	}
-	return switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, remoteName, branchName)
+	return newWorktreeAdoptionService(environment, repository).Change(ctx, worktreeAdoptionChangeOptions{
+		BranchName:                 branchName,
+		RemoteName:                 remoteName,
+		CommitMessages:             commitMessages,
+		RefetchRemoteAfterAdoption: true,
+		Change: func() error {
+			return switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, remoteName, branchName)
+		},
+	})
 }
 
 func mergeBaseIntoBranch(ctx context.Context, executor shared.GitExecutor, repositoryPath string, remoteName string, baseBranch string, branchName string) error {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -502,7 +502,7 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 		if commitBranchName == baseBranch {
 			commitBranchName = generatedSyncBranchName(repository, statusEntries)
 		}
-		if prepareErr := prepareStrictSyncBranchForDirtyWork(ctx, environment, repository, remoteName, baseBranch, commitBranchName); prepareErr != nil {
+		if prepareErr := prepareStrictSyncBranchForDirtyWork(ctx, environment, repository, remoteName, baseBranch, commitBranchName, options.CommitMessages); prepareErr != nil {
 			return prepareErr
 		}
 		committedClusters, commitErr := saveDirtyWorkClusters(ctx, environment.GitExecutor, repository.Path, statusEntries, options.CommitMessages)
@@ -515,7 +515,7 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 	}
 
 	if branchName == baseBranch {
-		if syncErr := syncBaseBranch(ctx, environment, repository, remoteName, baseBranch); syncErr != nil {
+		if syncErr := syncBaseBranch(ctx, environment, repository, remoteName, baseBranch, options.CommitMessages); syncErr != nil {
 			return syncErr
 		}
 		reportStrictSync(repository, environment, branchName, options.ResolutionSource, false, stashPushed)
@@ -556,7 +556,7 @@ type strictPullRequestCreateOptions struct {
 	Body                 string
 }
 
-func syncBaseBranch(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string) error {
+func syncBaseBranch(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string, commitMessages worktreeAdoptionCommitMessageOptions) error {
 	remoteReference := fmt.Sprintf("%s/%s", remoteName, baseBranch)
 	remoteExists, remoteExistsErr := remoteReferenceExists(ctx, environment.GitExecutor, repository.Path, remoteReference)
 	if remoteExistsErr != nil {
@@ -574,7 +574,7 @@ func syncBaseBranch(ctx context.Context, environment *workflow.Environment, repo
 		return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, baseBranch, gitSwitchTrackFlagConstant, remoteReference})
 	}
 
-	if switchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, baseBranch}); switchErr != nil {
+	if switchErr := switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, remoteName, baseBranch, commitMessages); switchErr != nil {
 		return switchErr
 	}
 	aheadCount, aheadErr := commitCount(ctx, environment.GitExecutor, repository.Path, fmt.Sprintf("%s..%s", remoteReference, baseBranch))
@@ -607,7 +607,7 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 		if !openPullRequest {
 			return false, fmt.Errorf(strictSyncMissingPullRequestTemplate, options.BranchName, options.BaseBranch)
 		}
-		if switchErr := switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BranchName); switchErr != nil {
+		if switchErr := switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, options.RemoteName, options.BranchName, options.CommitMessages); switchErr != nil {
 			return false, switchErr
 		}
 		aheadCount, aheadErr := commitCount(ctx, environment.GitExecutor, repository.Path, fmt.Sprintf("%s..%s", remoteReference, options.BranchName))
@@ -642,7 +642,7 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 		if !options.AllowAheadCommit {
 			return false, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
 		}
-		if switchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, options.BranchName}); switchErr != nil {
+		if switchErr := switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, options.RemoteName, options.BranchName, options.CommitMessages); switchErr != nil {
 			return false, switchErr
 		}
 		if mergeErr := mergeBaseIntoBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName); mergeErr != nil {
@@ -703,6 +703,28 @@ func switchToLocalOrRemoteBranch(ctx context.Context, executor shared.GitExecuto
 	}
 	remoteReference := fmt.Sprintf("%s/%s", remoteName, branchName)
 	return executeGit(ctx, executor, repositoryPath, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName, gitSwitchTrackFlagConstant, remoteReference})
+}
+
+func switchToLocalOrRemoteBranchWithAdoption(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, branchName string, commitMessages worktreeAdoptionCommitMessageOptions) error {
+	switchErr := switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, remoteName, branchName)
+	if switchErr == nil {
+		return nil
+	}
+	if !isBranchAlreadyUsedByWorktreeError(switchErr) {
+		return switchErr
+	}
+
+	if adoptionErr := adoptExistingBranchWorktree(ctx, environment, repository, worktreeAdoptionOptions{
+		BranchName:     branchName,
+		RemoteName:     remoteName,
+		CommitMessages: commitMessages,
+	}); adoptionErr != nil {
+		return adoptionErr
+	}
+	if fetchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName}); fetchErr != nil {
+		return fmt.Errorf(gitFetchFailureTemplateConstant, fetchErr)
+	}
+	return switchToLocalOrRemoteBranch(ctx, environment.GitExecutor, repository.Path, remoteName, branchName)
 }
 
 func mergeBaseIntoBranch(ctx context.Context, executor shared.GitExecutor, repositoryPath string, remoteName string, baseBranch string, branchName string) error {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -2,6 +2,7 @@ package syncflow
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -115,6 +116,9 @@ type strictSyncGitExecutor struct {
 	revListOutput     string
 	missingReferences map[string]bool
 	mergeError        error
+	blockedBranch     string
+	blockedWorktree   string
+	worktreeRemoved   bool
 }
 
 func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
@@ -124,6 +128,12 @@ func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details exe
 	}
 	switch details.Arguments[0] {
 	case "status":
+		if details.WorkingDirectory == executor.blockedWorktree && commandHasArgument(details.Arguments, gitPorcelainBranchFlagConstant) {
+			return execshell.ExecutionResult{StandardOutput: fmt.Sprintf("## %s...origin/%s\n M README.md\n", executor.blockedBranch, executor.blockedBranch)}, nil
+		}
+		if details.WorkingDirectory == executor.blockedWorktree {
+			return execshell.ExecutionResult{StandardOutput: "M  README.md\n"}, nil
+		}
 		return execshell.ExecutionResult{StandardOutput: executor.statusOutput}, nil
 	case "diff":
 		if commandHasArgument(details.Arguments, "--stat") {
@@ -156,8 +166,18 @@ func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details exe
 			return execshell.ExecutionResult{}, executor.mergeError
 		}
 	case "switch":
+		if len(details.Arguments) > 1 && details.Arguments[1] == executor.blockedBranch && !executor.worktreeRemoved {
+			return execshell.ExecutionResult{}, commandFailedError(fmt.Sprintf("fatal: %q is already used by worktree at %q", executor.blockedBranch, executor.blockedWorktree))
+		}
 		if len(details.Arguments) > 2 && details.Arguments[1] == gitCreateBranchFlagConstant && executor.missingReferences != nil {
 			delete(executor.missingReferences, "refs/heads/"+details.Arguments[2])
+		}
+	case "worktree":
+		if len(details.Arguments) > 2 && details.Arguments[1] == gitWorktreeListSubcommandConstant {
+			return execshell.ExecutionResult{StandardOutput: fmt.Sprintf("worktree /tmp/project\nbranch refs/heads/master\n\nworktree %s\nbranch refs/heads/%s\n", executor.blockedWorktree, executor.blockedBranch)}, nil
+		}
+		if len(details.Arguments) > 2 && details.Arguments[1] == gitWorktreeRemoveSubcommandConstant {
+			executor.worktreeRemoved = true
 		}
 	}
 	return execshell.ExecutionResult{}, nil
@@ -426,6 +446,63 @@ func TestHandleBranchSyncActionStrictPRBranchAutoCommitsDirtySameBranch(t *testi
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "reset --hard origin/feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push origin feature/foo")
 	require.Len(t, chatClient.requests, 1)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchAdoptsDirtySiblingWorktree(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		blockedBranch:   "feature/foo",
+		blockedWorktree: "/tmp/project-feature",
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Feature","headRefName":"feature/foo"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{response: "fix: adopt sibling worktree"}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "worktree list --porcelain")
+	require.Contains(t, recordedCommands, "status --porcelain --branch")
+	require.Contains(t, recordedCommands, "add --all")
+	require.Contains(t, recordedCommands, "commit -m fix: adopt sibling worktree")
+	require.Contains(t, recordedCommands, "push --set-upstream origin feature/foo")
+	require.Contains(t, recordedCommands, "worktree remove /tmp/project-feature")
+	require.Contains(t, recordedCommands, "worktree prune")
+	require.Contains(t, recordedCommands, "merge --no-edit origin/master")
+	require.Contains(t, recordedCommands, "push origin feature/foo")
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "worktree remove /tmp/project-feature"), recordedGitCommandLastIndex(gitExecutor.commands, "switch feature/foo"))
+	require.GreaterOrEqual(t, recordedGitCommandCount(gitExecutor.commands, "fetch --prune origin"), 2)
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "worktree prune"), recordedGitCommandLastIndex(gitExecutor.commands, "fetch --prune origin"))
+	require.Less(t, recordedGitCommandLastIndex(gitExecutor.commands, "fetch --prune origin"), recordedGitCommandLastIndex(gitExecutor.commands, "switch feature/foo"))
+	require.Len(t, chatClient.requests, 1)
+	require.True(t, gitExecutor.worktreeRemoved)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchRequireCleanRejectsDirtyWorktree(t *testing.T) {
@@ -827,6 +904,25 @@ func recordedGitCommandIndex(commands []execshell.CommandDetails, target string)
 		}
 	}
 	return -1
+}
+
+func recordedGitCommandLastIndex(commands []execshell.CommandDetails, target string) int {
+	for commandIndex := len(commands) - 1; commandIndex >= 0; commandIndex-- {
+		if strings.Join(commands[commandIndex].Arguments, " ") == target {
+			return commandIndex
+		}
+	}
+	return -1
+}
+
+func recordedGitCommandCount(commands []execshell.CommandDetails, target string) int {
+	count := 0
+	for commandIndex := range commands {
+		if strings.Join(commands[commandIndex].Arguments, " ") == target {
+			count++
+		}
+	}
+	return count
 }
 
 func commandHasArgument(arguments []string, target string) bool {

--- a/internal/branches/syncflow/worktree_adoption.go
+++ b/internal/branches/syncflow/worktree_adoption.go
@@ -50,6 +50,7 @@ const (
 	worktreeMessageAPIKeyFailureTemplate      = "environment variable %s must be set to generate a commit message"
 	worktreeMessageClientFailureTemplate      = "failed to initialize commit message client: %w"
 	worktreeMessageGenerationFailureTemplate  = "failed to generate commit message for sibling worktree %s: %w"
+	worktreeAdoptionChangeMissing             = "worktree adoption change function not configured"
 	worktreeAdoptDetectedMessage              = "adopting sibling worktree"
 	worktreeAdoptCommitMessage                = "committed sibling worktree changes"
 	worktreeAdoptPushMessage                  = "pushed sibling worktree branch"
@@ -61,6 +62,65 @@ type worktreeAdoptionOptions struct {
 	BranchName     string
 	RemoteName     string
 	CommitMessages worktreeAdoptionCommitMessageOptions
+}
+
+type worktreeAdoptionChangeOptions struct {
+	BranchName                 string
+	RemoteName                 string
+	CommitMessages             worktreeAdoptionCommitMessageOptions
+	RefetchRemoteAfterAdoption bool
+	Change                     func() error
+}
+
+type worktreeAdoptionService struct {
+	environment *workflow.Environment
+	repository  *workflow.RepositoryState
+}
+
+func newWorktreeAdoptionService(environment *workflow.Environment, repository *workflow.RepositoryState) worktreeAdoptionService {
+	return worktreeAdoptionService{
+		environment: environment,
+		repository:  repository,
+	}
+}
+
+func (service worktreeAdoptionService) Change(ctx context.Context, options worktreeAdoptionChangeOptions) error {
+	if options.Change == nil {
+		return errors.New(worktreeAdoptionChangeMissing)
+	}
+
+	changeErr := options.Change()
+	if changeErr == nil {
+		return nil
+	}
+	if !isBranchAlreadyUsedByWorktreeError(changeErr) {
+		return changeErr
+	}
+	if service.environment == nil || service.repository == nil {
+		return changeErr
+	}
+
+	remoteName := strings.TrimSpace(options.RemoteName)
+	if remoteName == "" {
+		remoteName = defaultRemoteNameConstant
+	}
+
+	adoptionErr := service.adoptExistingBranchWorktree(ctx, worktreeAdoptionOptions{
+		BranchName:     options.BranchName,
+		RemoteName:     remoteName,
+		CommitMessages: options.CommitMessages,
+	})
+	if adoptionErr != nil {
+		return adoptionErr
+	}
+
+	if options.RefetchRemoteAfterAdoption {
+		if fetchErr := executeGit(ctx, service.environment.GitExecutor, service.repository.Path, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName}); fetchErr != nil {
+			return fmt.Errorf(gitFetchFailureTemplateConstant, fetchErr)
+		}
+	}
+
+	return options.Change()
 }
 
 func isBranchAlreadyUsedByWorktreeError(err error) bool {
@@ -115,11 +175,11 @@ func worktreeAdoptionCommitMessageOptionsFromParameters(parameters map[string]an
 	return typedOptions, nil
 }
 
-func adoptExistingBranchWorktree(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, options worktreeAdoptionOptions) error {
-	if environment == nil || repository == nil {
+func (service worktreeAdoptionService) adoptExistingBranchWorktree(ctx context.Context, options worktreeAdoptionOptions) error {
+	if service.environment == nil || service.repository == nil {
 		return nil
 	}
-	if environment.GitExecutor == nil {
+	if service.environment.GitExecutor == nil {
 		return ErrGitExecutorNotConfigured
 	}
 
@@ -128,7 +188,7 @@ func adoptExistingBranchWorktree(ctx context.Context, environment *workflow.Envi
 		return nil
 	}
 
-	worktrees, listErr := listRepositoryWorktrees(ctx, environment.GitExecutor, repository.Path, branchName)
+	worktrees, listErr := listRepositoryWorktrees(ctx, service.environment.GitExecutor, service.repository.Path, branchName)
 	if listErr != nil {
 		return listErr
 	}
@@ -138,13 +198,13 @@ func adoptExistingBranchWorktree(ctx context.Context, environment *workflow.Envi
 		if candidate.BranchName != branchName {
 			continue
 		}
-		if sameFilesystemPath(candidate.Path, repository.Path) {
+		if sameFilesystemPath(candidate.Path, service.repository.Path) {
 			continue
 		}
 		if candidate.Locked {
 			return fmt.Errorf(worktreeLockedFailureTemplate, branchName, candidate.Path)
 		}
-		return adoptSiblingWorktree(ctx, environment, repository, candidate, options)
+		return service.adoptSiblingWorktree(ctx, candidate, options)
 	}
 
 	return nil
@@ -199,55 +259,55 @@ func parseListedWorktrees(output string) []listedWorktree {
 	return worktrees
 }
 
-func adoptSiblingWorktree(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, worktree listedWorktree, options worktreeAdoptionOptions) error {
+func (service worktreeAdoptionService) adoptSiblingWorktree(ctx context.Context, worktree listedWorktree, options worktreeAdoptionOptions) error {
 	branchName := strings.TrimSpace(options.BranchName)
 	remoteName := strings.TrimSpace(options.RemoteName)
 	if remoteName == "" {
 		remoteName = defaultRemoteNameConstant
 	}
 
-	environment.ReportRepositoryEvent(
-		repository,
+	service.environment.ReportRepositoryEvent(
+		service.repository,
 		shared.EventLevelInfo,
 		shared.EventCodeWorktreeAdopt,
 		worktreeAdoptDetectedMessage,
 		map[string]string{"branch": branchName, "worktree": worktree.Path},
 	)
 
-	status, statusErr := inspectSiblingWorktreeStatus(ctx, environment.GitExecutor, worktree.Path)
+	status, statusErr := inspectSiblingWorktreeStatus(ctx, service.environment.GitExecutor, worktree.Path)
 	if statusErr != nil {
 		return statusErr
 	}
 
 	pushed := false
 	if status.Dirty {
-		commitMessage, commitMessageErr := generateSiblingCommitMessage(ctx, environment.GitExecutor, worktree.Path, options.CommitMessages)
+		commitMessage, commitMessageErr := generateSiblingCommitMessage(ctx, service.environment.GitExecutor, worktree.Path, options.CommitMessages)
 		if commitMessageErr != nil {
 			return commitMessageErr
 		}
-		if commitErr := executeGit(ctx, environment.GitExecutor, worktree.Path, []string{gitCommitSubcommand, gitCommitMessageFlag, commitMessage}); commitErr != nil {
+		if commitErr := executeGit(ctx, service.environment.GitExecutor, worktree.Path, []string{gitCommitSubcommand, gitCommitMessageFlag, commitMessage}); commitErr != nil {
 			return fmt.Errorf(worktreeCommitFailureTemplate, worktree.Path, commitErr)
 		}
-		environment.ReportRepositoryEvent(
-			repository,
+		service.environment.ReportRepositoryEvent(
+			service.repository,
 			shared.EventLevelInfo,
 			shared.EventCodeWorktreeAdopt,
 			worktreeAdoptCommitMessage,
 			map[string]string{"branch": branchName, "worktree": worktree.Path},
 		)
-		if pushErr := pushSiblingBranch(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
+		if pushErr := pushSiblingBranch(ctx, service.environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
 			return pushErr
 		}
 		pushed = true
 	}
 
 	if !status.Dirty {
-		needsPush, needsPushErr := cleanSiblingBranchNeedsPush(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName, status)
+		needsPush, needsPushErr := cleanSiblingBranchNeedsPush(ctx, service.environment.GitExecutor, worktree.Path, remoteName, branchName, status)
 		if needsPushErr != nil {
 			return needsPushErr
 		}
 		if needsPush {
-			if pushErr := pushSiblingBranch(ctx, environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
+			if pushErr := pushSiblingBranch(ctx, service.environment.GitExecutor, worktree.Path, remoteName, branchName); pushErr != nil {
 				return pushErr
 			}
 			pushed = true
@@ -255,8 +315,8 @@ func adoptSiblingWorktree(ctx context.Context, environment *workflow.Environment
 	}
 
 	if pushed {
-		environment.ReportRepositoryEvent(
-			repository,
+		service.environment.ReportRepositoryEvent(
+			service.repository,
 			shared.EventLevelInfo,
 			shared.EventCodeWorktreeAdopt,
 			worktreeAdoptPushMessage,
@@ -264,22 +324,22 @@ func adoptSiblingWorktree(ctx context.Context, environment *workflow.Environment
 		)
 	}
 
-	if removeErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreeRemoveSubcommandConstant, worktree.Path}); removeErr != nil {
+	if removeErr := executeGit(ctx, service.environment.GitExecutor, service.repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreeRemoveSubcommandConstant, worktree.Path}); removeErr != nil {
 		return fmt.Errorf(worktreeRemoveFailureTemplate, worktree.Path, removeErr)
 	}
-	environment.ReportRepositoryEvent(
-		repository,
+	service.environment.ReportRepositoryEvent(
+		service.repository,
 		shared.EventLevelInfo,
 		shared.EventCodeWorktreeAdopt,
 		worktreeAdoptRemoveMessage,
 		map[string]string{"branch": branchName, "worktree": worktree.Path},
 	)
 
-	if pruneErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreePruneSubcommandConstant}); pruneErr != nil {
+	if pruneErr := executeGit(ctx, service.environment.GitExecutor, service.repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreePruneSubcommandConstant}); pruneErr != nil {
 		return fmt.Errorf(worktreePruneFailureTemplate, worktree.Path, pruneErr)
 	}
-	environment.ReportRepositoryEvent(
-		repository,
+	service.environment.ReportRepositoryEvent(
+		service.repository,
 		shared.EventLevelInfo,
 		shared.EventCodeWorktreeAdopt,
 		worktreeAdoptPruneMessage,

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -11,6 +11,19 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
 
 ## BugFixes
 
+- [x] [B008] (P1) `gix sync` strict PR flow no longer adopts dirty sibling worktrees for the requested branch.
+  Requested on 2026-06-03 after the `v0.6.1` release check showed the old sibling-worktree adoption helper still existed, but the public strict `gix sync` path did not call it when Git refused to switch to a branch already checked out in another folder.
+  ## Observation
+  - `gix sync` now routes public branch syncs through strict PR sync.
+  - Strict PR sync called `git switch` directly and returned Git's branch-in-worktree error instead of adopting the sibling worktree.
+  - The intended behavior is conditional: when the target branch is checked out in another worktree and that sibling has uncommitted files, commit and push those sibling changes before removing/pruning the sibling and retrying the switch.
+  ## Resolution
+  - Routed strict sync branch switching through an adoption-aware helper that only triggers on Git's sibling-worktree collision error.
+  - Reused the existing sibling adoption service so dirty siblings are staged, commit-message generated, committed, pushed, removed, pruned, and then retried through the normal strict sync path.
+  - Refetched the configured remote after adoption so strict sync ahead checks use the pushed sibling state.
+  - Added focused strict-sync regression coverage for a dirty sibling worktree on the requested PR branch.
+  - `make ci` passed locally.
+
 - [x] [B007] (P1) `.gitignore` hides new source and test files by default.
   Requested on 2026-05-21 after new `gix cd` implementation files were present on disk but only visible under ignored status because `.gitignore` used a catch-all `*` with a narrow allowlist.
   ## Observation

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -20,6 +20,7 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   ## Resolution
   - Routed strict sync branch switching through an adoption-aware helper that only triggers on Git's sibling-worktree collision error.
   - Reused the existing sibling adoption service so dirty siblings are staged, commit-message generated, committed, pushed, removed, pruned, and then retried through the normal strict sync path.
+  - Centralized the strict and non-strict retry paths behind `worktreeAdoptionService.Change` so branch switching no longer carries separate sibling-worktree adoption blocks.
   - Refetched the configured remote after adoption so strict sync ahead checks use the pushed sibling state.
   - Added focused strict-sync regression coverage for a dirty sibling worktree on the requested PR branch.
   - `make ci` passed locally.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -2,6 +2,7 @@
 - Reuse the existing adoption helper instead of duplicating commit/push/remove/prune logic.
 - Trigger adoption only when Git reports that the requested branch is already used by another worktree.
 - Preserve the conditional dirty behavior: commit the sibling worktree only when it has uncommitted files; otherwise skip the commit path.
+- Route strict and non-strict branch changes through the same adoption service instead of keeping separate retry blocks.
 - Refetch after adoption so strict sync compares against the pushed remote state before ahead/merge checks.
 - Add focused regression coverage for a dirty sibling worktree blocking a PR-backed sync branch.
 - `make ci` passed locally.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,7 +1,7 @@
-- I008 is implemented and locally validated.
-- Added typed workflow option/spec builders for duplicated action maps and file replacement safeguards.
-- Migrated CLI preset wrappers, web workflow primitive builders, and history variable overrides away from hand-written nested `map[string]any` mutation.
-- Reused centralized workflow option key constants in action handlers.
-- Added focused tests proving equivalent serialized workflow options and history override behavior.
-- Validated through `make format`, `make test`, `make lint`, and `make ci`.
-- Remaining follow-up: extract branch/PR/dirty-work helpers in a later slice if the duplicated sync internals continue to grow.
+- B008 restores sibling-worktree adoption in strict `gix sync`.
+- Reuse the existing adoption helper instead of duplicating commit/push/remove/prune logic.
+- Trigger adoption only when Git reports that the requested branch is already used by another worktree.
+- Preserve the conditional dirty behavior: commit the sibling worktree only when it has uncommitted files; otherwise skip the commit path.
+- Refetch after adoption so strict sync compares against the pushed remote state before ahead/merge checks.
+- Add focused regression coverage for a dirty sibling worktree blocking a PR-backed sync branch.
+- `make ci` passed locally.


### PR DESCRIPTION
## Summary
- Restores strict `gix sync` adoption when Git reports the requested branch is already checked out in a sibling worktree.
- Reuses the existing adoption helper so dirty siblings are committed, pushed, removed, pruned, refetched, and then retried through the normal strict sync path.
- Records B008 in the issue log and adds the unreleased changelog note.

## Validation
- `make ci`

Fixes B008.