### PR TITLE
Handle merged PR sync fallback

### DIFF
--- a/cmd/cli/application_commands.go
+++ b/cmd/cli/application_commands.go
@@ -55,6 +55,12 @@ func (application *Application) registerCommands(cobraCommand *cobra.Command) {
 		},
 		HumanReadableLoggingProvider: application.humanReadableLoggingEnabled,
 		ConfigurationProvider:        application.branchSyncConfiguration,
+		PrompterFactory: func(command *cobra.Command) shared.ConfirmationPrompter {
+			if command == nil {
+				return nil
+			}
+			return prompt.NewIOConfirmationPrompter(command.InOrStdin(), command.OutOrStdout())
+		},
 	}
 
 	defaultCommandBuilder := migratecli.CommandBuilder{

--- a/internal/branches/syncflow/command.go
+++ b/internal/branches/syncflow/command.go
@@ -56,6 +56,7 @@ type CommandBuilder struct {
 	GitManager                   shared.GitRepositoryManager
 	GitHubResolver               shared.GitHubMetadataResolver
 	FileSystem                   shared.FileSystem
+	PrompterFactory              func(*cobra.Command) shared.ConfirmationPrompter
 	TaskRunnerFactory            func(workflow.Dependencies) TaskRunnerExecutor
 }
 
@@ -133,17 +134,18 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 			GitRepositoryManager:         builder.GitManager,
 			GitHubResolver:               builder.GitHubResolver,
 			FileSystem:                   builder.FileSystem,
+			PrompterFactory:              builder.PrompterFactory,
 		},
 		taskrunner.DependenciesOptions{
-			Command:         command,
-			Output:          command.OutOrStdout(),
-			Errors:          command.ErrOrStderr(),
-			DisablePrompter: true,
+			Command: command,
+			Output:  command.OutOrStdout(),
+			Errors:  command.ErrOrStderr(),
 		},
 	)
 	if dependencyError != nil {
 		return dependencyError
 	}
+	dependencyResult.Workflow.SuppressOperationFailureOutput = true
 
 	if remoteURL, remoteTarget := resolveRemoteTarget(command, dependencyResult.GitExecutor, explicitBranch); remoteTarget {
 		if len(remainingArgs) > 0 {
@@ -206,8 +208,12 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 		},
 	}
 
+	assumeYes := false
+	if executionFlagsAvailable {
+		assumeYes = executionFlags.AssumeYes
+	}
 	runtimeOptions := workflow.RuntimeOptions{
-		AssumeYes: false,
+		AssumeYes: assumeYes,
 	}
 
 	_, runErr := taskRunner.Run(

--- a/internal/branches/syncflow/command_test.go
+++ b/internal/branches/syncflow/command_test.go
@@ -96,34 +96,54 @@ func TestCommandExecutesAcrossRoots(t *testing.T) {
 }
 
 func TestCommandSuppressesWorkflowFailureEcho(t *testing.T) {
-	temporaryRoot := t.TempDir()
-	missingPullRequestError := errors.New(`branch "feature/foo" does not have an open pull request into master`)
-	runner := &recordingTaskRunner{
-		errorOutput: missingPullRequestError.Error(),
-		err:         missingPullRequestError,
-	}
-	builder := CommandBuilder{
-		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
-		ConfigurationProvider: func() CommandConfiguration {
-			return CommandConfiguration{RepositoryRoots: []string{temporaryRoot}, RemoteName: "origin"}
+	testCases := []struct {
+		name       string
+		runError   error
+		branchName string
+	}{
+		{
+			name:       "missing_pull_request",
+			runError:   errors.New(`branch "feature/foo" does not have an open pull request into master`),
+			branchName: "feature/foo",
 		},
-		GitExecutor: &stubGitExecutor{},
-		TaskRunnerFactory: func(deps workflow.Dependencies) TaskRunnerExecutor {
-			runner.dependencies = deps
-			return runner
+		{
+			name:       "local_branch_ahead_of_remote",
+			runError:   errors.New(`local branch "bugfix/B025-auth-console-coop-header" has commits not on origin/bugfix/B025-auth-console-coop-header`),
+			branchName: "bugfix/B025-auth-console-coop-header",
 		},
 	}
-	command, err := builder.Build()
-	require.NoError(t, err)
-	errorOutput := &strings.Builder{}
-	command.SetErr(errorOutput)
-	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
 
-	contextAccessor := utils.NewCommandContextAccessor()
-	command.SetContext(contextAccessor.WithExecutionFlags(context.Background(), utils.ExecutionFlags{}))
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			temporaryRoot := t.TempDir()
+			runner := &recordingTaskRunner{
+				errorOutput: testCase.runError.Error(),
+				err:         testCase.runError,
+			}
+			builder := CommandBuilder{
+				LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+				ConfigurationProvider: func() CommandConfiguration {
+					return CommandConfiguration{RepositoryRoots: []string{temporaryRoot}, RemoteName: "origin"}
+				},
+				GitExecutor: &stubGitExecutor{},
+				TaskRunnerFactory: func(deps workflow.Dependencies) TaskRunnerExecutor {
+					runner.dependencies = deps
+					return runner
+				},
+			}
+			command, err := builder.Build()
+			require.NoError(t, err)
+			errorOutput := &strings.Builder{}
+			command.SetErr(errorOutput)
+			flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
 
-	require.ErrorIs(t, command.RunE(command, []string{"feature/foo"}), missingPullRequestError)
-	require.Equal(t, "", errorOutput.String())
+			contextAccessor := utils.NewCommandContextAccessor()
+			command.SetContext(contextAccessor.WithExecutionFlags(context.Background(), utils.ExecutionFlags{}))
+
+			require.ErrorIs(t, command.RunE(command, []string{testCase.branchName}), testCase.runError)
+			require.Equal(t, "", errorOutput.String())
+		})
+	}
 }
 
 func TestCommandKeepsWorkflowStandardOutput(t *testing.T) {

--- a/internal/branches/syncflow/command_test.go
+++ b/internal/branches/syncflow/command_test.go
@@ -2,6 +2,8 @@ package syncflow
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -91,6 +93,66 @@ func TestCommandExecutesAcrossRoots(t *testing.T) {
 	require.Equal(t, "origin", action.Options[taskOptionBranchRemote])
 	require.Equal(t, true, action.Options[taskOptionRequirePullRequest])
 	require.Equal(t, "master", action.Options[taskOptionBaseBranch])
+}
+
+func TestCommandSuppressesWorkflowFailureEcho(t *testing.T) {
+	temporaryRoot := t.TempDir()
+	missingPullRequestError := errors.New(`branch "feature/foo" does not have an open pull request into master`)
+	runner := &recordingTaskRunner{
+		errorOutput: missingPullRequestError.Error(),
+		err:         missingPullRequestError,
+	}
+	builder := CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() CommandConfiguration {
+			return CommandConfiguration{RepositoryRoots: []string{temporaryRoot}, RemoteName: "origin"}
+		},
+		GitExecutor: &stubGitExecutor{},
+		TaskRunnerFactory: func(deps workflow.Dependencies) TaskRunnerExecutor {
+			runner.dependencies = deps
+			return runner
+		},
+	}
+	command, err := builder.Build()
+	require.NoError(t, err)
+	errorOutput := &strings.Builder{}
+	command.SetErr(errorOutput)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+
+	contextAccessor := utils.NewCommandContextAccessor()
+	command.SetContext(contextAccessor.WithExecutionFlags(context.Background(), utils.ExecutionFlags{}))
+
+	require.ErrorIs(t, command.RunE(command, []string{"feature/foo"}), missingPullRequestError)
+	require.Equal(t, "", errorOutput.String())
+}
+
+func TestCommandKeepsWorkflowStandardOutput(t *testing.T) {
+	temporaryRoot := t.TempDir()
+	runner := &recordingTaskRunner{
+		standardOutput: "SYNCED: /tmp/project (feature/foo)\n",
+	}
+	builder := CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() CommandConfiguration {
+			return CommandConfiguration{RepositoryRoots: []string{temporaryRoot}, RemoteName: "origin"}
+		},
+		GitExecutor: &stubGitExecutor{},
+		TaskRunnerFactory: func(deps workflow.Dependencies) TaskRunnerExecutor {
+			runner.dependencies = deps
+			return runner
+		},
+	}
+	command, err := builder.Build()
+	require.NoError(t, err)
+	output := &strings.Builder{}
+	command.SetOut(output)
+	flagutils.BindRootFlags(command, flagutils.RootFlagValues{}, flagutils.RootFlagDefinition{Enabled: true})
+
+	contextAccessor := utils.NewCommandContextAccessor()
+	command.SetContext(contextAccessor.WithExecutionFlags(context.Background(), utils.ExecutionFlags{}))
+
+	require.NoError(t, command.RunE(command, []string{"feature/foo"}))
+	require.Equal(t, "SYNCED: /tmp/project (feature/foo)\n", output.String())
 }
 
 func TestCommandPropagatesPullRequestTitleAndBodyOptions(t *testing.T) {
@@ -283,11 +345,20 @@ type recordingTaskRunner struct {
 	roots          []string
 	definitions    []workflow.TaskDefinition
 	runtimeOptions workflow.RuntimeOptions
+	standardOutput string
+	errorOutput    string
+	err            error
 }
 
 func (runner *recordingTaskRunner) Run(ctx context.Context, roots []string, definitions []workflow.TaskDefinition, options workflow.RuntimeOptions) (workflow.ExecutionOutcome, error) {
 	runner.roots = append([]string{}, roots...)
 	runner.definitions = append([]workflow.TaskDefinition{}, definitions...)
 	runner.runtimeOptions = options
-	return workflow.ExecutionOutcome{}, nil
+	if strings.TrimSpace(runner.standardOutput) != "" && runner.dependencies.Output != nil {
+		fmt.Fprint(runner.dependencies.Output, runner.standardOutput)
+	}
+	if strings.TrimSpace(runner.errorOutput) != "" && runner.dependencies.Errors != nil && !runner.dependencies.SuppressOperationFailureOutput {
+		fmt.Fprintln(runner.dependencies.Errors, runner.errorOutput)
+	}
+	return workflow.ExecutionOutcome{}, runner.err
 }

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -66,6 +66,7 @@ const (
 	strictSyncDirtyWorktreeTemplate              = "worktree is dirty; remove --require-clean or use --stash before syncing"
 	strictSyncLocalOnlyCommitTemplate            = "local branch %q has commits not on %s/%s"
 	strictSyncMissingPullRequestTemplate         = "branch %q does not have an open pull request into %s"
+	strictSyncMergedPullRequestPromptTemplate    = "Pull request for branch %q into %s is already merged. Sync %s instead? [a/N/y] "
 	strictSyncConflictTemplate                   = "merge from %s/%s into %s stopped with conflicts; resolve them before pushing"
 	strictSyncFastForwardTemplate                = "fast-forward from %s/%s into %s stopped; commit, stash, or clean local changes before syncing"
 )
@@ -538,7 +539,7 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 		return nil
 	}
 
-	created, syncErr := syncPullRequestBranch(ctx, environment, repository, strictPullRequestBranchOptions{
+	pullRequestSyncResult, syncErr := syncPullRequestBranch(ctx, environment, repository, strictPullRequestBranchOptions{
 		BranchName:       branchName,
 		RemoteName:       remoteName,
 		BaseBranch:       baseBranch,
@@ -550,7 +551,11 @@ func handleStrictSyncAction(ctx context.Context, environment *workflow.Environme
 	if syncErr != nil {
 		return syncErr
 	}
-	reportStrictSync(repository, environment, branchName, options.ResolutionSource, created, stashPushed)
+	reportBranchName := branchName
+	if strings.TrimSpace(pullRequestSyncResult.SyncedBranch) != "" {
+		reportBranchName = pullRequestSyncResult.SyncedBranch
+	}
+	reportStrictSync(repository, environment, reportBranchName, options.ResolutionSource, pullRequestSyncResult.Created, stashPushed)
 	return nil
 }
 
@@ -562,6 +567,11 @@ type strictPullRequestBranchOptions struct {
 	DirtyWorktree    bool
 	CommitMessages   worktreeAdoptionCommitMessageOptions
 	PullRequest      strictSyncPullRequestMetadata
+}
+
+type strictPullRequestBranchResult struct {
+	Created      bool
+	SyncedBranch string
 }
 
 type strictPullRequestCreateOptions struct {
@@ -603,88 +613,104 @@ func syncBaseBranch(ctx context.Context, environment *workflow.Environment, repo
 	return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitResetSubcommandConstant, gitResetHardFlagConstant, remoteReference})
 }
 
-func syncPullRequestBranch(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, options strictPullRequestBranchOptions) (bool, error) {
+func syncPullRequestBranch(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, options strictPullRequestBranchOptions) (strictPullRequestBranchResult, error) {
 	remoteReference := fmt.Sprintf("%s/%s", options.RemoteName, options.BranchName)
 	remoteExists, remoteExistsErr := remoteReferenceExists(ctx, environment.GitExecutor, repository.Path, remoteReference)
 	if remoteExistsErr != nil {
-		return false, remoteExistsErr
+		return strictPullRequestBranchResult{}, remoteExistsErr
 	}
 
 	repositoryIdentifier := strictSyncRepositoryIdentifier(repository)
 	if repositoryIdentifier == "" {
-		return false, errors.New(strictSyncMissingRepositoryMessage)
+		return strictPullRequestBranchResult{}, errors.New(strictSyncMissingRepositoryMessage)
 	}
 
 	if remoteExists {
 		openPullRequest, pullRequestErr := branchHasOpenPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName)
 		if pullRequestErr != nil {
-			return false, pullRequestErr
+			return strictPullRequestBranchResult{}, pullRequestErr
 		}
 		if !openPullRequest {
-			return false, fmt.Errorf(strictSyncMissingPullRequestTemplate, options.BranchName, options.BaseBranch)
+			mergedPullRequest, mergedPullRequestErr := branchHasMergedPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName)
+			if mergedPullRequestErr != nil {
+				return strictPullRequestBranchResult{}, mergedPullRequestErr
+			}
+			if mergedPullRequest {
+				syncBaseBranchConfirmed, confirmErr := confirmSyncBaseAfterMergedPullRequest(environment, options.BranchName, options.BaseBranch)
+				if confirmErr != nil {
+					return strictPullRequestBranchResult{}, confirmErr
+				}
+				if syncBaseBranchConfirmed {
+					if syncErr := syncBaseBranch(ctx, environment, repository, options.RemoteName, options.BaseBranch, options.CommitMessages); syncErr != nil {
+						return strictPullRequestBranchResult{}, syncErr
+					}
+					return strictPullRequestBranchResult{SyncedBranch: options.BaseBranch}, nil
+				}
+			}
+			return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncMissingPullRequestTemplate, options.BranchName, options.BaseBranch)
 		}
 		if switchErr := switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, options.RemoteName, options.BranchName, options.CommitMessages); switchErr != nil {
-			return false, switchErr
+			return strictPullRequestBranchResult{}, switchErr
 		}
 		aheadCount, aheadErr := commitCount(ctx, environment.GitExecutor, repository.Path, fmt.Sprintf("%s..%s", remoteReference, options.BranchName))
 		if aheadErr != nil {
-			return false, aheadErr
+			return strictPullRequestBranchResult{}, aheadErr
 		}
 		if aheadCount > 0 && !options.AllowAheadCommit {
-			return false, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
+			return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
 		}
 		if aheadCount > 0 {
 			if mergeErr := mergeRemoteBranchIntoLocal(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BranchName); mergeErr != nil {
-				return false, mergeErr
+				return strictPullRequestBranchResult{}, mergeErr
 			}
 		} else if options.DirtyWorktree {
 			if fastForwardErr := fastForwardRemoteBranchIntoLocal(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BranchName); fastForwardErr != nil {
-				return false, fastForwardErr
+				return strictPullRequestBranchResult{}, fastForwardErr
 			}
 		} else if resetErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitResetSubcommandConstant, gitResetHardFlagConstant, remoteReference}); resetErr != nil {
-			return false, resetErr
+			return strictPullRequestBranchResult{}, resetErr
 		}
 		if mergeErr := mergeBaseIntoBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName); mergeErr != nil {
-			return false, mergeErr
+			return strictPullRequestBranchResult{}, mergeErr
 		}
-		return false, executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, options.RemoteName, options.BranchName})
+		return strictPullRequestBranchResult{}, executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitPushSubcommandConstant, options.RemoteName, options.BranchName})
 	}
 
 	localExists, localExistsErr := localBranchExists(ctx, environment.GitExecutor, repository.Path, options.BranchName)
 	if localExistsErr != nil {
-		return false, localExistsErr
+		return strictPullRequestBranchResult{}, localExistsErr
 	}
 	if localExists {
 		if !options.AllowAheadCommit {
-			return false, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
+			return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
 		}
 		if switchErr := switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, options.RemoteName, options.BranchName, options.CommitMessages); switchErr != nil {
-			return false, switchErr
+			return strictPullRequestBranchResult{}, switchErr
 		}
 		if mergeErr := mergeBaseIntoBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName); mergeErr != nil {
-			return false, mergeErr
+			return strictPullRequestBranchResult{}, mergeErr
 		}
 		if pullRequestErr := pushAndCreatePullRequest(ctx, environment, repository, repositoryIdentifier, options); pullRequestErr != nil {
-			return false, pullRequestErr
+			return strictPullRequestBranchResult{}, pullRequestErr
 		}
-		return true, nil
+		return strictPullRequestBranchResult{Created: true}, nil
 	}
 
 	baseReference := fmt.Sprintf("%s/%s", options.RemoteName, options.BaseBranch)
 	baseExists, baseExistsErr := remoteReferenceExists(ctx, environment.GitExecutor, repository.Path, baseReference)
 	if baseExistsErr != nil {
-		return false, baseExistsErr
+		return strictPullRequestBranchResult{}, baseExistsErr
 	}
 	if !baseExists {
-		return false, fmt.Errorf("remote base branch %q does not exist", baseReference)
+		return strictPullRequestBranchResult{}, fmt.Errorf("remote base branch %q does not exist", baseReference)
 	}
 	if createErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, options.BranchName, baseReference}); createErr != nil {
-		return false, createErr
+		return strictPullRequestBranchResult{}, createErr
 	}
 	if pullRequestErr := pushAndCreatePullRequest(ctx, environment, repository, repositoryIdentifier, options); pullRequestErr != nil {
-		return false, pullRequestErr
+		return strictPullRequestBranchResult{}, pullRequestErr
 	}
-	return true, nil
+	return strictPullRequestBranchResult{Created: true}, nil
 }
 
 func pushAndCreatePullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) error {
@@ -758,11 +784,19 @@ func fastForwardRemoteBranchIntoLocal(ctx context.Context, executor shared.GitEx
 }
 
 func branchHasOpenPullRequest(ctx context.Context, environment *workflow.Environment, repositoryIdentifier string, baseBranch string, branchName string) (bool, error) {
+	return branchHasPullRequestWithState(ctx, environment, repositoryIdentifier, baseBranch, branchName, githubcli.PullRequestStateOpen)
+}
+
+func branchHasMergedPullRequest(ctx context.Context, environment *workflow.Environment, repositoryIdentifier string, baseBranch string, branchName string) (bool, error) {
+	return branchHasPullRequestWithState(ctx, environment, repositoryIdentifier, baseBranch, branchName, githubcli.PullRequestStateMerged)
+}
+
+func branchHasPullRequestWithState(ctx context.Context, environment *workflow.Environment, repositoryIdentifier string, baseBranch string, branchName string, state githubcli.PullRequestState) (bool, error) {
 	if environment.GitHubClient == nil {
 		return false, errors.New(strictSyncMissingGitHubClientMessage)
 	}
 	pullRequests, pullRequestErr := environment.GitHubClient.ListPullRequests(ctx, repositoryIdentifier, githubcli.PullRequestListOptions{
-		State:       githubcli.PullRequestStateOpen,
+		State:       state,
 		BaseBranch:  baseBranch,
 		ResultLimit: 100,
 	})
@@ -775,6 +809,23 @@ func branchHasOpenPullRequest(ctx context.Context, environment *workflow.Environ
 		}
 	}
 	return false, nil
+}
+
+func confirmSyncBaseAfterMergedPullRequest(environment *workflow.Environment, branchName string, baseBranch string) (bool, error) {
+	if environment == nil {
+		return false, nil
+	}
+	if environment.PromptState != nil && environment.PromptState.IsAssumeYesEnabled() {
+		return true, nil
+	}
+	if environment.Prompter == nil {
+		return false, nil
+	}
+	confirmation, confirmErr := environment.Prompter.Confirm(fmt.Sprintf(strictSyncMergedPullRequestPromptTemplate, branchName, baseBranch, baseBranch))
+	if confirmErr != nil {
+		return false, confirmErr
+	}
+	return confirmation.Confirmed, nil
 }
 
 func createPullRequest(ctx context.Context, environment *workflow.Environment, options strictPullRequestCreateOptions) error {

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -631,21 +631,12 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 			return strictPullRequestBranchResult{}, pullRequestErr
 		}
 		if !openPullRequest {
-			mergedPullRequest, mergedPullRequestErr := branchHasMergedPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName)
-			if mergedPullRequestErr != nil {
-				return strictPullRequestBranchResult{}, mergedPullRequestErr
+			syncedBaseBranch, syncBaseBranchErr := syncBaseBranchAfterMergedPullRequest(ctx, environment, repository, repositoryIdentifier, options)
+			if syncBaseBranchErr != nil {
+				return strictPullRequestBranchResult{}, syncBaseBranchErr
 			}
-			if mergedPullRequest {
-				syncBaseBranchConfirmed, confirmErr := confirmSyncBaseAfterMergedPullRequest(environment, options.BranchName, options.BaseBranch)
-				if confirmErr != nil {
-					return strictPullRequestBranchResult{}, confirmErr
-				}
-				if syncBaseBranchConfirmed {
-					if syncErr := syncBaseBranch(ctx, environment, repository, options.RemoteName, options.BaseBranch, options.CommitMessages); syncErr != nil {
-						return strictPullRequestBranchResult{}, syncErr
-					}
-					return strictPullRequestBranchResult{SyncedBranch: options.BaseBranch}, nil
-				}
+			if syncedBaseBranch {
+				return strictPullRequestBranchResult{SyncedBranch: options.BaseBranch}, nil
 			}
 			return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncMissingPullRequestTemplate, options.BranchName, options.BaseBranch)
 		}
@@ -682,6 +673,13 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 	}
 	if localExists {
 		if !options.AllowAheadCommit {
+			syncedBaseBranch, syncBaseBranchErr := syncBaseBranchAfterMergedPullRequest(ctx, environment, repository, repositoryIdentifier, options)
+			if syncBaseBranchErr != nil {
+				return strictPullRequestBranchResult{}, syncBaseBranchErr
+			}
+			if syncedBaseBranch {
+				return strictPullRequestBranchResult{SyncedBranch: options.BaseBranch}, nil
+			}
 			return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncLocalOnlyCommitTemplate, options.BranchName, options.RemoteName, options.BranchName)
 		}
 		if switchErr := switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, options.RemoteName, options.BranchName, options.CommitMessages); switchErr != nil {
@@ -711,6 +709,27 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 		return strictPullRequestBranchResult{}, pullRequestErr
 	}
 	return strictPullRequestBranchResult{Created: true}, nil
+}
+
+func syncBaseBranchAfterMergedPullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) (bool, error) {
+	mergedPullRequest, mergedPullRequestErr := branchHasMergedPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName)
+	if mergedPullRequestErr != nil {
+		return false, mergedPullRequestErr
+	}
+	if !mergedPullRequest {
+		return false, nil
+	}
+	syncBaseBranchConfirmed, confirmErr := confirmSyncBaseAfterMergedPullRequest(environment, options.BranchName, options.BaseBranch)
+	if confirmErr != nil {
+		return false, confirmErr
+	}
+	if !syncBaseBranchConfirmed {
+		return false, nil
+	}
+	if syncErr := syncBaseBranch(ctx, environment, repository, options.RemoteName, options.BaseBranch, options.CommitMessages); syncErr != nil {
+		return false, syncErr
+	}
+	return true, nil
 }
 
 func pushAndCreatePullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) error {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -1176,6 +1176,57 @@ func TestHandleBranchSyncActionStrictPRBranchPromptsToSyncMasterWhenPullRequestM
 	require.Contains(t, strings.Join(githubExecutor.commands[1].Arguments, " "), "--state merged")
 }
 
+func TestHandleBranchSyncActionStrictPRBranchPromptsToSyncMasterWhenMergedPullRequestRemotePruned(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{
+		missingReferences: map[string]bool{
+			"origin/feature/foo": true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{output: `[{"number":7,"title":"Merged","headRefName":"feature/foo"}]`}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	output := &strings.Builder{}
+	prompter := &strictSyncPrompter{result: shared.ConfirmationResult{Confirmed: true}}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            output,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+		Prompter:          prompter,
+		PromptState:       prompt.NewSessionState(false),
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "switch master")
+	require.Contains(t, recordedCommands, "reset --hard origin/master")
+	require.NotContains(t, recordedCommands, "merge --no-edit origin/master")
+	require.NotContains(t, recordedCommands, "push origin feature/foo")
+	require.Equal(t, "SYNCED: /tmp/project (master)\n", output.String())
+	require.Equal(t, []string{`Pull request for branch "feature/foo" into master is already merged. Sync master instead? [a/N/y] `}, prompter.prompts)
+	require.Len(t, githubExecutor.commands, 1)
+	require.Contains(t, strings.Join(githubExecutor.commands[0].Arguments, " "), "--state merged")
+}
+
 func TestHandleBranchSyncActionStrictPRBranchKeepsMissingPullRequestErrorWhenMergedSyncDeclined(t *testing.T) {
 	gitExecutor := &strictSyncGitExecutor{}
 	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tyemirov/gix/internal/execshell"
 	"github.com/tyemirov/gix/internal/githubcli"
 	"github.com/tyemirov/gix/internal/gitrepo"
+	"github.com/tyemirov/gix/internal/repos/prompt"
 	"github.com/tyemirov/gix/internal/repos/shared"
 	"github.com/tyemirov/gix/internal/workflow"
 	"github.com/tyemirov/utils/llm"
@@ -232,6 +233,7 @@ func (executor *strictSyncGitExecutor) ExecuteGitHubCLI(context.Context, execshe
 
 type strictSyncGitHubExecutor struct {
 	output   string
+	outputs  []string
 	commands []execshell.CommandDetails
 }
 
@@ -241,7 +243,25 @@ func (executor *strictSyncGitHubExecutor) ExecuteGit(context.Context, execshell.
 
 func (executor *strictSyncGitHubExecutor) ExecuteGitHubCLI(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
 	executor.commands = append(executor.commands, details)
+	outputIndex := len(executor.commands) - 1
+	if outputIndex < len(executor.outputs) {
+		return execshell.ExecutionResult{StandardOutput: executor.outputs[outputIndex]}, nil
+	}
 	return execshell.ExecutionResult{StandardOutput: executor.output}, nil
+}
+
+type strictSyncPrompter struct {
+	result  shared.ConfirmationResult
+	err     error
+	prompts []string
+}
+
+func (prompter *strictSyncPrompter) Confirm(prompt string) (shared.ConfirmationResult, error) {
+	prompter.prompts = append(prompter.prompts, prompt)
+	if prompter.err != nil {
+		return shared.ConfirmationResult{}, prompter.err
+	}
+	return prompter.result, nil
 }
 
 type strictSyncChatClient struct {
@@ -1103,6 +1123,142 @@ func TestHandleBranchSyncActionStrictPRBranchRejectsMissingPullRequest(t *testin
 	require.Contains(t, syncError.Error(), "does not have an open pull request")
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
 	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "push origin feature/foo")
+}
+
+func TestHandleBranchSyncActionStrictPRBranchPromptsToSyncMasterWhenPullRequestMerged(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{outputs: []string{
+		`[]`,
+		`[{"number":7,"title":"Merged","headRefName":"feature/foo"}]`,
+	}}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	output := &strings.Builder{}
+	prompter := &strictSyncPrompter{result: shared.ConfirmationResult{Confirmed: true}}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            output,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+		Prompter:          prompter,
+		PromptState:       prompt.NewSessionState(false),
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "switch master")
+	require.Contains(t, recordedCommands, "reset --hard origin/master")
+	require.NotContains(t, recordedCommands, "merge --no-edit origin/master")
+	require.NotContains(t, recordedCommands, "push origin feature/foo")
+	require.Equal(t, "SYNCED: /tmp/project (master)\n", output.String())
+	require.Equal(t, []string{`Pull request for branch "feature/foo" into master is already merged. Sync master instead? [a/N/y] `}, prompter.prompts)
+	require.Len(t, githubExecutor.commands, 2)
+	require.Contains(t, strings.Join(githubExecutor.commands[0].Arguments, " "), "--state open")
+	require.Contains(t, strings.Join(githubExecutor.commands[1].Arguments, " "), "--state merged")
+}
+
+func TestHandleBranchSyncActionStrictPRBranchKeepsMissingPullRequestErrorWhenMergedSyncDeclined(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{outputs: []string{
+		`[]`,
+		`[{"number":7,"title":"Merged","headRefName":"feature/foo"}]`,
+	}}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	prompter := &strictSyncPrompter{}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+		Prompter:          prompter,
+		PromptState:       prompt.NewSessionState(false),
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+	}
+
+	syncError := handleBranchSyncAction(context.Background(), environment, repository, parameters)
+	require.Error(t, syncError)
+	require.Contains(t, syncError.Error(), "does not have an open pull request")
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.NotContains(t, recordedCommands, "switch master")
+	require.NotContains(t, recordedCommands, "reset --hard origin/master")
+	require.Len(t, prompter.prompts, 1)
+}
+
+func TestHandleBranchSyncActionStrictPRBranchAssumeYesSyncsMasterForMergedPullRequest(t *testing.T) {
+	gitExecutor := &strictSyncGitExecutor{}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{outputs: []string{
+		`[]`,
+		`[{"number":7,"title":"Merged","headRefName":"feature/foo"}]`,
+	}}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+		PromptState:       prompt.NewSessionState(true),
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "feature/foo",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "feature/foo",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       true,
+	}
+
+	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
+	require.Contains(t, recordedGitCommands(gitExecutor.commands), "reset --hard origin/master")
 }
 
 func TestHandleBranchSyncActionStrictPRBranchCommitFlagUsesDirtySyncCommitWithRequireClean(t *testing.T) {

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -47,6 +47,8 @@ type Dependencies struct {
 	DisableWorkflowLogging  bool
 	ReporterOptions         []shared.ReporterOption
 	DisableHeaderDecoration bool
+	// SuppressOperationFailureOutput leaves operation failures in returned errors without echoing them to Errors.
+	SuppressOperationFailureOutput bool
 }
 
 // RuntimeOptions captures user-provided execution modifiers.
@@ -272,20 +274,21 @@ func (executor *Executor) Execute(executionContext context.Context, roots []stri
 		reporterOptions...,
 	)
 	environment := &Environment{
-		AuditService:      auditService,
-		GitExecutor:       executor.dependencies.GitExecutor,
-		RepositoryManager: executor.dependencies.RepositoryManager,
-		GitHubClient:      executor.dependencies.GitHubClient,
-		FileSystem:        executor.dependencies.FileSystem,
-		Prompter:          dispatchingPrompter,
-		PromptState:       promptState,
-		Output:            executor.dependencies.Output,
-		Errors:            executor.dependencies.Errors,
-		Reporter:          reporter,
-		Logger:            executor.dependencies.Logger,
-		Variables:         NewVariableStore(),
-		sharedState:       &environmentSharedState{},
-		suppressHeaders:   executor.dependencies.DisableHeaderDecoration,
+		AuditService:                   auditService,
+		GitExecutor:                    executor.dependencies.GitExecutor,
+		RepositoryManager:              executor.dependencies.RepositoryManager,
+		GitHubClient:                   executor.dependencies.GitHubClient,
+		FileSystem:                     executor.dependencies.FileSystem,
+		Prompter:                       dispatchingPrompter,
+		PromptState:                    promptState,
+		Output:                         executor.dependencies.Output,
+		Errors:                         executor.dependencies.Errors,
+		Reporter:                       reporter,
+		Logger:                         executor.dependencies.Logger,
+		Variables:                      NewVariableStore(),
+		sharedState:                    &environmentSharedState{},
+		suppressHeaders:                executor.dependencies.DisableHeaderDecoration,
+		suppressOperationFailureOutput: executor.dependencies.SuppressOperationFailureOutput,
 	}
 	environment.State = state
 	if environment.Variables != nil {

--- a/internal/workflow/executor_runner.go
+++ b/internal/workflow/executor_runner.go
@@ -388,7 +388,7 @@ func executeRepositoryStageForRepository(
 		for _, failureErr := range subErrors {
 			formatted := formatOperationFailure(environment, failureErr, node.Operation.Name())
 			if !logRepositoryOperationError(environment, failureErr) {
-				if environment != nil && environment.Errors != nil {
+				if environment != nil && environment.Errors != nil && !environment.suppressOperationFailureOutput {
 					fmt.Fprintln(environment.Errors, formatted)
 				}
 			}
@@ -483,7 +483,7 @@ func executeGlobalStage(
 		for _, failureErr := range subErrors {
 			formatted := formatOperationFailure(environment, failureErr, node.Operation.Name())
 			if !logRepositoryOperationError(environment, failureErr) {
-				if environment != nil && environment.Errors != nil {
+				if environment != nil && environment.Errors != nil && !environment.suppressOperationFailureOutput {
 					fmt.Fprintln(environment.Errors, formatted)
 				}
 			}

--- a/internal/workflow/operation.go
+++ b/internal/workflow/operation.go
@@ -33,22 +33,23 @@ type RepositoryScopedOperation interface {
 
 // Environment exposes shared dependencies for workflow operations.
 type Environment struct {
-	AuditService      *audit.Service
-	GitExecutor       shared.GitExecutor
-	RepositoryManager *gitrepo.RepositoryManager
-	GitHubClient      *githubcli.Client
-	FileSystem        shared.FileSystem
-	Prompter          shared.ConfirmationPrompter
-	PromptState       *prompt.SessionState
-	Output            io.Writer
-	Errors            io.Writer
-	Reporter          shared.SummaryReporter
-	Logger            *zap.Logger
-	Variables         *VariableStore
-	currentStepName   string
-	State             *State
-	sharedState       *environmentSharedState
-	suppressHeaders   bool
+	AuditService                   *audit.Service
+	GitExecutor                    shared.GitExecutor
+	RepositoryManager              *gitrepo.RepositoryManager
+	GitHubClient                   *githubcli.Client
+	FileSystem                     shared.FileSystem
+	Prompter                       shared.ConfirmationPrompter
+	PromptState                    *prompt.SessionState
+	Output                         io.Writer
+	Errors                         io.Writer
+	Reporter                       shared.SummaryReporter
+	Logger                         *zap.Logger
+	Variables                      *VariableStore
+	currentStepName                string
+	State                          *State
+	sharedState                    *environmentSharedState
+	suppressHeaders                bool
+	suppressOperationFailureOutput bool
 }
 
 type environmentSharedState struct {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -11,6 +11,25 @@ Issue IDs in Features, Improvements, BugFixes, and Maintenance never reuse compl
 
 ## BugFixes
 
+- [x] [B012] (P1) `gix sync` should offer to sync `master` when a branch pull request is already merged.
+  Requested on 2026-06-07 after `gix sync` in `/Users/tyemirov/Development/MediaOps` on branch `gix/add-provider-gated-speech-speed-capability-and` printed `branch "gix/add-provider-gated-speech-speed-capability-and" does not have an open pull request into master` twice instead of recognizing that a closed-and-merged pull request should hand off to the base branch.
+  ## Observation
+  - Direct `gix sync` runs the sync action through the workflow task runner.
+  - Strict PR sync checks only for open pull requests before returning the missing-PR error, so a branch whose PR has already merged is treated like a branch that never had a PR.
+  - The workflow runner also writes the operation failure to stderr, then returns the same failure to `main`, which prints it again.
+  ## Deliverable
+  - When a branch has no open PR but has a merged PR into the configured base branch, prompt the user to sync the base branch instead.
+  - Make `--yes` accept that base-branch sync handoff without prompting.
+  - Keep true missing-PR failures visible exactly once.
+  - Preserve direct `gix sync` success output such as `SYNCED: ...`.
+  - Preserve workflow logging for explicit `gix workflow` runs.
+  ## Resolution
+  - Strict PR sync now checks for a merged pull request after the open-PR lookup fails.
+  - When a merged PR exists, direct `gix sync` prompts to sync the configured base branch instead; `--yes` accepts that handoff without prompting.
+  - Declining the prompt preserves the true missing-open-PR failure path.
+  - Direct `gix sync` suppresses only the duplicate workflow stderr echo, while workflow failures still return to the command and workflow stdout remains intact.
+  - Focused syncflow/workflow tests, `make test-fast`, `make test-slow`, `make test`, `make lint`, and `make ci` passed locally.
+
 - [x] [B011] (P1) `gix sync` leaves tracked ignored dirty paths after a successful sync.
   Requested on 2026-06-06 after `v0.6.5` allowed `gix sync` to finish in `/Users/tyemirov/Development/llm-proxy`, but `git status` still showed deleted `python/llm_proxy_client.egg-info/*` files and modified/deleted tracked `__pycache__` files.
   ## Observation

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,7 +1,3 @@
-- Confirmed the existing B010 integration test expected tracked ignored dirty paths to remain.
-- Changed strict sync coverage so tracked ignored dirty paths are restored, not staged or committed.
-- Implemented a sync status filter result that keeps stageable entries and tracked ignored entries separate.
-- Restored tracked ignored entries with `git restore --staged --worktree -- <paths>` after fetch succeeds and before dirty sync continues.
-- Tightened the black-box integration scenario to match the reported `llm-proxy` shape: tracked `egg-info` deletions plus tracked ignored `__pycache__` modifications/deletions.
-- Added focused syncflow tests for staged tracked ignored dirt, `--require-clean`, `--stash`, fetch failure before restore, and restore failure abort behavior.
-- Ran targeted sync tests plus `make test-fast`, non-cached `make test-slow`, `make test`, `make lint`, and `make ci`.
+- Completed B012: strict `gix sync` now detects merged pull requests after the open-PR lookup fails and prompts to sync the configured base branch.
+- Added coverage for confirmed prompts, declined prompts, `--yes`, true missing-open-PR failures, single direct-command failure output, and preserved stdout.
+- Validated with focused sync/workflow tests plus `make test-fast`, `make test-slow`, `make test`, `make lint`, and `make ci`.

--- a/issues.md/PLAN.md
+++ b/issues.md/PLAN.md
@@ -1,3 +1,4 @@
-- Completed B012: strict `gix sync` now detects merged pull requests after the open-PR lookup fails and prompts to sync the configured base branch.
-- Added coverage for confirmed prompts, declined prompts, `--yes`, true missing-open-PR failures, single direct-command failure output, and preserved stdout.
-- Validated with focused sync/workflow tests plus `make test-fast`, `make test-slow`, `make test`, `make lint`, and `make ci`.
+- Completed PR #369 review feedback for B012 pruned merged branches.
+- Added a strict-sync regression where `origin/<branch>` was pruned after merge but the local branch still exists.
+- Reused the merged-PR base-branch sync path from both remote-backed and non-`AllowAheadCommit` local-only strict PR branches.
+- Validated with focused syncflow tests, `make test`, `make lint`, and `make ci`.


### PR DESCRIPTION
## Summary
- detect merged pull requests after strict sync fails to find an open PR
- prompt direct gix sync to sync the configured base branch, with --yes accepting the handoff
- suppress only the duplicate direct-command workflow error echo while preserving returned errors and stdout

## Validation
- focused syncflow and workflow tests
- make test-fast
- make test-slow
- make test
- make lint
- make ci
