### PR TITLE
Fix B011 tracked ignored sync cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add strict action and CLI-level sync coverage for Python `egg-info` files mixed with ignored `__pycache__` entries.
 - Add strict-sync coverage proving ignored-only status stays on the clean `master` sync path.
 - Add sync-flow and black-box CLI coverage proving tracked ignored modified/deleted paths are restored while ordinary dirty files are still committed.
+- Add strict-sync failure-mode coverage for staged tracked ignored dirt, `--require-clean`, `--stash`, fetch-before-restore ordering, and restore failures.
 
 ## [v0.6.5] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Restore strict `gix sync` adoption of dirty sibling worktrees when the requested branch is already checked out in another folder.
 - Filter dirty `gix sync` pathspec clusters through Git ignore rules so ignored generated files do not cause `git add` failures.
 - Treat ignored-only dirty status as clean before selecting a generated `gix sync` work branch.
+- Restore tracked ignored dirty paths during successful `gix sync` runs so generated artifacts do not remain in `git status`.
 
 ### Testing 🧪
 - Update strict-sync pull request creation coverage for requested branches and generated dirty-`master` branches, including the branch diff context sent to the PR body generator and failure-before-push ordering.
@@ -19,6 +20,7 @@
 - Add strict-sync regression coverage for committing, pushing, removing, pruning, refetching, and retrying a dirty sibling worktree before switching to the requested branch.
 - Add strict action and CLI-level sync coverage for Python `egg-info` files mixed with ignored `__pycache__` entries.
 - Add strict-sync coverage proving ignored-only status stays on the clean `master` sync path.
+- Add sync-flow and black-box CLI coverage proving tracked ignored modified/deleted paths are restored while ordinary dirty files are still committed.
 
 ## [v0.6.5] - 2026-06-06
 

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -21,6 +21,7 @@ const (
 	strictSyncDirtyMessageFailureTemplate = "failed to generate dirty sync commit message for %q: %w"
 	strictSyncDirtyClusterFailureTemplate = "failed to commit dirty sync cluster %q: %w"
 	strictSyncDirtyIgnoreFailureTemplate  = "failed to inspect ignored dirty sync paths: %w"
+	strictSyncDirtyRestoreFailureTemplate = "failed to restore ignored dirty sync paths: %w"
 	strictSyncGeneratedBranchPrefix       = "gix"
 	strictSyncGeneratedSemanticFallback   = "work"
 	strictSyncGeneratedSemanticSlugLimit  = 56
@@ -46,6 +47,11 @@ var syncConventionalCommitTypes = map[string]struct{}{
 type syncCommitCluster struct {
 	Root  string
 	Paths []string
+}
+
+type syncStatusFilterResult struct {
+	StageableEntries      []string
+	IgnoredTrackedEntries []string
 }
 
 func saveDirtyWorkClusters(ctx context.Context, executor shared.GitExecutor, repositoryPath string, statusEntries []string, options worktreeAdoptionCommitMessageOptions) (int, error) {
@@ -142,34 +148,61 @@ func filterIgnoredSyncCommitClusters(ctx context.Context, executor shared.GitExe
 	return filteredClusters, nil
 }
 
-func filterIgnoredSyncStatusEntries(ctx context.Context, executor shared.GitExecutor, repositoryPath string, statusEntries []string) ([]string, error) {
+func filterIgnoredSyncStatusEntries(ctx context.Context, executor shared.GitExecutor, repositoryPath string, statusEntries []string) (syncStatusFilterResult, error) {
 	statusPaths := syncStatusEntriesPaths(statusEntries)
 	if len(statusPaths) == 0 {
-		return nil, nil
+		return syncStatusFilterResult{}, nil
 	}
 	ignoredPaths, ignoredErr := shared.CheckIgnoredPaths(ctx, executor, repositoryPath, statusPaths)
 	if ignoredErr != nil {
-		return nil, fmt.Errorf(strictSyncDirtyIgnoreFailureTemplate, ignoredErr)
+		return syncStatusFilterResult{}, fmt.Errorf(strictSyncDirtyIgnoreFailureTemplate, ignoredErr)
 	}
 	if len(ignoredPaths) == 0 {
-		return statusEntries, nil
+		return syncStatusFilterResult{StageableEntries: statusEntries}, nil
 	}
 
-	filteredEntries := make([]string, 0, len(statusEntries))
+	result := syncStatusFilterResult{
+		StageableEntries:      make([]string, 0, len(statusEntries)),
+		IgnoredTrackedEntries: make([]string, 0, len(ignoredPaths)),
+	}
 	for entryIndex := range statusEntries {
 		entryPaths := syncStatusEntryPaths(statusEntries[entryIndex])
+		hasIgnoredPath := false
+		hasStageablePath := false
 		for pathIndex := range entryPaths {
 			normalizedPath := normalizeSyncStatusPath(entryPaths[pathIndex])
 			if normalizedPath == "" {
 				continue
 			}
-			if _, ignored := ignoredPaths[normalizedPath]; !ignored {
-				filteredEntries = append(filteredEntries, statusEntries[entryIndex])
-				break
+			if _, ignored := ignoredPaths[normalizedPath]; ignored {
+				hasIgnoredPath = true
+				continue
 			}
+			hasStageablePath = true
+		}
+		if hasStageablePath {
+			result.StageableEntries = append(result.StageableEntries, statusEntries[entryIndex])
+			continue
+		}
+		trackedEntries, _ := worktree.SplitStatusEntries([]string{statusEntries[entryIndex]}, nil)
+		if hasIgnoredPath && len(trackedEntries) > 0 {
+			result.IgnoredTrackedEntries = append(result.IgnoredTrackedEntries, statusEntries[entryIndex])
 		}
 	}
-	return filteredEntries, nil
+	return result, nil
+}
+
+func restoreIgnoredSyncStatusEntries(ctx context.Context, executor shared.GitExecutor, repositoryPath string, statusEntries []string) error {
+	ignoredTrackedPaths := syncStatusEntriesPaths(statusEntries)
+	if len(ignoredTrackedPaths) == 0 {
+		return nil
+	}
+	restoreArguments := []string{gitRestoreSubcommandConstant, "--staged", "--worktree", gitPathspecSeparatorConstant}
+	restoreArguments = append(restoreArguments, ignoredTrackedPaths...)
+	if restoreErr := executeGit(ctx, executor, repositoryPath, restoreArguments); restoreErr != nil {
+		return fmt.Errorf(strictSyncDirtyRestoreFailureTemplate, restoreErr)
+	}
+	return nil
 }
 
 func syncCommitClusterPaths(clusters []syncCommitCluster) []string {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -48,6 +48,7 @@ const (
 	gitMergeFastForwardOnlyFlagConstant          = "--ff-only"
 	gitResetSubcommandConstant                   = "reset"
 	gitResetHardFlagConstant                     = "--hard"
+	gitRestoreSubcommandConstant                 = "restore"
 	gitPushSubcommandConstant                    = "push"
 	gitPushSetUpstreamFlagConstant               = "-u"
 	gitRevListSubcommandConstant                 = "rev-list"
@@ -467,11 +468,11 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 	if statusErr != nil {
 		return statusErr
 	}
-	stageableStatusEntries, stageableStatusErr := filterIgnoredSyncStatusEntries(ctx, environment.GitExecutor, repository.Path, statusEntries)
-	if stageableStatusErr != nil {
-		return stageableStatusErr
+	filteredStatus, filteredStatusErr := filterIgnoredSyncStatusEntries(ctx, environment.GitExecutor, repository.Path, statusEntries)
+	if filteredStatusErr != nil {
+		return filteredStatusErr
 	}
-	statusEntries = stageableStatusEntries
+	statusEntries = filteredStatus.StageableEntries
 	trackedStatus, untrackedStatus := worktree.SplitStatusEntries(statusEntries, nil)
 	dirty := len(trackedStatus) > 0 || len(untrackedStatus) > 0
 
@@ -496,6 +497,9 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 
 	if fetchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName}); fetchErr != nil {
 		return fmt.Errorf(gitFetchFailureTemplateConstant, fetchErr)
+	}
+	if restoreErr := restoreIgnoredSyncStatusEntries(ctx, environment.GitExecutor, repository.Path, filteredStatus.IgnoredTrackedEntries); restoreErr != nil {
+		return restoreErr
 	}
 
 	if dirty {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -476,6 +476,17 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 	trackedStatus, untrackedStatus := worktree.SplitStatusEntries(statusEntries, nil)
 	dirty := len(trackedStatus) > 0 || len(untrackedStatus) > 0
 
+	if dirty && options.RequireClean && !options.CommitChanges && !options.StashChanges {
+		return errors.New(strictSyncDirtyWorktreeTemplate)
+	}
+
+	if fetchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName}); fetchErr != nil {
+		return fmt.Errorf(gitFetchFailureTemplateConstant, fetchErr)
+	}
+	if restoreErr := restoreIgnoredSyncStatusEntries(ctx, environment.GitExecutor, repository.Path, filteredStatus.IgnoredTrackedEntries); restoreErr != nil {
+		return restoreErr
+	}
+
 	stashPushed := false
 	if dirty && options.StashChanges {
 		if stashErr := stashAllChanges(ctx, environment.GitExecutor, repository.Path); stashErr != nil {
@@ -493,13 +504,6 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 	checkpointCommitted := false
 	if dirty && options.RequireClean && !options.CommitChanges {
 		return errors.New(strictSyncDirtyWorktreeTemplate)
-	}
-
-	if fetchErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitFetchSubcommandConstant, gitFetchPruneFlagConstant, remoteName}); fetchErr != nil {
-		return fmt.Errorf(gitFetchFailureTemplateConstant, fetchErr)
-	}
-	if restoreErr := restoreIgnoredSyncStatusEntries(ctx, environment.GitExecutor, repository.Path, filteredStatus.IgnoredTrackedEntries); restoreErr != nil {
-		return restoreErr
 	}
 
 	if dirty {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -117,6 +117,7 @@ type strictSyncGitExecutor struct {
 	missingReferences  map[string]bool
 	ignoredPaths       map[string]bool
 	cachedIgnoredPaths map[string]bool
+	commandErrors      map[string]error
 	mergeError         error
 	blockedBranch      string
 	blockedWorktree    string
@@ -127,6 +128,11 @@ func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details exe
 	executor.commands = append(executor.commands, details)
 	if len(details.Arguments) == 0 {
 		return execshell.ExecutionResult{}, nil
+	}
+	if executor.commandErrors != nil {
+		if commandErr, exists := executor.commandErrors[strings.Join(details.Arguments, " ")]; exists {
+			return execshell.ExecutionResult{}, commandErr
+		}
 	}
 	switch details.Arguments[0] {
 	case "status":
@@ -698,6 +704,213 @@ func TestHandleBranchSyncActionStrictPRBranchRestoresTrackedIgnoredOnlyStatus(t 
 	require.NotContains(t, recordedCommands, "add --all")
 	require.NotContains(t, recordedCommands, "commit -m")
 	require.Len(t, chatClient.requests, 0)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchRestoresStagedTrackedIgnoredOnlyStatusWithRequireClean(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: strings.Join([]string{
+			"M  python/llm_proxy_client/__pycache__/client.cpython-313.pyc",
+			"D  python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc",
+		}, "\n") + "\n",
+		cachedIgnoredPaths: map[string]bool{
+			"python/llm_proxy_client/__pycache__/client.cpython-313.pyc":        true,
+			"python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Feature","headRefName":"feature/foo"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
+	require.Contains(t, recordedCommands, "switch feature/foo")
+	require.Contains(t, recordedCommands, "reset --hard origin/feature/foo")
+	require.Contains(t, recordedCommands, "merge --no-edit origin/master")
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "fetch --prune origin"), recordedGitCommandIndex(gitExecutor.commands, "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc"))
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc"), recordedGitCommandIndex(gitExecutor.commands, "switch feature/foo"))
+	require.NotContains(t, recordedCommands, "add --all")
+	require.NotContains(t, recordedCommands, "commit -m")
+	require.Len(t, chatClient.requests, 0)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchRestoresTrackedIgnoredStatusBeforeStashingDirtyWork(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: strings.Join([]string{
+			" M python/llm_proxy_client/__pycache__/client.cpython-313.pyc",
+			" M README.md",
+		}, "\n") + "\n",
+		cachedIgnoredPaths: map[string]bool{
+			"python/llm_proxy_client/__pycache__/client.cpython-313.pyc": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Feature","headRefName":"feature/foo"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionStashChanges:       true,
+		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	restoreCommand := "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc"
+	stashPushCommand := "stash push --include-untracked"
+	require.Contains(t, recordedCommands, restoreCommand)
+	require.Contains(t, recordedCommands, stashPushCommand)
+	require.Contains(t, recordedCommands, "stash pop")
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "fetch --prune origin"), recordedGitCommandIndex(gitExecutor.commands, restoreCommand))
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, restoreCommand), recordedGitCommandIndex(gitExecutor.commands, stashPushCommand))
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, stashPushCommand), recordedGitCommandIndex(gitExecutor.commands, "switch feature/foo"))
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "switch feature/foo"), recordedGitCommandIndex(gitExecutor.commands, "stash pop"))
+	require.NotContains(t, recordedCommands, "add --all")
+	require.NotContains(t, recordedCommands, "commit -m")
+	require.Len(t, chatClient.requests, 0)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchDoesNotRestoreTrackedIgnoredStatusWhenFetchFails(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: " M python/llm_proxy_client/__pycache__/client.cpython-313.pyc\n",
+		cachedIgnoredPaths: map[string]bool{
+			"python/llm_proxy_client/__pycache__/client.cpython-313.pyc": true,
+		},
+		commandErrors: map[string]error{
+			"fetch --prune origin": commandFailedError("fatal: fetch failed"),
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch: "master",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "master",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+	}
+
+	syncError := handleBranchSyncAction(context.Background(), environment, repository, parameters)
+	require.Error(t, syncError)
+	require.Contains(t, syncError.Error(), "failed to fetch updates")
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "fetch --prune origin")
+	require.NotContains(t, recordedCommands, "restore --staged --worktree")
+	require.NotContains(t, recordedCommands, "reset --hard origin/master")
+}
+
+func TestHandleBranchSyncActionStrictPRBranchStopsWhenTrackedIgnoredRestoreFails(t *testing.T) {
+	restoreCommand := "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc"
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: " M python/llm_proxy_client/__pycache__/client.cpython-313.pyc\n",
+		cachedIgnoredPaths: map[string]bool{
+			"python/llm_proxy_client/__pycache__/client.cpython-313.pyc": true,
+		},
+		commandErrors: map[string]error{
+			restoreCommand: commandFailedError("fatal: restore failed"),
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch: "master",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "master",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+	}
+
+	syncError := handleBranchSyncAction(context.Background(), environment, repository, parameters)
+	require.Error(t, syncError)
+	require.Contains(t, syncError.Error(), "failed to restore ignored dirty sync paths")
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, restoreCommand)
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "fetch --prune origin"), recordedGitCommandIndex(gitExecutor.commands, restoreCommand))
+	require.NotContains(t, recordedCommands, "switch master")
+	require.NotContains(t, recordedCommands, "reset --hard origin/master")
+	require.NotContains(t, recordedCommands, "add --all")
+	require.NotContains(t, recordedCommands, "commit -m")
 }
 
 func TestHandleBranchSyncActionStrictPRBranchTreatsIgnoredOnlyStatusAsClean(t *testing.T) {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -532,6 +532,7 @@ func TestHandleBranchSyncActionStrictPRBranchFiltersIgnoredDirtyPathsBeforeStagi
 			expectedCommands: []string{
 				"check-ignore --stdin",
 				"ls-files --cached --ignored --exclude-standard -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc scripts/deploy.sh",
+				"restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc",
 				"add --all -- scripts/deploy.sh",
 			},
 			rejectedCommands: []string{
@@ -552,6 +553,7 @@ func TestHandleBranchSyncActionStrictPRBranchFiltersIgnoredDirtyPathsBeforeStagi
 			expectedCommands: []string{
 				"check-ignore --stdin",
 				"ls-files --cached --ignored --exclude-standard -- python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc python/llm_proxy_client/client.py",
+				"restore --staged --worktree -- python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc",
 				"add --all -- python/llm_proxy_client/client.py",
 			},
 			rejectedCommands: []string{
@@ -574,6 +576,7 @@ func TestHandleBranchSyncActionStrictPRBranchFiltersIgnoredDirtyPathsBeforeStagi
 			commitMessage: "fix: sync release script",
 			expectedCommands: []string{
 				"check-ignore --stdin",
+				"restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc",
 				"add --all -- scripts/release.sh",
 			},
 			rejectedCommands: []string{
@@ -638,6 +641,63 @@ func TestHandleBranchSyncActionStrictPRBranchFiltersIgnoredDirtyPathsBeforeStagi
 			require.Len(t, chatClient.requests, 1)
 		})
 	}
+}
+
+func TestHandleBranchSyncActionStrictPRBranchRestoresTrackedIgnoredOnlyStatus(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput: strings.Join([]string{
+			" M python/llm_proxy_client/__pycache__/client.cpython-313.pyc",
+			" D python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc",
+		}, "\n") + "\n",
+		cachedIgnoredPaths: map[string]bool{
+			"python/llm_proxy_client/__pycache__/client.cpython-313.pyc":        true,
+			"python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":8,"title":"Generated","headRefName":"gix/sync-dirty-work"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "master",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "check-ignore --stdin")
+	require.Contains(t, recordedCommands, "ls-files --cached --ignored --exclude-standard -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
+	require.Contains(t, recordedCommands, "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
+	require.Contains(t, recordedCommands, "switch master")
+	require.Contains(t, recordedCommands, "reset --hard origin/master")
+	require.NotContains(t, recordedCommands, "switch -c gix/sync-dirty-work")
+	require.NotContains(t, recordedCommands, "add --all")
+	require.NotContains(t, recordedCommands, "commit -m")
+	require.Len(t, chatClient.requests, 0)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchTreatsIgnoredOnlyStatusAsClean(t *testing.T) {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -11,6 +11,24 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
 
 ## BugFixes
 
+- [x] [B011] (P1) `gix sync` leaves tracked ignored dirty paths after a successful sync.
+  Requested on 2026-06-06 after `v0.6.5` allowed `gix sync` to finish in `/Users/tyemirov/Development/llm-proxy`, but `git status` still showed deleted `python/llm_proxy_client.egg-info/*` files and modified/deleted tracked `__pycache__` files.
+  ## Observation
+  - B010 filters tracked ignored paths out of dirty sync staging so they no longer trigger ignored pathspec failures.
+  - Filtered tracked ignored paths are then dropped from the dirty set entirely, so sync can report `SYNCED` while `git status --porcelain` still contains tracked ignored generated artifacts.
+  ## Deliverable
+  - Restore tracked ignored dirty paths before sync proceeds so ignored generated artifacts do not remain as tracked worktree dirt.
+  - Preserve the B010 guarantee that ignored generated pathspecs never reach `git add --all --`.
+  - Preserve auto-commit behavior for ordinary tracked and unignored untracked changes.
+  - Add integration coverage proving `gix sync` leaves the worktree clean after mixed ordinary and tracked ignored dirty paths.
+  ## Resolution
+  - Dirty sync now keeps stageable status entries separate from tracked ignored status entries.
+  - After the remote fetch succeeds, `gix sync` restores tracked ignored dirty paths with `git restore --staged --worktree -- <paths>` before saving ordinary dirty work.
+  - Ignored untracked paths remain unstaged, tracked ignored generated artifacts are restored to `HEAD`, and ordinary dirty files still flow through the existing generated-commit path.
+  - Updated strict-sync table coverage to assert restore commands for cached ignored modifications/deletions and ignored-only tracked dirt.
+  - Updated the black-box sync integration test to prove modified/deleted tracked `.pyc` files are restored, ignored pathspecs never reach `git add --all --`, the ordinary script change is committed, and final `git status --porcelain` is clean.
+  - `make test-fast`, non-cached `make test-slow`, `make test`, `make lint`, and `make ci` passed locally.
+
 - [x] [B010] (P1) `gix sync` still stages tracked files under ignored parent directories.
   Requested on 2026-06-06 after installing `v0.6.4` and rerunning `gix sync` in `/Users/tyemirov/Development/llm-proxy`.
   ## Observation

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -26,7 +26,7 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - After the remote fetch succeeds, `gix sync` restores tracked ignored dirty paths with `git restore --staged --worktree -- <paths>` before saving ordinary dirty work.
   - Ignored untracked paths remain unstaged, tracked ignored generated artifacts are restored to `HEAD`, and ordinary dirty files still flow through the existing generated-commit path.
   - Updated strict-sync table coverage to assert restore commands for cached ignored modifications/deletions and ignored-only tracked dirt.
-  - Updated the black-box sync integration test to prove modified/deleted tracked `.pyc` files are restored, ignored pathspecs never reach `git add --all --`, the ordinary script change is committed, and final `git status --porcelain` is clean.
+  - Updated the black-box sync integration test to prove modified/deleted tracked `.pyc` files are restored, ignored pathspecs never reach `git add --all --`, tracked `egg-info` deletions are committed, and final `git status --porcelain` is clean.
   - `make test-fast`, non-cached `make test-slow`, `make test`, `make lint`, and `make ci` passed locally.
 
 - [x] [B010] (P1) `gix sync` still stages tracked files under ignored parent directories.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -26,6 +26,7 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
   - After the remote fetch succeeds, `gix sync` restores tracked ignored dirty paths with `git restore --staged --worktree -- <paths>` before saving ordinary dirty work.
   - Ignored untracked paths remain unstaged, tracked ignored generated artifacts are restored to `HEAD`, and ordinary dirty files still flow through the existing generated-commit path.
   - Updated strict-sync table coverage to assert restore commands for cached ignored modifications/deletions and ignored-only tracked dirt.
+  - Added strict-sync failure-mode coverage proving staged tracked ignored dirt is restored under `--require-clean`, `--stash` restores tracked ignored dirt before stashing ordinary work, fetch failures do not restore paths, and restore failures stop before branch switching or commits.
   - Updated the black-box sync integration test to prove modified/deleted tracked `.pyc` files are restored, ignored pathspecs never reach `git add --all --`, tracked `egg-info` deletions are committed, and final `git status --porcelain` is clean.
   - `make test-fast`, non-cached `make test-slow`, `make test`, `make lint`, and `make ci` passed locally.
 

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -3,4 +3,5 @@
 - Implemented a sync status filter result that keeps stageable entries and tracked ignored entries separate.
 - Restored tracked ignored entries with `git restore --staged --worktree -- <paths>` after fetch succeeds and before dirty sync continues.
 - Tightened the black-box integration scenario to match the reported `llm-proxy` shape: tracked `egg-info` deletions plus tracked ignored `__pycache__` modifications/deletions.
+- Added focused syncflow tests for staged tracked ignored dirt, `--require-clean`, `--stash`, fetch failure before restore, and restore failure abort behavior.
 - Ran targeted sync tests plus `make test-fast`, non-cached `make test-slow`, `make test`, `make lint`, and `make ci`.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,7 +1,5 @@
-# B010 sync tracked ignored pathspecs
-
-- Reproduced the missed `gix sync` case where tracked `.pyc` files live under ignored `__pycache__` directories.
-- Extended shared ignore filtering with Git's cached ignored view so tracked ignored files are filtered before `git add --all --`.
-- Kept unignored tracked and untracked dirty paths eligible for auto-commit.
-- Added regression coverage for cached ignored paths and the strict PR dirty-sync staging path.
-- `make test-fast`, `make test-slow`, `make lint`, and `make ci` passed locally.
+- Confirmed the existing B010 integration test expected tracked ignored dirty paths to remain.
+- Changed strict sync coverage so tracked ignored dirty paths are restored, not staged or committed.
+- Implemented a sync status filter result that keeps stageable entries and tracked ignored entries separate.
+- Restored tracked ignored entries with `git restore --staged --worktree -- <paths>` after fetch succeeds and before dirty sync continues.
+- Ran targeted sync tests plus `make test-fast`, non-cached `make test-slow`, `make test`, `make lint`, and `make ci`.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -2,4 +2,5 @@
 - Changed strict sync coverage so tracked ignored dirty paths are restored, not staged or committed.
 - Implemented a sync status filter result that keeps stageable entries and tracked ignored entries separate.
 - Restored tracked ignored entries with `git restore --staged --worktree -- <paths>` after fetch succeeds and before dirty sync continues.
+- Tightened the black-box integration scenario to match the reported `llm-proxy` shape: tracked `egg-info` deletions plus tracked ignored `__pycache__` modifications/deletions.
 - Ran targeted sync tests plus `make test-fast`, non-cached `make test-slow`, `make test`, `make lint`, and `make ci`.

--- a/tests/sync_refresh_integration_test.go
+++ b/tests/sync_refresh_integration_test.go
@@ -255,9 +255,12 @@ func TestSyncFiltersTrackedIgnoredDirtyPathsBeforeStaging(testInstance *testing.
 
 	gitignorePath := filepath.Join(repositoryPath, ".gitignore")
 	require.NoError(testInstance, os.WriteFile(gitignorePath, []byte("__pycache__/\n"), 0o644))
-	scriptPath := filepath.Join(repositoryPath, "scripts", "release.sh")
-	require.NoError(testInstance, os.MkdirAll(filepath.Dir(scriptPath), 0o755))
-	require.NoError(testInstance, os.WriteFile(scriptPath, []byte("#!/bin/sh\necho initial\n"), 0o755))
+	eggInfoPath := filepath.Join(repositoryPath, "python", "llm_proxy_client.egg-info")
+	eggInfoPackageFile := filepath.Join(eggInfoPath, "PKG-INFO")
+	eggInfoSourcesFile := filepath.Join(eggInfoPath, "SOURCES.txt")
+	require.NoError(testInstance, os.MkdirAll(eggInfoPath, 0o755))
+	require.NoError(testInstance, os.WriteFile(eggInfoPackageFile, []byte("metadata before\n"), 0o644))
+	require.NoError(testInstance, os.WriteFile(eggInfoSourcesFile, []byte("sources before\n"), 0o644))
 	clientCacheFile := filepath.Join(repositoryPath, "python", "llm_proxy_client", "__pycache__", "client.cpython-313.pyc")
 	testCacheFile := filepath.Join(repositoryPath, "python", "tests", "__pycache__", "test_client.cpython-313-pytest-9.0.3.pyc")
 	require.NoError(testInstance, os.MkdirAll(filepath.Dir(clientCacheFile), 0o755))
@@ -265,7 +268,7 @@ func TestSyncFiltersTrackedIgnoredDirtyPathsBeforeStaging(testInstance *testing.
 	require.NoError(testInstance, os.WriteFile(clientCacheFile, []byte("client cache before\n"), 0o644))
 	require.NoError(testInstance, os.WriteFile(testCacheFile, []byte("test cache before\n"), 0o644))
 
-	addCommand := exec.Command("git", "-C", repositoryPath, "add", ".gitignore", "scripts/release.sh")
+	addCommand := exec.Command("git", "-C", repositoryPath, "add", ".gitignore", "python/llm_proxy_client.egg-info/PKG-INFO", "python/llm_proxy_client.egg-info/SOURCES.txt")
 	addCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, addCommand.Run())
 	forceAddCommand := exec.Command("git", "-C", repositoryPath, "add", "-f", "python/llm_proxy_client/__pycache__/client.cpython-313.pyc", "python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
@@ -280,7 +283,8 @@ func TestSyncFiltersTrackedIgnoredDirtyPathsBeforeStaging(testInstance *testing.
 	pushCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, pushCommand.Run())
 
-	require.NoError(testInstance, os.WriteFile(scriptPath, []byte("#!/bin/sh\necho updated\n"), 0o755))
+	require.NoError(testInstance, os.Remove(eggInfoPackageFile))
+	require.NoError(testInstance, os.Remove(eggInfoSourcesFile))
 	require.NoError(testInstance, os.WriteFile(clientCacheFile, []byte("client cache after\n"), 0o644))
 	require.NoError(testInstance, os.Remove(testCacheFile))
 
@@ -348,17 +352,21 @@ operations:
 	require.NoError(testInstance, readError)
 	invocationLog := string(invocationLogContents)
 	require.Contains(testInstance, invocationLog, "check-ignore --stdin")
-	require.Contains(testInstance, invocationLog, "ls-files --cached --ignored --exclude-standard -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc scripts/release.sh")
+	require.Contains(testInstance, invocationLog, "ls-files --cached --ignored --exclude-standard -- python/llm_proxy_client.egg-info/PKG-INFO python/llm_proxy_client.egg-info/SOURCES.txt python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
 	require.Contains(testInstance, invocationLog, "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
 	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
-	require.Contains(testInstance, invocationLog, "add --all -- scripts/release.sh")
+	require.Contains(testInstance, invocationLog, "add --all -- python/llm_proxy_client.egg-info/PKG-INFO python/llm_proxy_client.egg-info/SOURCES.txt")
 	require.NotContains(testInstance, invocationLog, "add --all -- python/llm_proxy_client/__pycache__")
 	require.NotContains(testInstance, invocationLog, "add --all -- python/tests/__pycache__")
 	require.Contains(testInstance, invocationLog, "commit -m docs: sync tracked dirty work")
 
 	require.Equal(testInstance, expectedGeneratedBranchName, strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
 	require.Equal(testInstance, "docs: sync tracked dirty work", strings.TrimSpace(runGit(testInstance, repositoryPath, "log", "-1", "--pretty=%s")))
-	require.Equal(testInstance, "M\tscripts/release.sh", strings.TrimSpace(runGit(testInstance, repositoryPath, "show", "--name-status", "--pretty=format:", "HEAD")))
+	nameStatusOutput := strings.TrimSpace(runGit(testInstance, repositoryPath, "show", "--name-status", "--pretty=format:", "HEAD"))
+	require.ElementsMatch(testInstance, []string{
+		"D\tpython/llm_proxy_client.egg-info/PKG-INFO",
+		"D\tpython/llm_proxy_client.egg-info/SOURCES.txt",
+	}, strings.Split(nameStatusOutput, "\n"))
 
 	statusOutput := runGit(testInstance, repositoryPath, "status", "--porcelain")
 	require.Empty(testInstance, strings.TrimSpace(statusOutput))

--- a/tests/sync_refresh_integration_test.go
+++ b/tests/sync_refresh_integration_test.go
@@ -349,6 +349,7 @@ operations:
 	invocationLog := string(invocationLogContents)
 	require.Contains(testInstance, invocationLog, "check-ignore --stdin")
 	require.Contains(testInstance, invocationLog, "ls-files --cached --ignored --exclude-standard -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc scripts/release.sh")
+	require.Contains(testInstance, invocationLog, "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
 	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
 	require.Contains(testInstance, invocationLog, "add --all -- scripts/release.sh")
 	require.NotContains(testInstance, invocationLog, "add --all -- python/llm_proxy_client/__pycache__")
@@ -360,7 +361,11 @@ operations:
 	require.Equal(testInstance, "M\tscripts/release.sh", strings.TrimSpace(runGit(testInstance, repositoryPath, "show", "--name-status", "--pretty=format:", "HEAD")))
 
 	statusOutput := runGit(testInstance, repositoryPath, "status", "--porcelain")
-	require.Contains(testInstance, statusOutput, " M python/llm_proxy_client/__pycache__/client.cpython-313.pyc")
-	require.Contains(testInstance, statusOutput, " D python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
-	require.NotContains(testInstance, statusOutput, "scripts/release.sh")
+	require.Empty(testInstance, strings.TrimSpace(statusOutput))
+	clientCacheContents, clientCacheReadError := os.ReadFile(clientCacheFile)
+	require.NoError(testInstance, clientCacheReadError)
+	require.Equal(testInstance, "client cache before\n", string(clientCacheContents))
+	testCacheContents, testCacheReadError := os.ReadFile(testCacheFile)
+	require.NoError(testInstance, testCacheReadError)
+	require.Equal(testInstance, "test cache before\n", string(testCacheContents))
 }


### PR DESCRIPTION
## Summary
- Fixes B011 by separating stageable dirty status entries from tracked ignored dirty entries.
- Restores tracked ignored generated artifacts after fetch succeeds and before dirty sync commits ordinary changes.
- Moves restore before stash so generated tracked ignored dirt is not stashed and popped back into the worktree.
- Tightens the black-box CLI scenario to mirror the reported llm-proxy shape: tracked egg-info deletions plus tracked ignored __pycache__ modifications/deletions.
- Adds focused syncflow coverage for staged/index dirt, --require-clean, --stash, fetch failure, restore failure, and command ordering.
- Verifies final git status --porcelain is clean.

## Validation
- go test ./internal/branches/syncflow with B011 focused filter
- make test-fast
- go clean -testcache && make test-slow
- make ci
- make test
- make lint
