### PR TITLE
bugfix/B030-prune-stale-worktree-metadata

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -527,6 +527,31 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - `make ci`
   - `git diff --check`
 
+- [x] [B030] (P1) `gix sync` must prune stale linked-worktree metadata before adoption.
+  Requested on 2026-07-20 after `gix sync bugfix/B274-resumable-speech-render-plan` in `/Users/tyemirov/Development/MediaOps` reported `WORKTREE_ADOPT` and then failed to inspect the missing `/private/tmp/mediaops-b274.ymJPGA` directory.
+  Observation:
+  - Git marks the linked-worktree record as `prunable` because its gitdir points to a non-existent location.
+  - The sync adoption parser reads the path and branch but ignores the `prunable` record, treating it as a live sibling worktree.
+  - Adoption then invokes `git status` in the missing directory and aborts before retrying the requested branch switch.
+  Deliverable:
+  - Prune the repository's stale worktree metadata before adoption retries a branch switch.
+  - Preserve the existing adoption path for live linked and main worktrees.
+  - Add public CLI coverage starting from a missing, prunable linked worktree.
+  Validation:
+  - Focused failing-then-passing public CLI regression.
+  - `make format`
+  - `make test`
+  - `make lint`
+  - `make ci`
+  - `git diff --check`
+  Resolution:
+  - Parsed Git's `prunable` worktree marker and pruned stale metadata before retrying the requested switch.
+  - Kept locked, live linked, and main-worktree adoption behavior on their existing paths.
+  - Added a public CLI regression that deletes a linked `master` worktree, verifies Git reports it as prunable, and proves explicit `gix sync master` completes after cleanup.
+  Validation Result:
+  - The regression failed before the fix with `WORKTREE_ADOPT` followed by a missing-directory `chdir` error.
+  - `make format`, focused `make test-slow`, `make test`, `make lint`, `make ci`, and `git diff --check` passed locally.
+
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - _No changes._
 
 ### Bug Fixes 🐛
+- Pruned stale linked-worktree metadata before `gix sync` retries branch adoption, so a missing temporary worktree no longer causes a `chdir` failure.
 - Switched worktree inspection to NUL-delimited porcelain status so `gix sync` passes literal filenames containing spaces to Git instead of treating display quotes as path bytes.
 - Rejected explicit dirty base-branch sync before commit generation when the required remote base ref does not exist, preventing stranded local commits.
 - Made explicit `gix sync <branch>` commit dirty work to the named branch; explicit `gix sync master` now merges `origin/master` and pushes `master` instead of creating a generated rescue branch.
@@ -24,6 +25,7 @@
 - Kept the syncflow builder description as the canonical text shown by `gix sync --help`.
 
 ### Testing 🧪
+- Added public CLI coverage for explicit `gix sync master` from a missing, Git-prunable linked worktree.
 - Added a public plain-`gix sync` regression proving deletion of `legacy/managing-director/IMD Logo.png` is committed and pushed with the literal path argument.
 - Added a black-box regression proving an explicit dirty `master` sync with no `origin/master` leaves local history and pending files unchanged without calling the LLM.
 - Added black-box coverage for explicit dirty `master` sync from both `master` and a feature branch, including clustered commits, remote merge, direct push, and absence of generated PR branches.

--- a/internal/branches/syncflow/worktree_adoption.go
+++ b/internal/branches/syncflow/worktree_adoption.go
@@ -50,6 +50,7 @@ const (
 	worktreeRemoveFailureTemplate             = "failed to remove sibling worktree %s: %w"
 	worktreeDetachFailureTemplate             = "failed to detach sibling main worktree %s: %w"
 	worktreePruneFailureTemplate              = "failed to prune worktrees after removing %s: %w"
+	worktreeStalePruneFailureTemplate         = "failed to prune stale worktree metadata for branch %q at %s: %w"
 	worktreeMessageClientConfigurationFailure = "commit message generation requires model configuration"
 	worktreeMessageAPIKeyFailureTemplate      = "environment variable %s must be set to generate a commit message"
 	worktreeMessageClientFailureTemplate      = "failed to initialize commit message client: %w"
@@ -61,6 +62,7 @@ const (
 	worktreeAdoptRemoveMessage                = "removed sibling worktree"
 	worktreeAdoptDetachMessage                = "detached sibling main worktree"
 	worktreeAdoptPruneMessage                 = "pruned worktree metadata"
+	worktreeAdoptPruneStaleMessage            = "pruned stale worktree metadata"
 )
 
 type worktreeAdoptionOptions struct {
@@ -151,6 +153,7 @@ type listedWorktree struct {
 	Path       string
 	BranchName string
 	Locked     bool
+	Prunable   bool
 }
 
 type worktreeStatus struct {
@@ -213,6 +216,19 @@ func (service worktreeAdoptionService) adoptExistingBranchWorktree(ctx context.C
 		if candidate.Locked {
 			return fmt.Errorf(worktreeLockedFailureTemplate, branchName, candidate.Path)
 		}
+		if candidate.Prunable {
+			if pruneErr := executeGit(ctx, service.environment.GitExecutor, service.repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreePruneSubcommandConstant}); pruneErr != nil {
+				return fmt.Errorf(worktreeStalePruneFailureTemplate, branchName, candidate.Path, pruneErr)
+			}
+			service.environment.ReportRepositoryEvent(
+				service.repository,
+				shared.EventLevelInfo,
+				shared.EventCodeWorktreeAdopt,
+				worktreeAdoptPruneStaleMessage,
+				map[string]string{"branch": branchName, "worktree": candidate.Path},
+			)
+			return nil
+		}
 		return service.adoptSiblingWorktree(ctx, candidate, options)
 	}
 
@@ -262,6 +278,8 @@ func parseListedWorktrees(output string) []listedWorktree {
 			current.BranchName = strings.TrimPrefix(referenceName, gitBranchReferencePrefix)
 		case "locked":
 			current.Locked = true
+		case "prunable":
+			current.Prunable = true
 		}
 	}
 	flushCurrent()

--- a/tests/sync_worktree_adoption_integration_test.go
+++ b/tests/sync_worktree_adoption_integration_test.go
@@ -76,6 +76,47 @@ func TestSyncRejectsCleanAheadSiblingWorktreeWithoutGitHubPullRequest(testInstan
 	require.NoFileExists(testInstance, filepath.Join(fixture.RepositoryPath, "ahead.txt"))
 }
 
+func TestSyncExplicitMasterPrunesStaleLinkedWorktreeBeforeSwitch(testInstance *testing.T) {
+	repositoryRoot := integrationRepositoryRoot(testInstance)
+	workspacePath := testInstance.TempDir()
+	remotePath := filepath.Join(workspacePath, "remote.git")
+	repositoryPath := filepath.Join(workspacePath, "repository")
+	siblingPath := filepath.Join(workspacePath, "stale-master")
+
+	runGitWithDir(testInstance, "", "init", "--bare", remotePath)
+	runGitWithDir(testInstance, "", "init", "--initial-branch=master", repositoryPath)
+	configureGitIdentity(testInstance, repositoryPath)
+	runGit(testInstance, repositoryPath, "remote", "add", "origin", remotePath)
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("initial\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "README.md")
+	runGit(testInstance, repositoryPath, "commit", "-m", "initial commit")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", "master")
+
+	runGit(testInstance, repositoryPath, "switch", "-c", "feature/current-work")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", "feature/current-work")
+	runGit(testInstance, repositoryPath, "worktree", "add", siblingPath, "master")
+	canonicalSiblingPath, canonicalSiblingPathErr := filepath.EvalSymlinks(siblingPath)
+	require.NoError(testInstance, canonicalSiblingPathErr)
+	require.NoError(testInstance, os.RemoveAll(siblingPath))
+
+	staleWorktreeList := runGit(testInstance, repositoryPath, "worktree", "list", "--porcelain")
+	require.Contains(testInstance, staleWorktreeList, "worktree "+canonicalSiblingPath)
+	require.Contains(testInstance, staleWorktreeList, "prunable")
+
+	configurationPath := writeSyncWorktreeAdoptionConfiguration(testInstance, "")
+	output := runIntegrationCommand(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{},
+		syncWorktreeAdoptionTimeout,
+		[]string{"run", ".", "--config", configurationPath, "sync", "master", "--roots", repositoryPath},
+	)
+
+	require.Contains(testInstance, output, fmt.Sprintf("SYNCED: %s (master)", repositoryPath))
+	require.Equal(testInstance, "master", strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
+	require.NotContains(testInstance, runGit(testInstance, repositoryPath, "worktree", "list", "--porcelain"), "worktree "+canonicalSiblingPath)
+}
+
 func createSyncWorktreeAdoptionFixture(testInstance *testing.T) syncWorktreeAdoptionFixture {
 	testInstance.Helper()
 


### PR DESCRIPTION
### Bug Fix: Prune Stale Linked Worktree Metadata Before Branch Adoption

This change resolves an issue where `gix sync` would fail to switch to a branch (e.g., `master`) if a previously linked worktree for that branch had become stale, i.e., its directory was missing but its metadata remained in Git as `prunable`. Previously, the adoption flow would erroneously treat such a stale entry as an active sibling worktree and fail with an error on directory access instead of recovering.

**Key changes:**
- Worktree adoption logic now detects `prunable` linked worktree entries.
- If a stale worktree is found, the workflow automatically runs `git worktree prune` to remove stale metadata before retrying the branch switch.
- Locked, live worktrees and the main worktree adoption remain unchanged.
- Added an integration test that deletes a linked `master` worktree, verifies the prunable status in Git, and confirms that `gix sync master` successfully adopts and switches to the branch after cleanup.

**Documentation and coverage:**
- Documented the requirement and the implemented fix in `.mprlab/ISSUES.md`.
- Expanded public CLI regression tests to cover this scenario.

This prevents `WORKTREE_ADOPT` errors and