### PR TITLE
bugfix/sync-existing-branch-create-pr

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -260,6 +260,37 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - `make test`
   - `make lint`
   - `make ci`
+- [x] [B018] (P1) `gix sync` should open a pull request for an existing remote branch with real changes and no open PR.
+  Requested on 2026-07-05 after `gix sync` in `/Users/tyemirov/Development/social_threader` on branch `gix/add-ci-for-mobile-app-with-coverage-and-config-checks` failed with `branch "gix/add-ci-for-mobile-app-with-coverage-and-config-checks" does not have an open pull request`, even though the branch had a diff against `origin/master`.
+  ## Observation
+  - Strict sync handled local-only branches with commits beyond the base by pushing and creating a pull request.
+  - When the remote branch already existed, strict sync checked only for an open PR and a merged-PR handoff before returning the missing-PR error.
+  - That skipped the real branch-diff check for `origin/<branch>` and refused to create a PR for an already-pushed work branch.
+  ## Resolution
+  - Existing remote branches with no open PR now check both `origin/<base>..origin/<branch>` and the local branch before falling back to merged-PR handoff.
+  - When either ref has commits beyond the base, strict sync switches to the branch, aligns it with the remote branch, merges the base, generates PR metadata from the diff, pushes, and opens the PR.
+  - Branches with no base delta still keep the merged-PR handoff and true missing-PR error paths.
+  ## Validation
+  - `go test ./tests -run TestSyncExistingRemoteBranchWithoutPullRequestCreatesPullRequest -count=1`
+  - `git diff --check`
+  - `make test`
+  - `make lint`
+  - `make ci`
+- [x] [B019] (P1) `gix sync` should hand off merged PR branches before creating new PRs and should honor explicit `master` sync from linked worktrees.
+  Requested on 2026-07-06 after `gix sync` on `improvement/I053-provider-history-handles` reported no open pull request instead of prompting to sync `master`, and `gix sync master` then failed while trying to remove `/Users/tyemirov/Development/MediaOps` even though that path is the main working tree.
+  ## Observation
+  - The existing-remote no-PR path checked branch diffs before checking merged pull requests, so squash-merged branches could look like new review branches because their commits were not ancestors of `origin/master`.
+  - Explicit base-branch sync used the sibling-worktree adoption flow when `master` was already checked out elsewhere, and that flow always attempted `git worktree remove`, which Git rejects for a main working tree.
+  ## Resolution
+  - Strict sync now checks merged pull request handoff before creating a pull request for an existing remote branch with no open PR.
+  - If the merged-PR prompt is declined, sync keeps the missing-open-PR error instead of opening a new PR for the already-merged branch.
+  - Worktree adoption now preserves any sibling worktree changes, pushes when needed, and detaches a sibling main worktree instead of trying to remove it; removable linked worktrees still use the existing remove-and-prune path.
+  ## Validation
+  - `go test ./tests -run 'TestSync(CurrentMergedBranchPromptsAndSyncsMasterBeforeCreatingPullRequest|ExplicitMasterReleasesMainWorktreeAndSwitchesLinkedWorktree|ExistingRemoteBranchWithoutPullRequestCreatesPullRequest)' -count=1`
+  - `git diff --check`
+  - `make test`
+  - `make lint`
+  - `make ci`
 
 
 ## Improvements

--- a/internal/branches/syncflow/task_action.go
+++ b/internal/branches/syncflow/task_action.go
@@ -572,6 +572,11 @@ type strictPullRequestBranchResult struct {
 	SyncedBranch string
 }
 
+type mergedPullRequestSyncResult struct {
+	Merged bool
+	Synced bool
+}
+
 type strictPullRequestCreateOptions struct {
 	RepositoryIdentifier string
 	BaseBranch           string
@@ -629,12 +634,22 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 			return strictPullRequestBranchResult{}, pullRequestErr
 		}
 		if openPullRequest == nil {
-			syncedBaseBranch, syncBaseBranchErr := syncBaseBranchAfterMergedPullRequest(ctx, environment, repository, repositoryIdentifier, options)
+			mergedSyncResult, syncBaseBranchErr := syncBaseBranchAfterMergedPullRequest(ctx, environment, repository, repositoryIdentifier, options)
 			if syncBaseBranchErr != nil {
 				return strictPullRequestBranchResult{}, syncBaseBranchErr
 			}
-			if syncedBaseBranch {
+			if mergedSyncResult.Synced {
 				return strictPullRequestBranchResult{SyncedBranch: options.BaseBranch}, nil
+			}
+			if mergedSyncResult.Merged {
+				return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncMissingPullRequestTemplate, options.BranchName)
+			}
+			createdPullRequest, createPullRequestErr := syncExistingRemoteBranchWithoutPullRequest(ctx, environment, repository, repositoryIdentifier, options)
+			if createPullRequestErr != nil {
+				return strictPullRequestBranchResult{}, createPullRequestErr
+			}
+			if createdPullRequest {
+				return strictPullRequestBranchResult{Created: true}, nil
 			}
 			return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncMissingPullRequestTemplate, options.BranchName)
 		}
@@ -676,11 +691,11 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 			return strictPullRequestBranchResult{}, localAheadOfBaseErr
 		}
 		if !localAheadOfBase {
-			syncedBaseBranch, syncBaseBranchErr := syncBaseBranchAfterMergedPullRequest(ctx, environment, repository, repositoryIdentifier, options)
+			mergedSyncResult, syncBaseBranchErr := syncBaseBranchAfterMergedPullRequest(ctx, environment, repository, repositoryIdentifier, options)
 			if syncBaseBranchErr != nil {
 				return strictPullRequestBranchResult{}, syncBaseBranchErr
 			}
-			if syncedBaseBranch {
+			if mergedSyncResult.Synced {
 				return strictPullRequestBranchResult{SyncedBranch: options.BaseBranch}, nil
 			}
 			return strictPullRequestBranchResult{}, fmt.Errorf(strictSyncEmptyLocalBranchTemplate, options.BranchName, options.RemoteName, options.BaseBranch)
@@ -714,34 +729,85 @@ func syncPullRequestBranch(ctx context.Context, environment *workflow.Environmen
 	return strictPullRequestBranchResult{Created: true}, nil
 }
 
+func syncExistingRemoteBranchWithoutPullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) (bool, error) {
+	remoteReference := fmt.Sprintf("%s/%s", options.RemoteName, options.BranchName)
+	remoteAheadOfBase, remoteAheadOfBaseErr := referenceHasCommitsBeyondBase(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, remoteReference)
+	if remoteAheadOfBaseErr != nil {
+		return false, remoteAheadOfBaseErr
+	}
+
+	localExists, localExistsErr := localBranchExists(ctx, environment.GitExecutor, repository.Path, options.BranchName)
+	if localExistsErr != nil {
+		return false, localExistsErr
+	}
+	localAheadOfBase := false
+	if localExists {
+		var localAheadOfBaseErr error
+		localAheadOfBase, localAheadOfBaseErr = branchHasCommitsBeyondBase(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName)
+		if localAheadOfBaseErr != nil {
+			return false, localAheadOfBaseErr
+		}
+	}
+
+	if !remoteAheadOfBase && !localAheadOfBase {
+		return false, nil
+	}
+
+	if switchErr := switchToLocalOrRemoteBranchWithAdoption(ctx, environment, repository, options.RemoteName, options.BranchName, options.CommitMessages); switchErr != nil {
+		return false, switchErr
+	}
+	aheadCount, aheadErr := commitCount(ctx, environment.GitExecutor, repository.Path, fmt.Sprintf("%s..%s", remoteReference, options.BranchName))
+	if aheadErr != nil {
+		return false, aheadErr
+	}
+	if aheadCount > 0 {
+		if mergeErr := mergeRemoteBranchIntoLocal(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BranchName, options.CommitMessages); mergeErr != nil {
+			return false, mergeErr
+		}
+	} else if resetErr := executeGit(ctx, environment.GitExecutor, repository.Path, []string{gitResetSubcommandConstant, gitResetHardFlagConstant, remoteReference}); resetErr != nil {
+		return false, resetErr
+	}
+	if mergeErr := mergeBaseIntoBranch(ctx, environment.GitExecutor, repository.Path, options.RemoteName, options.BaseBranch, options.BranchName, options.CommitMessages); mergeErr != nil {
+		return false, mergeErr
+	}
+	if pullRequestErr := pushAndCreatePullRequest(ctx, environment, repository, repositoryIdentifier, options); pullRequestErr != nil {
+		return false, pullRequestErr
+	}
+	return true, nil
+}
+
 func branchHasCommitsBeyondBase(ctx context.Context, executor shared.GitExecutor, repositoryPath string, remoteName string, baseBranch string, branchName string) (bool, error) {
+	return referenceHasCommitsBeyondBase(ctx, executor, repositoryPath, remoteName, baseBranch, branchName)
+}
+
+func referenceHasCommitsBeyondBase(ctx context.Context, executor shared.GitExecutor, repositoryPath string, remoteName string, baseBranch string, reference string) (bool, error) {
 	baseReference := fmt.Sprintf("%s/%s", remoteName, baseBranch)
-	aheadCount, aheadErr := commitCount(ctx, executor, repositoryPath, fmt.Sprintf("%s..%s", baseReference, branchName))
+	aheadCount, aheadErr := commitCount(ctx, executor, repositoryPath, fmt.Sprintf("%s..%s", baseReference, reference))
 	if aheadErr != nil {
 		return false, aheadErr
 	}
 	return aheadCount > 0, nil
 }
 
-func syncBaseBranchAfterMergedPullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) (bool, error) {
+func syncBaseBranchAfterMergedPullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) (mergedPullRequestSyncResult, error) {
 	mergedPullRequest, mergedPullRequestErr := branchHasMergedPullRequest(ctx, environment, repositoryIdentifier, options.BaseBranch, options.BranchName)
 	if mergedPullRequestErr != nil {
-		return false, mergedPullRequestErr
+		return mergedPullRequestSyncResult{}, mergedPullRequestErr
 	}
 	if !mergedPullRequest {
-		return false, nil
+		return mergedPullRequestSyncResult{}, nil
 	}
 	syncBaseBranchConfirmed, confirmErr := confirmSyncBaseAfterMergedPullRequest(environment, options.BranchName, options.BaseBranch)
 	if confirmErr != nil {
-		return false, confirmErr
+		return mergedPullRequestSyncResult{}, confirmErr
 	}
 	if !syncBaseBranchConfirmed {
-		return false, nil
+		return mergedPullRequestSyncResult{Merged: true}, nil
 	}
 	if syncErr := syncBaseBranch(ctx, environment, repository, options.RemoteName, options.BaseBranch, options.CommitMessages); syncErr != nil {
-		return false, syncErr
+		return mergedPullRequestSyncResult{}, syncErr
 	}
-	return true, nil
+	return mergedPullRequestSyncResult{Merged: true, Synced: true}, nil
 }
 
 func pushAndCreatePullRequest(ctx context.Context, environment *workflow.Environment, repository *workflow.RepositoryState, repositoryIdentifier string, options strictPullRequestBranchOptions) error {

--- a/internal/branches/syncflow/worktree_adoption.go
+++ b/internal/branches/syncflow/worktree_adoption.go
@@ -24,6 +24,7 @@ const (
 	gitWorktreePruneSubcommandConstant        = "prune"
 	gitPorcelainFlagConstant                  = "--porcelain"
 	gitPorcelainBranchFlagConstant            = "--branch"
+	gitSwitchDetachFlagConstant               = "--detach"
 	gitStatusSubcommand                       = "status"
 	gitAddSubcommand                          = "add"
 	gitCommitSubcommand                       = "commit"
@@ -45,7 +46,9 @@ const (
 	worktreePushFailureTemplate               = "failed to push adopted worktree branch %q from %s: %w"
 	worktreePushInspectionFailureTemplate     = "failed to inspect push requirement for branch %q against %q from %s: %w"
 	worktreeRemoteInspectionFailureTemplate   = "failed to inspect remote branch %q from %s: %w"
+	worktreeKindInspectionFailureTemplate     = "failed to inspect worktree kind at %s: %w"
 	worktreeRemoveFailureTemplate             = "failed to remove sibling worktree %s: %w"
+	worktreeDetachFailureTemplate             = "failed to detach sibling main worktree %s: %w"
 	worktreePruneFailureTemplate              = "failed to prune worktrees after removing %s: %w"
 	worktreeMessageClientConfigurationFailure = "commit message generation requires model configuration"
 	worktreeMessageAPIKeyFailureTemplate      = "environment variable %s must be set to generate a commit message"
@@ -56,6 +59,7 @@ const (
 	worktreeAdoptCommitMessage                = "committed sibling worktree changes"
 	worktreeAdoptPushMessage                  = "pushed sibling worktree branch"
 	worktreeAdoptRemoveMessage                = "removed sibling worktree"
+	worktreeAdoptDetachMessage                = "detached sibling main worktree"
 	worktreeAdoptPruneMessage                 = "pruned worktree metadata"
 )
 
@@ -329,6 +333,24 @@ func (service worktreeAdoptionService) adoptSiblingWorktree(ctx context.Context,
 		)
 	}
 
+	mainWorktree, mainWorktreeErr := isMainWorktreePath(worktree.Path)
+	if mainWorktreeErr != nil {
+		return mainWorktreeErr
+	}
+	if mainWorktree {
+		if detachErr := executeGit(ctx, service.environment.GitExecutor, worktree.Path, []string{gitSwitchSubcommandConstant, gitSwitchDetachFlagConstant}); detachErr != nil {
+			return fmt.Errorf(worktreeDetachFailureTemplate, worktree.Path, detachErr)
+		}
+		service.environment.ReportRepositoryEvent(
+			service.repository,
+			shared.EventLevelInfo,
+			shared.EventCodeWorktreeAdopt,
+			worktreeAdoptDetachMessage,
+			map[string]string{"branch": branchName, "worktree": worktree.Path},
+		)
+		return nil
+	}
+
 	if removeErr := executeGit(ctx, service.environment.GitExecutor, service.repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreeRemoveSubcommandConstant, worktree.Path}); removeErr != nil {
 		return fmt.Errorf(worktreeRemoveFailureTemplate, worktree.Path, removeErr)
 	}
@@ -352,6 +374,17 @@ func (service worktreeAdoptionService) adoptSiblingWorktree(ctx context.Context,
 	)
 
 	return nil
+}
+
+func isMainWorktreePath(worktreePath string) (bool, error) {
+	metadataInfo, metadataErr := os.Stat(filepath.Join(worktreePath, ".git"))
+	if metadataErr != nil {
+		if os.IsNotExist(metadataErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf(worktreeKindInspectionFailureTemplate, worktreePath, metadataErr)
+	}
+	return metadataInfo.IsDir(), nil
 }
 
 func inspectSiblingWorktreeStatus(ctx context.Context, executor shared.GitExecutor, worktreePath string) (worktreeStatus, error) {

--- a/tests/sync_merged_branch_integration_test.go
+++ b/tests/sync_merged_branch_integration_test.go
@@ -1,0 +1,338 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	syncMergedBranchIntegrationTimeout = 20 * time.Second
+	syncMergedBranchOwnerRepository    = "owner/project"
+	syncMergedBranchRemoteURL          = "https://github.com/" + syncMergedBranchOwnerRepository + ".git"
+	syncMergedBranchGitHubLogVariable  = "GIX_SYNC_TEST_GH_LOG"
+	syncMergedBranchNameVariable       = "GIX_SYNC_TEST_BRANCH"
+	syncMergedBranchMergedVariable     = "GIX_SYNC_TEST_MERGED"
+)
+
+type syncMergedBranchFixture struct {
+	RemotePath     string
+	RootPath       string
+	RepositoryPath string
+	BranchName     string
+}
+
+func TestSyncCurrentMergedBranchPromptsAndSyncsMasterBeforeCreatingPullRequest(testInstance *testing.T) {
+	repositoryRoot := integrationRepositoryRoot(testInstance)
+	branchName := "feature/squashed-review"
+	fixture := createSyncMergedBranchFixture(testInstance, branchName)
+	configurationPath := writeSyncMergedBranchConfiguration(testInstance)
+	githubLogPath := filepath.Join(testInstance.TempDir(), "gh.log")
+	pathVariable := buildSyncMergedBranchExecutablePath(testInstance)
+
+	output, runError := runIntegrationCommandWithInput(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{
+			PathVariable: pathVariable,
+			EnvironmentOverrides: map[string]string{
+				syncMergedBranchGitHubLogVariable: githubLogPath,
+				syncMergedBranchNameVariable:      branchName,
+			},
+		},
+		syncMergedBranchIntegrationTimeout,
+		"y\n",
+		[]string{"run", ".", "--config", configurationPath, "--log-level", "error", "sync", branchName, "--roots", fixture.RepositoryPath},
+	)
+	require.NoError(testInstance, runError, output)
+
+	require.Contains(testInstance, output, `Pull request for branch "feature/squashed-review" into master is already merged. Sync master instead?`)
+	require.Contains(testInstance, output, fmt.Sprintf("SYNCED: %s (master)", fixture.RepositoryPath))
+	require.Equal(testInstance, "master", strings.TrimSpace(runGit(testInstance, fixture.RepositoryPath, "branch", "--show-current")))
+	require.Equal(testInstance, "squashed review\n", readTextFile(testInstance, filepath.Join(fixture.RepositoryPath, "feature.txt")))
+
+	githubLog := readTextFile(testInstance, githubLogPath)
+	require.Contains(testInstance, githubLog, "pr list --repo owner/project --state open --head feature/squashed-review")
+	require.Contains(testInstance, githubLog, "pr list --repo owner/project --state merged --base master --head feature/squashed-review")
+	require.NotContains(testInstance, githubLog, "pr create")
+}
+
+func TestSyncExplicitMasterReleasesMainWorktreeAndSwitchesLinkedWorktree(testInstance *testing.T) {
+	repositoryRoot := integrationRepositoryRoot(testInstance)
+	workspacePath := syncHomeWorkspace(testInstance)
+	remotePath := filepath.Join(workspacePath, "remote.git")
+	mainRepositoryPath := filepath.Join(workspacePath, "main", "project")
+	linkedRootPath := filepath.Join(workspacePath, "linked")
+	linkedWorktreePath := filepath.Join(linkedRootPath, "project-linked")
+	branchName := "feature/linked-sync"
+	createSyncGitHubBackedRepository(testInstance, remotePath, mainRepositoryPath)
+
+	require.NoError(testInstance, os.WriteFile(filepath.Join(mainRepositoryPath, "README.md"), []byte("initial\n"), 0o644))
+	runGit(testInstance, mainRepositoryPath, "add", "README.md")
+	runGit(testInstance, mainRepositoryPath, "commit", "-m", "initial commit")
+	runGit(testInstance, mainRepositoryPath, "push", "-u", "origin", "master")
+
+	runGit(testInstance, mainRepositoryPath, "switch", "-c", branchName)
+	require.NoError(testInstance, os.WriteFile(filepath.Join(mainRepositoryPath, "feature.txt"), []byte("feature work\n"), 0o644))
+	runGit(testInstance, mainRepositoryPath, "add", "feature.txt")
+	runGit(testInstance, mainRepositoryPath, "commit", "-m", "feature work")
+	runGit(testInstance, mainRepositoryPath, "push", "-u", "origin", branchName)
+	runGit(testInstance, mainRepositoryPath, "switch", "master")
+	require.NoError(testInstance, os.MkdirAll(linkedRootPath, 0o755))
+	runGit(testInstance, mainRepositoryPath, "worktree", "add", linkedWorktreePath, branchName)
+
+	configurationPath := writeSyncMergedBranchConfiguration(testInstance)
+	githubLogPath := filepath.Join(testInstance.TempDir(), "gh.log")
+	pathVariable := buildSyncMergedBranchExecutablePath(testInstance)
+
+	output, runError := runIntegrationCommandWithInput(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{
+			PathVariable: pathVariable,
+			EnvironmentOverrides: map[string]string{
+				syncMergedBranchGitHubLogVariable: githubLogPath,
+				syncMergedBranchNameVariable:      branchName,
+			},
+		},
+		syncMergedBranchIntegrationTimeout,
+		"",
+		[]string{"run", ".", "--config", configurationPath, "--log-level", "error", "sync", "master", "--roots", linkedWorktreePath},
+	)
+	require.NoError(testInstance, runError, output)
+
+	require.Contains(testInstance, output, fmt.Sprintf("SYNCED: %s (master)", linkedWorktreePath))
+	require.Equal(testInstance, "master", strings.TrimSpace(runGit(testInstance, linkedWorktreePath, "branch", "--show-current")))
+	require.Empty(testInstance, strings.TrimSpace(runGit(testInstance, mainRepositoryPath, "branch", "--show-current")))
+	require.Empty(testInstance, strings.TrimSpace(runGit(testInstance, mainRepositoryPath, "status", "--porcelain")))
+	require.NotContains(testInstance, output, "main working tree")
+}
+
+func TestSyncExistingRemoteBranchWithoutPullRequestCreatesPullRequest(testInstance *testing.T) {
+	repositoryRoot := integrationRepositoryRoot(testInstance)
+	branchName := "feature/unreviewed-remote"
+	workspacePath := syncHomeWorkspace(testInstance)
+	remotePath := filepath.Join(workspacePath, "remote.git")
+	repositoryPath := filepath.Join(workspacePath, "project")
+	createSyncGitHubBackedRepository(testInstance, remotePath, repositoryPath)
+
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("initial\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "README.md")
+	runGit(testInstance, repositoryPath, "commit", "-m", "initial commit")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", "master")
+
+	runGit(testInstance, repositoryPath, "switch", "-c", branchName)
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "feature.txt"), []byte("needs review\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "feature.txt")
+	runGit(testInstance, repositoryPath, "commit", "-m", "feature needs review")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", branchName)
+	runGit(testInstance, repositoryPath, "switch", "master")
+
+	configurationPath := writeSyncMergedBranchConfiguration(testInstance)
+	githubLogPath := filepath.Join(testInstance.TempDir(), "gh.log")
+	pathVariable := buildSyncMergedBranchExecutablePath(testInstance)
+	pullRequestBody := "Publish the existing remote branch for review."
+
+	output, runError := runIntegrationCommandWithInput(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{
+			PathVariable: pathVariable,
+			EnvironmentOverrides: map[string]string{
+				syncMergedBranchGitHubLogVariable: githubLogPath,
+				syncMergedBranchNameVariable:      branchName,
+				syncMergedBranchMergedVariable:    "false",
+			},
+		},
+		syncMergedBranchIntegrationTimeout,
+		"",
+		[]string{"run", ".", "--config", configurationPath, "--log-level", "error", "sync", branchName, "--body", pullRequestBody, "--roots", repositoryPath},
+	)
+	require.NoError(testInstance, runError, output)
+
+	require.Contains(testInstance, output, fmt.Sprintf("SYNCED: %s (%s)", repositoryPath, branchName))
+	require.Equal(testInstance, branchName, strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
+	githubLog := readTextFile(testInstance, githubLogPath)
+	require.Contains(testInstance, githubLog, "pr list --repo owner/project --state open --head feature/unreviewed-remote")
+	require.Contains(testInstance, githubLog, "pr list --repo owner/project --state merged --base master --head feature/unreviewed-remote")
+	require.Contains(testInstance, githubLog, "pr create --repo owner/project --base master --head feature/unreviewed-remote --title feature/unreviewed-remote --body Publish the existing remote branch for review.")
+}
+
+func createSyncMergedBranchFixture(testInstance *testing.T, branchName string) syncMergedBranchFixture {
+	testInstance.Helper()
+
+	workspacePath := syncHomeWorkspace(testInstance)
+	remotePath := filepath.Join(workspacePath, "remote.git")
+	repositoryRootPath := filepath.Join(workspacePath, "roots")
+	repositoryPath := filepath.Join(repositoryRootPath, "project")
+	createSyncGitHubBackedRepository(testInstance, remotePath, repositoryPath)
+
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("initial\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "README.md")
+	runGit(testInstance, repositoryPath, "commit", "-m", "initial commit")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", "master")
+
+	runGit(testInstance, repositoryPath, "switch", "-c", branchName)
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "feature.txt"), []byte("squashed review\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "feature.txt")
+	runGit(testInstance, repositoryPath, "commit", "-m", "feature branch commit")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", branchName)
+
+	runGit(testInstance, repositoryPath, "switch", "master")
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "feature.txt"), []byte("squashed review\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "feature.txt")
+	runGit(testInstance, repositoryPath, "commit", "-m", "squash merged feature")
+	runGit(testInstance, repositoryPath, "push", "origin", "master")
+	runGit(testInstance, repositoryPath, "switch", branchName)
+
+	return syncMergedBranchFixture{
+		RemotePath:     remotePath,
+		RootPath:       repositoryRootPath,
+		RepositoryPath: repositoryPath,
+		BranchName:     branchName,
+	}
+}
+
+func createSyncGitHubBackedRepository(testInstance *testing.T, remotePath string, repositoryPath string) {
+	testInstance.Helper()
+
+	require.NoError(testInstance, os.MkdirAll(filepath.Dir(remotePath), 0o755))
+	require.NoError(testInstance, os.MkdirAll(filepath.Dir(repositoryPath), 0o755))
+	runGitWithDir(testInstance, "", "init", "--bare", remotePath)
+	runGitWithDir(testInstance, "", "init", "--initial-branch=master", repositoryPath)
+	configureGitIdentity(testInstance, repositoryPath)
+	runGit(testInstance, repositoryPath, "remote", "add", "origin", localFileURL(remotePath))
+}
+
+func writeSyncMergedBranchConfiguration(testInstance *testing.T) string {
+	testInstance.Helper()
+
+	configurationPath := filepath.Join(testInstance.TempDir(), "config.yaml")
+	configurationContent := `common:
+  log_level: error
+  log_format: console
+operations:
+  - command: ["sync"]
+    with:
+      remote: origin
+      require_clean: true
+`
+	require.NoError(testInstance, os.WriteFile(configurationPath, []byte(configurationContent), 0o600))
+	return configurationPath
+}
+
+func syncMergedBranchGitHubStubScript() string {
+	return `#!/bin/sh
+printf '%s\n' "$*" >>"$GIX_SYNC_TEST_GH_LOG"
+
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf '%s\n' '{"nameWithOwner":"owner/project","description":"","defaultBranchRef":{"name":"master"},"isInOrganization":false}'
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  state=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state)
+        state="$2"
+        shift
+        ;;
+    esac
+    shift
+  done
+  if [ "$state" = "open" ]; then
+    printf '%s\n' '[]'
+    exit 0
+  fi
+  if [ "$state" = "merged" ]; then
+    if [ "$GIX_SYNC_TEST_MERGED" = "false" ]; then
+      printf '%s\n' '[]'
+      exit 0
+    fi
+    printf '[{"number":9,"title":"Merged","headRefName":"%s","baseRefName":"master"}]\n' "$GIX_SYNC_TEST_BRANCH"
+    exit 0
+  fi
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  printf '%s\n' 'https://github.com/owner/project/pull/10'
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+`
+}
+
+func buildSyncMergedBranchExecutablePath(testInstance *testing.T) string {
+	testInstance.Helper()
+
+	stubDirectory := testInstance.TempDir()
+	realGitPath, lookupError := exec.LookPath("git")
+	require.NoError(testInstance, lookupError)
+
+	gitStubScript := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "remote" ] && [ "$2" = "get-url" ] && [ "$3" = "origin" ]; then
+  printf '%%s\n' %q
+  exit 0
+fi
+exec %q "$@"
+`, syncMergedBranchRemoteURL, realGitPath)
+	require.NoError(testInstance, os.WriteFile(filepath.Join(stubDirectory, "git"), []byte(gitStubScript), 0o755))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(stubDirectory, "gh"), []byte(syncMergedBranchGitHubStubScript()), 0o755))
+
+	currentPath := os.Getenv(pathEnvironmentVariableNameConstant)
+	if currentPath == "" {
+		return stubDirectory
+	}
+	return stubDirectory + string(os.PathListSeparator) + currentPath
+}
+
+func runIntegrationCommandWithInput(testInstance *testing.T, repositoryRoot string, options integrationCommandOptions, timeout time.Duration, input string, arguments []string) (string, error) {
+	testInstance.Helper()
+
+	executionContext, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	command := exec.CommandContext(executionContext, "go", arguments...)
+	command.Dir = repositoryRoot
+	command.Env = buildCommandEnvironment(options)
+	command.Stdin = strings.NewReader(input)
+
+	outputBytes, runError := command.CombinedOutput()
+	return string(outputBytes), runError
+}
+
+func localFileURL(path string) string {
+	return (&url.URL{Scheme: "file", Path: path}).String()
+}
+
+func syncHomeWorkspace(testInstance *testing.T) string {
+	testInstance.Helper()
+	homeDirectory, homeError := os.UserHomeDir()
+	require.NoError(testInstance, homeError)
+	workspacePath, workspaceError := os.MkdirTemp(homeDirectory, "gix-sync-merged-branch-")
+	require.NoError(testInstance, workspaceError)
+	testInstance.Cleanup(func() {
+		_ = os.RemoveAll(workspacePath)
+	})
+	canonicalPath, canonicalError := filepath.EvalSymlinks(workspacePath)
+	require.NoError(testInstance, canonicalError)
+	return canonicalPath
+}
+
+func readTextFile(testInstance *testing.T, path string) string {
+	testInstance.Helper()
+	contents, readError := os.ReadFile(path)
+	require.NoError(testInstance, readError)
+	return string(contents)
+}

--- a/tests/sync_merged_branch_integration_test.go
+++ b/tests/sync_merged_branch_integration_test.go
@@ -50,7 +50,7 @@ func TestSyncCurrentMergedBranchPromptsAndSyncsMasterBeforeCreatingPullRequest(t
 		},
 		syncMergedBranchIntegrationTimeout,
 		"y\n",
-		[]string{"run", ".", "--config", configurationPath, "--log-level", "error", "sync", branchName, "--roots", fixture.RepositoryPath},
+		[]string{"run", ".", "--config", configurationPath, "--log-level", "error", "sync", "--roots", fixture.RepositoryPath},
 	)
 	require.NoError(testInstance, runError, output)
 


### PR DESCRIPTION
### Pull Request Description

**Purpose:**
This update resolves key issues in the branch synchronization workflow, especially around handling existing remote branches without open pull requests, merged branch handoff, and worktree adoption. It also improves test coverage for these scenarios.

---

#### 1. Fix: Synchronization of Existing Remote Branches Without Open Pull Requests

- Previously, sync would return an error when encountering a remote branch with real changes but no open PR, despite diverging from the base.
- Now, the logic checks for actual commits ahead of the base on both `origin/<branch>` and the local branch. If differences are found, it will automatically open a pull request with the correct metadata.
- If no commits are ahead, it falls back to merged-PR handoff and provides clear error messages when appropriate.

---

#### 2. Fix: Merged Pull Request Handoff and Worktree Adoption/Switching

- The workflow now checks for merged pull requests before attempting to create a new PR for an existing remote branch without a PR, helping avoid confusion when the branch was already merged (e.g., via squash merging).
- Upon discovering that a branch had a merged PR, it prompts users to sync the main branch (`master`) and, if declined, does **not