### PR TITLE
bugfix/I009-stale-generated-sync-branch

### DIFF
--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -20,10 +20,27 @@ const (
 	strictSyncDirtyStageFailureTemplate   = "failed to stage dirty sync cluster %q: %w"
 	strictSyncDirtyMessageFailureTemplate = "failed to generate dirty sync commit message for %q: %w"
 	strictSyncDirtyClusterFailureTemplate = "failed to commit dirty sync cluster %q: %w"
-	strictSyncGeneratedBranchPrefix       = "sync"
-	strictSyncGeneratedRepositoryFallback = "repository"
-	strictSyncGeneratedPathFallback       = "work"
+	strictSyncGeneratedBranchPrefix       = "gix"
+	strictSyncGeneratedSemanticFallback   = "work"
+	strictSyncGeneratedSemanticSlugLimit  = 56
+	strictSyncGeneratedBranchFailure      = "failed to generate dirty sync branch name: %w"
+	strictSyncGeneratedBranchLimit        = 100
+	strictSyncGeneratedBranchLimitMessage = "unable to select generated sync branch after 100 attempts for %q"
 )
+
+var syncConventionalCommitTypes = map[string]struct{}{
+	"build":    {},
+	"chore":    {},
+	"ci":       {},
+	"docs":     {},
+	"feat":     {},
+	"fix":      {},
+	"perf":     {},
+	"refactor": {},
+	"revert":   {},
+	"style":    {},
+	"test":     {},
+}
 
 type syncCommitCluster struct {
 	Root  string
@@ -165,25 +182,141 @@ func buildSyncCommitClusters(statusEntries []string) []syncCommitCluster {
 	return clusters
 }
 
-func generatedSyncBranchName(repository *workflow.RepositoryState, statusEntries []string) string {
-	repositoryName := strictSyncGeneratedRepositoryFallback
-	if repository != nil {
-		candidate := filepath.Base(filepath.Clean(strings.TrimSpace(repository.Path)))
-		if slug := syncBranchSlug(candidate); slug != "" {
-			repositoryName = slug
+func generatedSyncBranchName(ctx context.Context, executor shared.GitExecutor, repositoryPath string, options worktreeAdoptionCommitMessageOptions) (string, error) {
+	message, messageErr := generateSyncBranchMessage(ctx, executor, repositoryPath, options)
+	if messageErr != nil {
+		return "", fmt.Errorf(strictSyncGeneratedBranchFailure, messageErr)
+	}
+	slug := syncBranchSlug(syncBranchSemanticSubject(message))
+	if slug == "" {
+		slug = strictSyncGeneratedSemanticFallback
+	}
+	slug = truncateSyncBranchSlug(slug, "")
+	return strings.Join([]string{strictSyncGeneratedBranchPrefix, slug}, "/"), nil
+}
+
+func generateSyncBranchMessage(ctx context.Context, executor shared.GitExecutor, repositoryPath string, options worktreeAdoptionCommitMessageOptions) (string, error) {
+	client, clientErr := resolveCommitMessageClient(options)
+	if clientErr != nil {
+		return "", clientErr
+	}
+	var temperature *float64
+	if options.Temperature != 0 {
+		temperatureValue := options.Temperature
+		temperature = &temperatureValue
+	}
+	generator := commitmsg.Generator{
+		GitExecutor: executor,
+		Client:      client,
+	}
+	result, generateErr := generator.Generate(ctx, commitmsg.Options{
+		RepositoryPath: repositoryPath,
+		Source:         commitmsg.DiffSourceAll,
+		MaxTokens:      options.MaxTokens,
+		Temperature:    temperature,
+	})
+	if generateErr != nil {
+		return "", generateErr
+	}
+	return result.Message, nil
+}
+
+func selectGeneratedSyncBranchName(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string, options worktreeAdoptionCommitMessageOptions) (string, error) {
+	initialBranchName, initialBranchErr := generatedSyncBranchName(ctx, environment.GitExecutor, repository.Path, options)
+	if initialBranchErr != nil {
+		return "", initialBranchErr
+	}
+	repositoryIdentifier := strictSyncRepositoryIdentifier(repository)
+	for candidateIndex := 0; candidateIndex < strictSyncGeneratedBranchLimit; candidateIndex++ {
+		candidateBranchName := generatedSyncBranchCandidateName(initialBranchName, candidateIndex)
+		remoteReference := fmt.Sprintf("%s/%s", remoteName, candidateBranchName)
+		remoteExists, remoteExistsErr := remoteReferenceExists(ctx, environment.GitExecutor, repository.Path, remoteReference)
+		if remoteExistsErr != nil {
+			return "", remoteExistsErr
+		}
+		if !remoteExists {
+			return candidateBranchName, nil
+		}
+		if repositoryIdentifier == "" {
+			return "", errors.New(strictSyncMissingRepositoryMessage)
+		}
+		openPullRequest, pullRequestErr := branchHasOpenPullRequest(ctx, environment, repositoryIdentifier, baseBranch, candidateBranchName)
+		if pullRequestErr != nil {
+			return "", pullRequestErr
+		}
+		if openPullRequest {
+			return candidateBranchName, nil
 		}
 	}
+	return "", fmt.Errorf(strictSyncGeneratedBranchLimitMessage, initialBranchName)
+}
 
-	pathName := strictSyncGeneratedPathFallback
-	clusters := buildSyncCommitClusters(statusEntries)
-	if len(clusters) > 0 {
-		rootLabel := syncGeneratedBranchPathLabel(clusters[0].Root)
-		if slug := syncBranchSlug(rootLabel); slug != "" {
-			pathName = slug
+func generatedSyncBranchCandidateName(initialBranchName string, candidateIndex int) string {
+	if candidateIndex == 0 {
+		return initialBranchName
+	}
+	suffix := fmt.Sprintf("-%d", candidateIndex+1)
+	prefix, slug, found := strings.Cut(initialBranchName, "/")
+	if !found {
+		return truncateSyncBranchSlug(initialBranchName, suffix) + suffix
+	}
+	return prefix + "/" + truncateSyncBranchSlug(slug, suffix) + suffix
+}
+
+func truncateSyncBranchSlug(slug string, suffix string) string {
+	availableLength := strictSyncGeneratedSemanticSlugLimit - len(suffix)
+	if availableLength <= 0 {
+		return strictSyncGeneratedSemanticFallback
+	}
+	trimmedSlug := strings.Trim(slug, "-")
+	if len(trimmedSlug) <= availableLength {
+		if trimmedSlug == "" {
+			return strictSyncGeneratedSemanticFallback
+		}
+		return trimmedSlug
+	}
+	rawTruncated := trimmedSlug[:availableLength]
+	truncated := strings.Trim(rawTruncated, "-")
+	if trimmedSlug[availableLength] != '-' && !strings.HasSuffix(rawTruncated, "-") {
+		if separatorIndex := strings.LastIndex(truncated, "-"); separatorIndex > 0 {
+			truncated = strings.Trim(truncated[:separatorIndex], "-")
 		}
 	}
+	if truncated == "" {
+		return strictSyncGeneratedSemanticFallback
+	}
+	return truncated
+}
 
-	return strings.Join([]string{strictSyncGeneratedBranchPrefix, repositoryName, pathName}, "/")
+func syncBranchSemanticSubject(message string) string {
+	lines := strings.Split(message, "\n")
+	for lineIndex := range lines {
+		trimmed := strings.TrimSpace(lines[lineIndex])
+		if trimmed == "" {
+			continue
+		}
+		return strings.TrimSpace(stripConventionalCommitPrefix(trimmed))
+	}
+	return ""
+}
+
+func stripConventionalCommitPrefix(subject string) string {
+	colonIndex := strings.Index(subject, ":")
+	if colonIndex <= 0 {
+		return subject
+	}
+	prefix := strings.TrimSpace(subject[:colonIndex])
+	normalizedType := strings.TrimSuffix(prefix, "!")
+	if scopeIndex := strings.Index(normalizedType, "("); scopeIndex >= 0 {
+		if !strings.HasSuffix(normalizedType, ")") {
+			return subject
+		}
+		normalizedType = strings.TrimSpace(normalizedType[:scopeIndex])
+	}
+	if _, exists := syncConventionalCommitTypes[normalizedType]; !exists {
+		return subject
+	}
+	return subject[colonIndex+1:]
 }
 
 func syncStatusEntriesHaveConflicts(statusEntries []string) bool {
@@ -244,25 +377,6 @@ func normalizeSyncStatusPath(path string) string {
 		return ""
 	}
 	return strings.TrimPrefix(normalized, "./")
-}
-
-func syncGeneratedBranchPathLabel(root string) string {
-	trimmedRoot := strings.TrimSpace(root)
-	if trimmedRoot == "" {
-		return ""
-	}
-	if strings.HasPrefix(trimmedRoot, ".") {
-		return strings.TrimLeft(trimmedRoot, ".")
-	}
-	extension := filepath.Ext(trimmedRoot)
-	if extension == "" {
-		return trimmedRoot
-	}
-	withoutExtension := strings.TrimSuffix(trimmedRoot, extension)
-	if withoutExtension == "" {
-		return trimmedRoot
-	}
-	return withoutExtension
 }
 
 func syncBranchSlug(value string) string {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -499,7 +499,11 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 		}
 		commitBranchName := branchName
 		if commitBranchName == baseBranch {
-			commitBranchName = generatedSyncBranchName(repository, statusEntries)
+			generatedBranchName, generatedBranchErr := selectGeneratedSyncBranchName(ctx, environment, repository, remoteName, baseBranch, options.CommitMessages)
+			if generatedBranchErr != nil {
+				return generatedBranchErr
+			}
+			commitBranchName = generatedBranchName
 		}
 		if prepareErr := prepareStrictSyncBranchForDirtyWork(ctx, environment, repository, remoteName, baseBranch, commitBranchName, options.CommitMessages); prepareErr != nil {
 			return prepareErr

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -742,12 +742,13 @@ func TestHandleBranchSyncActionStrictPRBranchUsesExplicitPullRequestMetadata(t *
 }
 
 func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMaster(t *testing.T) {
+	generatedBranchName := "gix/cancel-upstream-request-on-downstream-timeout"
 	pullRequestBody := "## Summary\n- Updates README content from the dirty master branch."
 	gitExecutor := &strictSyncGitExecutor{
 		statusOutput: " M README.md\n",
 		missingReferences: map[string]bool{
-			"origin/sync/project/readme":     true,
-			"refs/heads/sync/project/readme": true,
+			"origin/" + generatedBranchName:     true,
+			"refs/heads/" + generatedBranchName: true,
 		},
 	}
 	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
@@ -755,7 +756,7 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	githubExecutor := &strictSyncGitHubExecutor{}
 	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
 	require.NoError(t, githubClientError)
-	chatClient := &strictSyncChatClient{responses: []string{"docs: update readme", pullRequestBody}}
+	chatClient := &strictSyncChatClient{responses: []string{"fix: cancel upstream request on downstream timeout", "docs: update readme", pullRequestBody}}
 	environment := &workflow.Environment{
 		GitExecutor:       gitExecutor,
 		RepositoryManager: gitManager,
@@ -784,20 +785,95 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	}
 
 	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c sync/project/readme origin/master")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c "+generatedBranchName+" origin/master")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "add --all -- README.md")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "commit -m docs: update readme")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin sync/project/readme")
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master...sync/project/readme")
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --unified=3 origin/master...sync/project/readme")
-	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "diff --stat origin/master...sync/project/readme"), recordedGitCommandIndex(gitExecutor.commands, "push -u origin sync/project/readme"))
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin "+generatedBranchName)
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --stat origin/master..."+generatedBranchName)
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "diff --unified=3 origin/master..."+generatedBranchName)
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "diff --stat origin/master..."+generatedBranchName), recordedGitCommandIndex(gitExecutor.commands, "push -u origin "+generatedBranchName))
 	require.Len(t, githubExecutor.commands, 1)
-	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", "sync/project/readme", "--title", "sync/project/readme", "--body", pullRequestBody}, githubExecutor.commands[0].Arguments)
-	require.Len(t, chatClient.requests, 2)
-	require.Contains(t, chatClient.requests[1].Messages[1].Content, "Comparison range: origin/master...sync/project/readme")
-	require.Contains(t, chatClient.requests[1].Messages[1].Content, "README.md | 1 +")
-	require.Contains(t, chatClient.requests[1].Messages[1].Content, "diff --git a/README.md b/README.md")
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", generatedBranchName, "--title", generatedBranchName, "--body", pullRequestBody}, githubExecutor.commands[0].Arguments)
+	require.Len(t, chatClient.requests, 3)
+	require.Contains(t, chatClient.requests[0].Messages[1].Content, "Diff source: ALL")
+	require.Contains(t, chatClient.requests[2].Messages[1].Content, "Comparison range: origin/master..."+generatedBranchName)
+	require.Contains(t, chatClient.requests[2].Messages[1].Content, "README.md | 1 +")
+	require.Contains(t, chatClient.requests[2].Messages[1].Content, "diff --git a/README.md b/README.md")
+}
+
+func TestHandleBranchSyncActionStrictPRBranchSkipsStaleGeneratedRemoteBranch(t *testing.T) {
+	generatedBranchName := "gix/cancel-upstream-request-on-downstream-timeout"
+	collisionBranchName := generatedBranchName + "-2"
+	pullRequestBody := "## Summary\n- Updates README content without reusing the stale branch."
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: " M README.md\n",
+		missingReferences: map[string]bool{
+			"origin/" + collisionBranchName:     true,
+			"refs/heads/" + collisionBranchName: true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{responses: []string{"fix: cancel upstream request on downstream timeout", "docs: update readme", pullRequestBody}}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "master",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "switch -c "+generatedBranchName+" origin/master")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c "+collisionBranchName+" origin/master")
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin "+collisionBranchName)
+	require.Len(t, githubExecutor.commands, 2)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", collisionBranchName, "--title", collisionBranchName, "--body", pullRequestBody}, githubExecutor.commands[1].Arguments)
+	require.Len(t, chatClient.requests, 3)
+	require.Contains(t, chatClient.requests[0].Messages[1].Content, "Diff source: ALL")
+	require.Contains(t, chatClient.requests[2].Messages[1].Content, "Comparison range: origin/master..."+collisionBranchName)
+}
+
+func TestGeneratedSyncBranchNameLimitsSemanticSlug(t *testing.T) {
+	longSemanticSubject := "fix: cancel upstream request on downstream timeout while preserving router context propagation"
+	gitExecutor := &strictSyncGitExecutor{statusOutput: " M README.md\n"}
+	chatClient := &strictSyncChatClient{response: longSemanticSubject}
+
+	branchName, branchNameErr := generatedSyncBranchName(context.Background(), gitExecutor, "/tmp/project", worktreeAdoptionCommitMessageOptions{Client: chatClient})
+
+	require.NoError(t, branchNameErr)
+	require.Equal(t, "gix/cancel-upstream-request-on-downstream-timeout-while", branchName)
+	_, semanticSlug, found := strings.Cut(branchName, "/")
+	require.True(t, found)
+	require.LessOrEqual(t, len(semanticSlug), strictSyncGeneratedSemanticSlugLimit)
+	collisionBranchName := generatedSyncBranchCandidateName(branchName, 1)
+	require.Equal(t, "gix/cancel-upstream-request-on-downstream-timeout-while-2", collisionBranchName)
+	_, collisionSemanticSlug, collisionFound := strings.Cut(collisionBranchName, "/")
+	require.True(t, collisionFound)
+	require.LessOrEqual(t, len(collisionSemanticSlug), strictSyncGeneratedSemanticSlugLimit)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchDoesNotPushWhenPullRequestBodyGenerationFails(t *testing.T) {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -826,3 +826,20 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - `make format`, `make test`, `make lint`, and `make ci` passed locally.
   ### Follow-up
   Branch/PR/dirty-work helper extraction remains a later unification slice now that the typed option builder path is stable.
+
+- [x] [I009] Avoid stale generated branch collisions during dirty `gix sync master`.
+  Requested on 2026-06-03 after dirty `master` sync in `/Users/tyemirov/Development/llm-proxy` failed with `branch "sync/llm-proxy/readme" does not have an open pull request into master`.
+  ### Summary
+  Dirty `master` sync generated deterministic work branch names from the repository and first dirty path cluster, such as `sync/llm-proxy/readme`. The branch name should identify the semantic change represented by the diff instead of incidental repository, file, time, or sequence metadata.
+  ### Plan
+  - Add focused strict-sync coverage proving dirty `master` branch names are derived from the generated semantic diff summary.
+  - Limit the semantic branch component to 56 characters, including any collision suffix.
+  - Keep reusing the semantic generated branch when it still has an open PR.
+  - Select the next generated branch suffix only when a semantic generated branch already exists remotely without an open PR.
+  - Preserve existing local-only generated branch recovery.
+  ### Resolution
+  - Added strict-sync regression coverage for dirty `master` branch naming from the generated semantic diff summary.
+  - Replaced `sync/<repo>/<path>` with `gix/<semantic-change>`, stripping Conventional Commit type prefixes before slugging the subject.
+  - Capped the semantic branch component at 56 characters and trims at word boundaries when possible.
+  - Kept collision handling as a last resort: an already-occupied semantic branch advances to the next numeric suffix before the normal commit, push, and pull-request flow continues.
+  - `make test`, `make lint`, and `make ci` passed locally.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,8 +1,6 @@
-- B008 restores sibling-worktree adoption in strict `gix sync`.
-- Reuse the existing adoption helper instead of duplicating commit/push/remove/prune logic.
-- Trigger adoption only when Git reports that the requested branch is already used by another worktree.
-- Preserve the conditional dirty behavior: commit the sibling worktree only when it has uncommitted files; otherwise skip the commit path.
-- Route strict and non-strict branch changes through the same adoption service instead of keeping separate retry blocks.
-- Refetch after adoption so strict sync compares against the pushed remote state before ahead/merge checks.
-- Add focused regression coverage for a dirty sibling worktree blocking a PR-backed sync branch.
-- `make ci` passed locally.
+- Derive dirty `master` generated branch names as `gix/<semantic-change>` instead of repository or file paths.
+- Limit the semantic branch component to 56 characters, including any collision suffix.
+- Keep dirty `master` sync reusing a semantic generated branch only when that remote branch still has an open PR.
+- Select the next generated branch suffix only when the semantic branch name already exists remotely without an open PR.
+- Preserve existing partial-run recovery for local-only generated branches.
+- `make test`, `make lint`, and `make ci` passed locally.

--- a/tests/sync_refresh_integration_test.go
+++ b/tests/sync_refresh_integration_test.go
@@ -27,6 +27,7 @@ const (
 func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T) {
 	testInstance.Helper()
 
+	expectedGeneratedBranchName := "gix/sync-dirty-work"
 	repositoryRoot := integrationRepositoryRoot(testInstance)
 	realGitPath, lookupError := exec.LookPath("git")
 	require.NoError(testInstance, lookupError)
@@ -171,7 +172,7 @@ operations:
 	invocationLogContents, readError := os.ReadFile(gitInvocationLog)
 	require.NoError(testInstance, readError)
 	invocationLog := string(invocationLogContents)
-	require.Contains(testInstance, invocationLog, "switch -c sync/worktree/readme origin/master")
+	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
 	require.Contains(testInstance, invocationLog, "add --all -- README.md")
 	require.Contains(testInstance, invocationLog, "commit -m docs: sync dirty work")
 	require.NotContains(testInstance, string(invocationLogContents), "pull --ff-only")
@@ -180,7 +181,7 @@ operations:
 	localFileContents, localReadError := os.ReadFile(readmePath)
 	require.NoError(testInstance, localReadError)
 	require.Equal(testInstance, "modified locally\n", string(localFileContents))
-	require.Equal(testInstance, "sync/worktree/readme", strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
+	require.Equal(testInstance, expectedGeneratedBranchName, strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
 	require.Empty(testInstance, strings.TrimSpace(runGit(testInstance, repositoryPath, "status", "--porcelain")))
 	require.Equal(testInstance, "docs: sync dirty work", strings.TrimSpace(runGit(testInstance, repositoryPath, "log", "-1", "--pretty=%s")))
 }


### PR DESCRIPTION
### Summary

This change improves the generation of sync branch names to avoid collisions with stale branches by adopting semantic branch names derived from commit messages. Instead of using generic branch prefixes, branch names now incorporate meaningful slugs extracted from commit message subjects following conventional commit types. The new logic attempts multiple candidate names if collisions are detected, ensuring unique and descriptive branch names.

### Details

- Replaced the static "sync" prefix with a "gix" prefix and introduced semantic slugs based on commit messages.
- Added logic to parse commit messages and strip conventional commit prefixes to generate meaningful branch name components.
- Implemented a retry mechanism to generate unique branch names by appending numeric suffixes when collisions with existing remote branches or open pull requests occur.
- Updated tests to reflect the new branch naming scheme and to verify that stale branches are skipped in favor of fresh, semantically named branches.
- Refactored branch name generation into separate functions for clarity and maintainability.

This enhancement reduces confusion and potential conflicts caused by stale or generic sync branch names, improving branch management and pull request workflows.