### PR TITLE
tyemirov/bugfix/gix-sync-dirty-base-switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 # AGENTS.md
 
+## Forward-Only Contract Discipline
+
+This repository follows a forward-only, confident programming paradigm. This is a binding agent contract: no fallbacks, no backward compatibility, no legacy support, and no compatibility shims. Do not spend design or implementation effort on backward compatibility considerations except for explicit one-off data migrations into the current canonical contract.
+
+Repeat for emphasis because this rule is binding: no fallbacks, no backward compatibility, no legacy compatibility. Delete or reject obsolete code paths, stale schemas, deprecated config, and old persisted shapes instead of preserving them through compatibility layers, dual reads/writes, aliases, or best-effort recovery.
+
+One-off data migrations are allowed only when they move existing persisted data into the current schema in a bounded operation. After migration, remove the bridge and keep only the current contract.
+
 ## gix, a Git/GitHub helper CLI
 
 gix keeps large fleets of Git repositories in a healthy state. It bundles the day-to-day tasks every maintainer repeats: normalising folder names, aligning remotes, pruning stale branches, scrubbing GHCR images, and shipping consistent release notes. See README.md for details

--- a/cmd/cli/workflow/run.go
+++ b/cmd/cli/workflow/run.go
@@ -116,15 +116,13 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 	configurationPath := configurationPathCandidate
 	var workflowConfiguration workflow.Configuration
 	loadedFromPreset := false
-	if presetCatalog != nil {
-		presetConfiguration, presetFound, presetError := presetCatalog.Load(configurationPath)
-		if presetError != nil {
-			return fmt.Errorf(loadPresetErrorTemplateConstant, configurationPath, presetError)
-		}
-		if presetFound {
-			workflowConfiguration = presetConfiguration
-			loadedFromPreset = true
-		}
+	presetConfiguration, presetFound, presetError := presetCatalog.Load(configurationPath)
+	if presetError != nil {
+		return fmt.Errorf(loadPresetErrorTemplateConstant, configurationPath, presetError)
+	}
+	if presetFound {
+		workflowConfiguration = presetConfiguration
+		loadedFromPreset = true
 	}
 
 	if !loadedFromPreset {

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -287,6 +287,9 @@ func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workf
 		return currentBranchErr
 	}
 	if startAtCurrentCheckout {
+		if alignmentErr := ensureDirtySyncBaseBranchRemoteAligned(ctx, environment.GitExecutor, repository.Path, remoteName, baseBranch); alignmentErr != nil {
+			return alignmentErr
+		}
 		return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName})
 	}
 	return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName, baseReference})
@@ -304,6 +307,20 @@ func dirtySyncBranchStartsAtCurrentCheckout(ctx context.Context, environment *wo
 		return false, fmt.Errorf(strictSyncCurrentBranchFailure, currentBranchErr)
 	}
 	return strings.TrimSpace(currentBranch) == strings.TrimSpace(baseBranch), nil
+}
+
+func ensureDirtySyncBaseBranchRemoteAligned(ctx context.Context, executor shared.GitExecutor, repositoryPath string, remoteName string, baseBranch string) error {
+	trimmedRemoteName := strings.TrimSpace(remoteName)
+	trimmedBaseBranch := strings.TrimSpace(baseBranch)
+	remoteReference := fmt.Sprintf("%s/%s", trimmedRemoteName, trimmedBaseBranch)
+	aheadCount, aheadErr := commitCount(ctx, executor, repositoryPath, fmt.Sprintf("%s..%s", remoteReference, trimmedBaseBranch))
+	if aheadErr != nil {
+		return aheadErr
+	}
+	if aheadCount > 0 {
+		return fmt.Errorf(strictSyncLocalOnlyCommitTemplate, trimmedBaseBranch, trimmedRemoteName, trimmedBaseBranch)
+	}
+	return nil
 }
 
 func buildSyncCommitClusters(statusEntries []string) []syncCommitCluster {

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -22,6 +22,8 @@ const (
 	strictSyncDirtyClusterFailureTemplate = "failed to commit dirty sync cluster %q: %w"
 	strictSyncDirtyIgnoreFailureTemplate  = "failed to inspect ignored dirty sync paths: %w"
 	strictSyncDirtyRestoreFailureTemplate = "failed to restore ignored dirty sync paths: %w"
+	strictSyncCurrentBranchFailure        = "failed to inspect current branch before dirty sync branch creation: %w"
+	strictSyncCurrentBranchRepository     = "repository required to inspect current branch before dirty sync branch creation"
 	strictSyncGeneratedBranchPrefix       = "gix"
 	strictSyncGeneratedSemanticFallback   = "work"
 	strictSyncGeneratedSemanticSlugLimit  = 56
@@ -280,7 +282,28 @@ func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workf
 	if !baseExists {
 		return fmt.Errorf("remote base branch %q does not exist", baseReference)
 	}
+	startAtCurrentCheckout, currentBranchErr := dirtySyncBranchStartsAtCurrentCheckout(ctx, environment, repository, baseBranch)
+	if currentBranchErr != nil {
+		return currentBranchErr
+	}
+	if startAtCurrentCheckout {
+		return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName})
+	}
 	return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName, baseReference})
+}
+
+func dirtySyncBranchStartsAtCurrentCheckout(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, baseBranch string) (bool, error) {
+	if repository == nil {
+		return false, errors.New(strictSyncCurrentBranchRepository)
+	}
+	if environment == nil || environment.RepositoryManager == nil {
+		return false, errors.New(refreshMissingRepositoryManagerMessage)
+	}
+	currentBranch, currentBranchErr := environment.RepositoryManager.GetCurrentBranch(ctx, repository.Path)
+	if currentBranchErr != nil {
+		return false, fmt.Errorf(strictSyncCurrentBranchFailure, currentBranchErr)
+	}
+	return strings.TrimSpace(currentBranch) == strings.TrimSpace(baseBranch), nil
 }
 
 func buildSyncCommitClusters(statusEntries []string) []syncCommitCluster {

--- a/internal/branches/syncflow/dirty_sync.go
+++ b/internal/branches/syncflow/dirty_sync.go
@@ -287,9 +287,6 @@ func prepareStrictSyncBranchForDirtyWork(ctx context.Context, environment *workf
 		return currentBranchErr
 	}
 	if startAtCurrentCheckout {
-		if alignmentErr := ensureDirtySyncBaseBranchRemoteAligned(ctx, environment.GitExecutor, repository.Path, remoteName, baseBranch); alignmentErr != nil {
-			return alignmentErr
-		}
 		return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName})
 	}
 	return executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitSwitchSubcommandConstant, gitCreateBranchFlagConstant, branchName, baseReference})
@@ -307,20 +304,6 @@ func dirtySyncBranchStartsAtCurrentCheckout(ctx context.Context, environment *wo
 		return false, fmt.Errorf(strictSyncCurrentBranchFailure, currentBranchErr)
 	}
 	return strings.TrimSpace(currentBranch) == strings.TrimSpace(baseBranch), nil
-}
-
-func ensureDirtySyncBaseBranchRemoteAligned(ctx context.Context, executor shared.GitExecutor, repositoryPath string, remoteName string, baseBranch string) error {
-	trimmedRemoteName := strings.TrimSpace(remoteName)
-	trimmedBaseBranch := strings.TrimSpace(baseBranch)
-	remoteReference := fmt.Sprintf("%s/%s", trimmedRemoteName, trimmedBaseBranch)
-	aheadCount, aheadErr := commitCount(ctx, executor, repositoryPath, fmt.Sprintf("%s..%s", remoteReference, trimmedBaseBranch))
-	if aheadErr != nil {
-		return aheadErr
-	}
-	if aheadCount > 0 {
-		return fmt.Errorf(strictSyncLocalOnlyCommitTemplate, trimmedBaseBranch, trimmedRemoteName, trimmedBaseBranch)
-	}
-	return nil
 }
 
 func buildSyncCommitClusters(statusEntries []string) []syncCommitCluster {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -123,7 +123,13 @@ type strictSyncGitExecutor struct {
 	blockedBranch      string
 	blockedWorktree    string
 	worktreeRemoved    bool
+	currentBranch      string
 }
+
+const (
+	strictSyncGitAbbrevRefFlag = "--abbrev-ref"
+	strictSyncGitHeadReference = "HEAD"
+)
 
 func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details execshell.CommandDetails) (execshell.ExecutionResult, error) {
 	executor.commands = append(executor.commands, details)
@@ -193,6 +199,13 @@ func (executor *strictSyncGitExecutor) ExecuteGit(_ context.Context, details exe
 		}
 		return execshell.ExecutionResult{StandardOutput: output}, nil
 	case "rev-parse":
+		if len(details.Arguments) > 2 && details.Arguments[1] == strictSyncGitAbbrevRefFlag && details.Arguments[2] == strictSyncGitHeadReference {
+			currentBranch := executor.currentBranch
+			if currentBranch == "" {
+				currentBranch = defaultSyncBaseBranch
+			}
+			return execshell.ExecutionResult{StandardOutput: currentBranch + "\n"}, nil
+		}
 		if len(details.Arguments) > 2 && details.Arguments[1] == "--verify" && executor.missingReferences[details.Arguments[2]] {
 			return execshell.ExecutionResult{}, commandFailedError("fatal: Needed a single revision")
 		}
@@ -1593,7 +1606,8 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	}
 
 	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c "+generatedBranchName+" origin/master")
+	require.NotEqual(t, -1, recordedGitCommandIndex(gitExecutor.commands, "switch -c "+generatedBranchName))
+	require.Equal(t, -1, recordedGitCommandIndex(gitExecutor.commands, "switch -c "+generatedBranchName+" origin/master"))
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "add --all -- README.md")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "commit -m docs: update readme")
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "merge --no-edit origin/master")
@@ -1655,8 +1669,9 @@ func TestHandleBranchSyncActionStrictPRBranchSkipsStaleGeneratedRemoteBranch(t *
 	}
 
 	require.NoError(t, handleBranchSyncAction(context.Background(), environment, repository, parameters))
-	require.NotContains(t, recordedGitCommands(gitExecutor.commands), "switch -c "+generatedBranchName+" origin/master")
-	require.Contains(t, recordedGitCommands(gitExecutor.commands), "switch -c "+collisionBranchName+" origin/master")
+	require.Equal(t, -1, recordedGitCommandIndex(gitExecutor.commands, "switch -c "+generatedBranchName+" origin/master"))
+	require.NotEqual(t, -1, recordedGitCommandIndex(gitExecutor.commands, "switch -c "+collisionBranchName))
+	require.Equal(t, -1, recordedGitCommandIndex(gitExecutor.commands, "switch -c "+collisionBranchName+" origin/master"))
 	require.Contains(t, recordedGitCommands(gitExecutor.commands), "push -u origin "+collisionBranchName)
 	require.Len(t, githubExecutor.commands, 2)
 	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", collisionBranchName, "--title", collisionBranchName, "--body", pullRequestBody}, githubExecutor.commands[1].Arguments)

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -1624,8 +1624,9 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	require.Contains(t, chatClient.requests[2].Messages[1].Content, "diff --git a/README.md b/README.md")
 }
 
-func TestHandleBranchSyncActionStrictPRBranchRejectsDirtyMasterWhenLocalBaseAhead(t *testing.T) {
+func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMasterWhenLocalBaseAhead(t *testing.T) {
 	generatedBranchName := "gix/cancel-upstream-request-on-downstream-timeout"
+	pullRequestBody := "## Summary\n- Preserves local master commits and dirty README work."
 	gitExecutor := &strictSyncGitExecutor{
 		statusOutput:  " M README.md\n",
 		revListOutput: "1\n",
@@ -1639,7 +1640,7 @@ func TestHandleBranchSyncActionStrictPRBranchRejectsDirtyMasterWhenLocalBaseAhea
 	githubExecutor := &strictSyncGitHubExecutor{}
 	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
 	require.NoError(t, githubClientError)
-	chatClient := &strictSyncChatClient{response: "fix: cancel upstream request on downstream timeout"}
+	chatClient := &strictSyncChatClient{responses: []string{"fix: cancel upstream request on downstream timeout", "docs: update readme", pullRequestBody}}
 	environment := &workflow.Environment{
 		GitExecutor:       gitExecutor,
 		RepositoryManager: gitManager,
@@ -1669,14 +1670,17 @@ func TestHandleBranchSyncActionStrictPRBranchRejectsDirtyMasterWhenLocalBaseAhea
 
 	syncError := handleBranchSyncAction(context.Background(), environment, repository, parameters)
 
-	require.Error(t, syncError)
-	require.Contains(t, syncError.Error(), `local branch "master" has commits not on origin/master`)
+	require.NoError(t, syncError)
 	recordedCommands := recordedGitCommands(gitExecutor.commands)
-	require.Contains(t, recordedCommands, "rev-list --count origin/master..master")
-	require.NotContains(t, recordedCommands, "switch -c "+generatedBranchName)
-	require.NotContains(t, recordedCommands, "add --all -- README.md")
-	require.NotContains(t, recordedCommands, "commit -m")
-	require.Len(t, chatClient.requests, 1)
+	require.NotContains(t, recordedCommands, "rev-list --count origin/master..master")
+	require.Contains(t, recordedCommands, "switch -c "+generatedBranchName)
+	require.Contains(t, recordedCommands, "add --all -- README.md")
+	require.Contains(t, recordedCommands, "commit -m docs: update readme")
+	require.Contains(t, recordedCommands, "merge --no-edit origin/master")
+	require.Contains(t, recordedCommands, "push -u origin "+generatedBranchName)
+	require.Len(t, githubExecutor.commands, 1)
+	require.Equal(t, []string{"pr", "create", "--repo", "owner/project", "--base", "master", "--head", generatedBranchName, "--title", generatedBranchName, "--body", pullRequestBody}, githubExecutor.commands[0].Arguments)
+	require.Len(t, chatClient.requests, 3)
 }
 
 func TestHandleBranchSyncActionStrictPRBranchSkipsStaleGeneratedRemoteBranch(t *testing.T) {

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -1624,6 +1624,61 @@ func TestHandleBranchSyncActionStrictPRBranchCreatesGeneratedBranchFromDirtyMast
 	require.Contains(t, chatClient.requests[2].Messages[1].Content, "diff --git a/README.md b/README.md")
 }
 
+func TestHandleBranchSyncActionStrictPRBranchRejectsDirtyMasterWhenLocalBaseAhead(t *testing.T) {
+	generatedBranchName := "gix/cancel-upstream-request-on-downstream-timeout"
+	gitExecutor := &strictSyncGitExecutor{
+		statusOutput:  " M README.md\n",
+		revListOutput: "1\n",
+		missingReferences: map[string]bool{
+			"origin/" + generatedBranchName:     true,
+			"refs/heads/" + generatedBranchName: true,
+		},
+	}
+	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(t, managerError)
+	githubExecutor := &strictSyncGitHubExecutor{}
+	githubClient, githubClientError := githubcli.NewClient(githubExecutor)
+	require.NoError(t, githubClientError)
+	chatClient := &strictSyncChatClient{response: "fix: cancel upstream request on downstream timeout"}
+	environment := &workflow.Environment{
+		GitExecutor:       gitExecutor,
+		RepositoryManager: gitManager,
+		GitHubClient:      githubClient,
+		Logger:            zap.NewNop(),
+		Output:            io.Discard,
+		Errors:            io.Discard,
+		Reporter:          &recordingReporter{},
+	}
+	repository := &workflow.RepositoryState{
+		Path: "/tmp/project",
+		Inspection: audit.RepositoryInspection{
+			LocalBranch:    "master",
+			FinalOwnerRepo: "owner/project",
+		},
+	}
+	parameters := map[string]any{
+		taskOptionBranchName:         "master",
+		taskOptionBranchRemote:       shared.OriginRemoteNameConstant,
+		taskOptionRequirePullRequest: true,
+		taskOptionBaseBranch:         "master",
+		taskOptionRequireClean:       false,
+		taskOptionWorktreeCommitMessage: worktreeAdoptionCommitMessageOptions{
+			Client: chatClient,
+		},
+	}
+
+	syncError := handleBranchSyncAction(context.Background(), environment, repository, parameters)
+
+	require.Error(t, syncError)
+	require.Contains(t, syncError.Error(), `local branch "master" has commits not on origin/master`)
+	recordedCommands := recordedGitCommands(gitExecutor.commands)
+	require.Contains(t, recordedCommands, "rev-list --count origin/master..master")
+	require.NotContains(t, recordedCommands, "switch -c "+generatedBranchName)
+	require.NotContains(t, recordedCommands, "add --all -- README.md")
+	require.NotContains(t, recordedCommands, "commit -m")
+	require.Len(t, chatClient.requests, 1)
+}
+
 func TestHandleBranchSyncActionStrictPRBranchSkipsStaleGeneratedRemoteBranch(t *testing.T) {
 	generatedBranchName := "gix/cancel-upstream-request-on-downstream-timeout"
 	collisionBranchName := generatedBranchName + "-2"

--- a/tests/sync_refresh_integration_test.go
+++ b/tests/sync_refresh_integration_test.go
@@ -79,7 +79,7 @@ func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T
 	require.NoError(testInstance, os.WriteFile(gitignorePath, []byte("__pycache__/\n"), 0o644))
 
 	readmePath := filepath.Join(repositoryPath, "README.md")
-	require.NoError(testInstance, os.WriteFile(readmePath, []byte("initial\n"), 0o644))
+	require.NoError(testInstance, os.WriteFile(readmePath, []byte("initial\nmiddle\nstable\n"), 0o644))
 
 	addCommand := exec.Command("git", "-C", repositoryPath, "add", ".gitignore", "README.md")
 	addCommand.Env = buildGitCommandEnvironment(nil)
@@ -106,10 +106,10 @@ func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T
 	upstreamEmailCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, upstreamEmailCommand.Run())
 
-	upstreamFilePath := filepath.Join(upstreamPath, "UPSTREAM.md")
-	require.NoError(testInstance, os.WriteFile(upstreamFilePath, []byte("remote update\n"), 0o644))
+	upstreamFilePath := filepath.Join(upstreamPath, "README.md")
+	require.NoError(testInstance, os.WriteFile(upstreamFilePath, []byte("remote update\nmiddle\nstable\n"), 0o644))
 
-	upstreamAddCommand := exec.Command("git", "-C", upstreamPath, "add", "UPSTREAM.md")
+	upstreamAddCommand := exec.Command("git", "-C", upstreamPath, "add", "README.md")
 	upstreamAddCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, upstreamAddCommand.Run())
 
@@ -121,7 +121,7 @@ func TestSyncCommitsDirtyMasterWorktreeOnGeneratedBranch(testInstance *testing.T
 	upstreamPushCommand.Env = buildGitCommandEnvironment(nil)
 	require.NoError(testInstance, upstreamPushCommand.Run())
 
-	require.NoError(testInstance, os.WriteFile(readmePath, []byte("modified locally\n"), 0o644))
+	require.NoError(testInstance, os.WriteFile(readmePath, []byte("initial\nmiddle\nmodified locally\n"), 0o644))
 	eggInfoPath := filepath.Join(repositoryPath, "python", "llm_proxy_client.egg-info")
 	require.NoError(testInstance, os.MkdirAll(eggInfoPath, 0o755))
 	require.NoError(testInstance, os.WriteFile(filepath.Join(eggInfoPath, "PKG-INFO"), []byte("metadata\n"), 0o644))
@@ -193,12 +193,14 @@ operations:
 	testInstance.Logf("sync output:\n%s", output)
 	require.Contains(testInstance, output, "strict sync requires a GitHub repository remote")
 	require.NotContains(testInstance, output, "worktree is dirty")
+	require.NotContains(testInstance, output, "would be overwritten by checkout")
 
 	invocationLogContents, readError := os.ReadFile(gitInvocationLog)
 	require.NoError(testInstance, readError)
 	invocationLog := string(invocationLogContents)
 	require.Contains(testInstance, invocationLog, "check-ignore --stdin")
-	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
+	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+"\n")
+	require.NotContains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
 	require.Contains(testInstance, invocationLog, "add --all -- README.md")
 	require.Contains(testInstance, invocationLog, "add --all -- python/llm_proxy_client.egg-info/PKG-INFO python/llm_proxy_client.egg-info/SOURCES.txt")
 	require.NotContains(testInstance, invocationLog, "add --all -- python/llm_proxy_client/__pycache__")
@@ -209,7 +211,7 @@ operations:
 
 	localFileContents, localReadError := os.ReadFile(readmePath)
 	require.NoError(testInstance, localReadError)
-	require.Equal(testInstance, "modified locally\n", string(localFileContents))
+	require.Equal(testInstance, "initial\nmiddle\nmodified locally\n", string(localFileContents))
 	require.Equal(testInstance, expectedGeneratedBranchName, strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
 	require.Empty(testInstance, strings.TrimSpace(runGit(testInstance, repositoryPath, "status", "--porcelain")))
 	require.Equal(testInstance, "docs: sync dirty work", strings.TrimSpace(runGit(testInstance, repositoryPath, "log", "-1", "--pretty=%s")))
@@ -354,7 +356,8 @@ operations:
 	require.Contains(testInstance, invocationLog, "check-ignore --stdin")
 	require.Contains(testInstance, invocationLog, "ls-files --cached --ignored --exclude-standard -- python/llm_proxy_client.egg-info/PKG-INFO python/llm_proxy_client.egg-info/SOURCES.txt python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
 	require.Contains(testInstance, invocationLog, "restore --staged --worktree -- python/llm_proxy_client/__pycache__/client.cpython-313.pyc python/tests/__pycache__/test_client.cpython-313-pytest-9.0.3.pyc")
-	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
+	require.Contains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+"\n")
+	require.NotContains(testInstance, invocationLog, "switch -c "+expectedGeneratedBranchName+" origin/master")
 	require.Contains(testInstance, invocationLog, "add --all -- python/llm_proxy_client.egg-info/PKG-INFO python/llm_proxy_client.egg-info/SOURCES.txt")
 	require.NotContains(testInstance, invocationLog, "add --all -- python/llm_proxy_client/__pycache__")
 	require.NotContains(testInstance, invocationLog, "add --all -- python/tests/__pycache__")


### PR DESCRIPTION
This update improves the handling of dirty worktrees during branch sync by creating the dirty sync branch from the current checkout if it matches the base branch, avoiding unnecessary checkouts from the remote base. It adds logic to detect the current branch and conditionally switch branches accordingly. The sync integration test is enhanced to better reflect realistic file states and verify the new branch creation behavior. Additionally, the preset configuration loading logic in the workflow run command is simplified for clarity. Documentation is extended with a forward-only contract discipline section to emphasize the project's stance on backward compatibility and legacy code removal.