### PR TITLE
Fix B009 sync ignored path staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@
 ### Bug Fixes 🐛
 - Restore strict `gix sync` adoption of dirty sibling worktrees when the requested branch is already checked out in another folder.
 - Filter dirty `gix sync` pathspec clusters through Git ignore rules so ignored generated files do not cause `git add` failures.
+- Treat ignored-only dirty status as clean before selecting a generated `gix sync` work branch.
 
 ### Testing 🧪
 - Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator and failure-before-push ordering.
 - Add sync command and strict action coverage for explicit PR title/body controls.
 - Add strict-sync regression coverage for committing, pushing, removing, pruning, refetching, and retrying a dirty sibling worktree before switching to the requested branch.
 - Add strict action and CLI-level sync coverage for Python `egg-info` files mixed with ignored `__pycache__` entries.
+- Add strict-sync coverage proving ignored-only status stays on the clean `master` sync path.
 
 ## [v0.6.3] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@
 
 ### Bug Fixes 🐛
 - Restore strict `gix sync` adoption of dirty sibling worktrees when the requested branch is already checked out in another folder.
+- Filter dirty `gix sync` pathspec clusters through Git ignore rules so ignored generated files do not cause `git add` failures.
 
 ### Testing 🧪
 - Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator and failure-before-push ordering.
 - Add sync command and strict action coverage for explicit PR title/body controls.
 - Add strict-sync regression coverage for committing, pushing, removing, pruning, refetching, and retrying a dirty sibling worktree before switching to the requested branch.
+- Add strict action and CLI-level sync coverage for Python `egg-info` files mixed with ignored `__pycache__` entries.
 
 ## [v0.6.3] - 2026-06-03
 

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -142,6 +142,36 @@ func filterIgnoredSyncCommitClusters(ctx context.Context, executor shared.GitExe
 	return filteredClusters, nil
 }
 
+func filterIgnoredSyncStatusEntries(ctx context.Context, executor shared.GitExecutor, repositoryPath string, statusEntries []string) ([]string, error) {
+	statusPaths := syncStatusEntriesPaths(statusEntries)
+	if len(statusPaths) == 0 {
+		return nil, nil
+	}
+	ignoredPaths, ignoredErr := shared.CheckIgnoredPaths(ctx, executor, repositoryPath, statusPaths)
+	if ignoredErr != nil {
+		return nil, fmt.Errorf(strictSyncDirtyIgnoreFailureTemplate, ignoredErr)
+	}
+	if len(ignoredPaths) == 0 {
+		return statusEntries, nil
+	}
+
+	filteredEntries := make([]string, 0, len(statusEntries))
+	for entryIndex := range statusEntries {
+		entryPaths := syncStatusEntryPaths(statusEntries[entryIndex])
+		for pathIndex := range entryPaths {
+			normalizedPath := normalizeSyncStatusPath(entryPaths[pathIndex])
+			if normalizedPath == "" {
+				continue
+			}
+			if _, ignored := ignoredPaths[normalizedPath]; !ignored {
+				filteredEntries = append(filteredEntries, statusEntries[entryIndex])
+				break
+			}
+		}
+	}
+	return filteredEntries, nil
+}
+
 func syncCommitClusterPaths(clusters []syncCommitCluster) []string {
 	paths := make([]string, 0)
 	seenPaths := make(map[string]struct{})
@@ -149,6 +179,26 @@ func syncCommitClusterPaths(clusters []syncCommitCluster) []string {
 		cluster := clusters[clusterIndex]
 		for pathIndex := range cluster.Paths {
 			path := cluster.Paths[pathIndex]
+			if _, seen := seenPaths[path]; seen {
+				continue
+			}
+			seenPaths[path] = struct{}{}
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+func syncStatusEntriesPaths(statusEntries []string) []string {
+	paths := make([]string, 0)
+	seenPaths := make(map[string]struct{})
+	for entryIndex := range statusEntries {
+		entryPaths := syncStatusEntryPaths(statusEntries[entryIndex])
+		for pathIndex := range entryPaths {
+			path := normalizeSyncStatusPath(entryPaths[pathIndex])
+			if path == "" {
+				continue
+			}
 			if _, seen := seenPaths[path]; seen {
 				continue
 			}

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -20,6 +20,7 @@ const (
 	strictSyncDirtyStageFailureTemplate   = "failed to stage dirty sync cluster %q: %w"
 	strictSyncDirtyMessageFailureTemplate = "failed to generate dirty sync commit message for %q: %w"
 	strictSyncDirtyClusterFailureTemplate = "failed to commit dirty sync cluster %q: %w"
+	strictSyncDirtyIgnoreFailureTemplate  = "failed to inspect ignored dirty sync paths: %w"
 	strictSyncGeneratedBranchPrefix       = "gix"
 	strictSyncGeneratedSemanticFallback   = "work"
 	strictSyncGeneratedSemanticSlugLimit  = 56
@@ -49,6 +50,14 @@ type syncCommitCluster struct {
 
 func saveDirtyWorkClusters(ctx context.Context, executor shared.GitExecutor, repositoryPath string, statusEntries []string, options worktreeAdoptionCommitMessageOptions) (int, error) {
 	clusters := buildSyncCommitClusters(statusEntries)
+	if len(clusters) == 0 {
+		return 0, nil
+	}
+	filteredClusters, filterErr := filterIgnoredSyncCommitClusters(ctx, executor, repositoryPath, clusters)
+	if filterErr != nil {
+		return 0, filterErr
+	}
+	clusters = filteredClusters
 	if len(clusters) == 0 {
 		return 0, nil
 	}
@@ -96,6 +105,58 @@ func saveDirtyWorkClusters(ctx context.Context, executor shared.GitExecutor, rep
 	}
 
 	return committedClusters, nil
+}
+
+func filterIgnoredSyncCommitClusters(ctx context.Context, executor shared.GitExecutor, repositoryPath string, clusters []syncCommitCluster) ([]syncCommitCluster, error) {
+	clusterPaths := syncCommitClusterPaths(clusters)
+	if len(clusterPaths) == 0 {
+		return nil, nil
+	}
+	ignoredPaths, ignoredErr := shared.CheckIgnoredPaths(ctx, executor, repositoryPath, clusterPaths)
+	if ignoredErr != nil {
+		return nil, fmt.Errorf(strictSyncDirtyIgnoreFailureTemplate, ignoredErr)
+	}
+	if len(ignoredPaths) == 0 {
+		return clusters, nil
+	}
+
+	filteredClusters := make([]syncCommitCluster, 0, len(clusters))
+	for clusterIndex := range clusters {
+		cluster := clusters[clusterIndex]
+		filteredPaths := make([]string, 0, len(cluster.Paths))
+		for pathIndex := range cluster.Paths {
+			path := cluster.Paths[pathIndex]
+			if _, ignored := ignoredPaths[path]; ignored {
+				continue
+			}
+			filteredPaths = append(filteredPaths, path)
+		}
+		if len(filteredPaths) == 0 {
+			continue
+		}
+		filteredClusters = append(filteredClusters, syncCommitCluster{
+			Root:  cluster.Root,
+			Paths: filteredPaths,
+		})
+	}
+	return filteredClusters, nil
+}
+
+func syncCommitClusterPaths(clusters []syncCommitCluster) []string {
+	paths := make([]string, 0)
+	seenPaths := make(map[string]struct{})
+	for clusterIndex := range clusters {
+		cluster := clusters[clusterIndex]
+		for pathIndex := range cluster.Paths {
+			path := cluster.Paths[pathIndex]
+			if _, seen := seenPaths[path]; seen {
+				continue
+			}
+			seenPaths[path] = struct{}{}
+			paths = append(paths, path)
+		}
+	}
+	return paths
 }
 
 func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, remoteName string, baseBranch string, branchName string, commitMessages worktreeAdoptionCommitMessageOptions) error {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -467,6 +467,11 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 	if statusErr != nil {
 		return statusErr
 	}
+	stageableStatusEntries, stageableStatusErr := filterIgnoredSyncStatusEntries(ctx, environment.GitExecutor, repository.Path, statusEntries)
+	if stageableStatusErr != nil {
+		return stageableStatusErr
+	}
+	statusEntries = stageableStatusEntries
 	trackedStatus, untrackedStatus := worktree.SplitStatusEntries(statusEntries, nil)
 	dirty := len(trackedStatus) > 0 || len(untrackedStatus) > 0
 

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -115,6 +115,7 @@ type strictSyncGitExecutor struct {
 	diffOutput        string
 	revListOutput     string
 	missingReferences map[string]bool
+	ignoredPaths      map[string]bool
 	mergeError        error
 	blockedBranch     string
 	blockedWorktree   string
@@ -135,6 +136,21 @@ func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details exe
 			return execshell.ExecutionResult{StandardOutput: "M  README.md\n"}, nil
 		}
 		return execshell.ExecutionResult{StandardOutput: executor.statusOutput}, nil
+	case "check-ignore":
+		ignored := make([]string, 0)
+		for _, candidatePath := range strings.Split(string(details.StandardInput), "\n") {
+			trimmedPath := strings.TrimSpace(candidatePath)
+			if trimmedPath == "" {
+				continue
+			}
+			if executor.ignoredPaths[trimmedPath] {
+				ignored = append(ignored, trimmedPath)
+			}
+		}
+		if len(ignored) == 0 {
+			return execshell.ExecutionResult{}, commandFailedErrorWithExitCode("", 1)
+		}
+		return execshell.ExecutionResult{StandardOutput: strings.Join(ignored, "\n") + "\n"}, nil
 	case "diff":
 		if commandHasArgument(details.Arguments, "--stat") {
 			output := executor.diffStatOutput
@@ -445,6 +461,63 @@ func TestHandleBranchSyncActionStrictPRBranchAutoCommitsDirtySameBranch(t *testi
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "reset --hard origin/feature/foo")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push origin feature/foo")
+	require.Len(t, chatClient.requests, 1)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchFiltersIgnoredDirtyPathsBeforeStaging(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: strings.Join([]string{
+			"?? python/llm_proxy_client.egg-info/PKG-INFO",
+			"?? python/llm_proxy_client.egg-info/SOURCES.txt",
+			"!! python/llm_proxy_client/__pycache__/client.cpython-313.pyc",
+			"!! python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc",
+		}, "\n") + "\n",
+		revListOutput: "1\n",
+		ignoredPaths: map[string]bool{
+			"python/llm_proxy_client/__pycache__/client.cpython-313.pyc":        true,
+			"python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Feature","headRefName":"feature/foo"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{response: "fix: sync generated client metadata"}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "check-ignore --stdin")
+	require.Contains(t, recordedCommands, "add --all -- python/llm_proxy_client.egg-info/PKG-INFO python/llm_proxy_client.egg-info/SOURCES.txt")
+	require.NotContains(t, recordedCommands, "__pycache__")
+	require.Contains(t, recordedCommands, "commit -m fix: sync generated client metadata")
+	require.Contains(t, recordedCommands, "push origin feature/foo")
 	require.Len(t, chatClient.requests, 1)
 }
 

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -521,6 +521,61 @@ func TestHandleBranchSyncActionStrictPRBranchFiltersIgnoredDirtyPathsBeforeStagi
 	require.Len(t, chatClient.requests, 1)
 }
 
+func TestHandleBranchSyncActionStrictPRBranchTreatsIgnoredOnlyStatusAsClean(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: strings.Join([]string{
+			"!! python/llm_proxy_client/__pycache__/client.cpython-313.pyc",
+			"!! python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc",
+		}, "\n") + "\n",
+		ignoredPaths: map[string]bool{
+			"python/llm_proxy_client/__pycache__/client.cpython-313.pyc":        true,
+			"python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":8,"title":"Generated","headRefName":"gix/sync-dirty-work"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "master",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "check-ignore --stdin")
+	require.Contains(t, recordedCommands, "switch master")
+	require.Contains(t, recordedCommands, "reset --hard origin/master")
+	require.NotContains(t, recordedCommands, "switch -c gix/sync-dirty-work")
+	require.NotContains(t, recordedCommands, "add --all")
+	require.NotContains(t, recordedCommands, "commit -m")
+	require.Len(t, chatClient.requests, 0)
+}
+
 func TestHandleBranchSyncActionStrictPRBranchAdoptsDirtySiblingWorktree(t *testing.T) {
 	gitExecutor := &strictSyncGitExecutor{
 		blockedBranch:   "feature/foo",

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -11,6 +11,21 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
 
 ## BugFixes
 
+- [x] [B009] (P1) `gix sync` tries to stage ignored generated paths during dirty auto-commit.
+  Requested on 2026-06-06 after `gix sync` in `/Users/tyemirov/Development/llm-proxy` failed while running `git add --all --` with Python generated files from `egg-info` and ignored `__pycache__` folders.
+  ## Observation
+  - Dirty sync builds explicit pathspec clusters from worktree status and passes them to `git add --all --`.
+  - In the reported failure, ignored `python/llm_proxy_client/__pycache__` and `python/tests/__pycache__` paths reached `git add`, which Git rejected because they are ignored by `.gitignore`.
+  ## Deliverable
+  - Ensure dirty sync filters ignored generated paths before staging explicit pathspec clusters.
+  - Preserve auto-commit behavior for tracked changes and unignored untracked files.
+  - Add regression coverage proving ignored paths do not reach `git add`.
+  ## Resolution
+  - Dirty sync now checks each selected staging pathspec with Git ignore rules before invoking `git add --all --`.
+  - Ignored pathspecs are removed from their commit cluster while unignored generated metadata files remain stageable.
+  - Added strict-sync action coverage and CLI-level sync coverage for Python `egg-info` files mixed with ignored `__pycache__` entries.
+  - `make test`, `make lint`, and `make ci` passed locally.
+
 - [x] [B008] (P1) `gix sync` strict PR flow no longer adopts dirty sibling worktrees for the requested branch.
   Requested on 2026-06-03 after the `v0.6.1` release check showed the old sibling-worktree adoption helper still existed, but the public strict `gix sync` path did not call it when Git refused to switch to a branch already checked out in another folder.
   ## Observation

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -23,6 +23,7 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   ## Resolution
   - Dirty sync now checks each selected staging pathspec with Git ignore rules before invoking `git add --all --`.
   - Ignored pathspecs are removed from their commit cluster while unignored generated metadata files remain stageable.
+  - Ignored-only status entries are filtered before dirty branch selection, so `gix sync master` stays on the clean base-branch sync path when there is nothing stageable.
   - Added strict-sync action coverage and CLI-level sync coverage for Python `egg-info` files mixed with ignored `__pycache__` entries.
   - `make test`, `make lint`, and `make ci` passed locally.
 

--- a/tests/sync_refresh_integration_test.go
+++ b/tests/sync_refresh_integration_test.go
@@ -37,6 +37,14 @@ func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T
 		"#!/bin/sh",
 		"echo \"$@\" >> " + gitInvocationLog,
 		"if [ \"$1\" = \"pull\" ] && [ \"$2\" = \"--rebase\" ]; then exit 42; fi",
+		"if [ \"$1\" = \"status\" ] && [ \"$2\" = \"--porcelain\" ]; then",
+		"  " + realGitPath + " \"$@\"",
+		"  status_exit=$?",
+		"  if [ \"$status_exit\" -eq 0 ]; then",
+		"    printf '%s\\n' '!! python/llm_proxy_client/__pycache__/client.cpython-313.pyc' '!! python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc'",
+		"  fi",
+		"  exit \"$status_exit\"",
+		"fi",
 		"exec " + realGitPath + " \"$@\"",
 	}, "\n") + "\n")
 	pathVariable := buildStubbedExecutablePath(testInstance, "git", string(gitStubScript))
@@ -59,14 +67,21 @@ func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T
 	configEmailCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, configEmailCommand.Run())
 
+	statusConfigCommand := exec.Command("git", "-C", repositoryPath, "config", "status.showUntrackedFiles", "all")
+	statusConfigCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, statusConfigCommand.Run())
+
 	remoteAddCommand := exec.Command("git", "-C", repositoryPath, "remote", "add", "origin", remotePath)
 	remoteAddCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, remoteAddCommand.Run())
 
+	gitignorePath := filepath.Join(repositoryPath, ".gitignore")
+	require.NoError(testInstance, os.WriteFile(gitignorePath, []byte("__pycache__/\n"), 0o644))
+
 	readmePath := filepath.Join(repositoryPath, "README.md")
 	require.NoError(testInstance, os.WriteFile(readmePath, []byte("initial\n"), 0o644))
 
-	addCommand := exec.Command("git", "-C", repositoryPath, "add", "README.md")
+	addCommand := exec.Command("git", "-C", repositoryPath, "add", ".gitignore", "README.md")
 	addCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, addCommand.Run())
 
@@ -107,6 +122,16 @@ func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T
 	require.NoError(testInstance, upstreamPushCommand.Run())
 
 	require.NoError(testInstance, os.WriteFile(readmePath, []byte("modified locally\n"), 0o644))
+	eggInfoPath := filepath.Join(repositoryPath, "python", "llm_proxy_client.egg-info")
+	require.NoError(testInstance, os.MkdirAll(eggInfoPath, 0o755))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(eggInfoPath, "PKG-INFO"), []byte("metadata\n"), 0o644))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(eggInfoPath, "SOURCES.txt"), []byte("sources\n"), 0o644))
+	clientCachePath := filepath.Join(repositoryPath, "python", "llm_proxy_client", "__pycache__")
+	require.NoError(testInstance, os.MkdirAll(clientCachePath, 0o755))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(clientCachePath, "client.cpython-313.pyc"), []byte("cache\n"), 0o644))
+	testCachePath := filepath.Join(repositoryPath, "python", "tests", "__pycache__")
+	require.NoError(testInstance, os.MkdirAll(testCachePath, 0o755))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(testCachePath, "test_client.cpython-313-pytest-9.0.3.pyc"), []byte("cache\n"), 0o644))
 
 	llmServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/chat/completions" {
@@ -172,8 +197,11 @@ operations:
 	invocationLogContents, readError := os.ReadFile(gitInvocationLog)
 	require.NoError(testInstance, readError)
 	invocationLog := string(invocationLogContents)
+	require.Contains(testInstance, invocationLog, "check-ignore --stdin")
 	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
 	require.Contains(testInstance, invocationLog, "add --all -- README.md")
+	require.Contains(testInstance, invocationLog, "add --all -- python/llm_proxy_client.egg-info/PKG-INFO python/llm_proxy_client.egg-info/SOURCES.txt")
+	require.NotContains(testInstance, invocationLog, "__pycache__")
 	require.Contains(testInstance, invocationLog, "commit -m docs: sync dirty work")
 	require.NotContains(testInstance, string(invocationLogContents), "pull --ff-only")
 	require.NotContains(testInstance, string(invocationLogContents), "pull --rebase")


### PR DESCRIPTION
## Summary
- Filter dirty-sync staging clusters through Git ignore rules before `git add --all --`.
- Keep unignored generated metadata pathspecs stageable while dropping ignored `__pycache__` paths.
- Record B009 in the issue log and changelog.

## Tests
- `timeout -k 350s -s SIGKILL 350s make test`
- `timeout -k 350s -s SIGKILL 350s make lint`
- `timeout -k 350s -s SIGKILL 350s make ci`