### PR TITLE
tyemirov/improvement/I008-audit-table-output

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -669,6 +669,30 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - `make lint`
   - `make ci`
 
+- [x] [I008] (P1) Make direct audit reports terminal-readable with explicit export formats.
+  Requested on 2026-07-24.
+  Goal:
+  Make `gix audit` readable in an interactive terminal while retaining exact, intentional CSV and HTML exports.
+  Requirements:
+  - Render a complete table by default for direct `gix audit` invocations.
+  - Accept only `--format table`, `--format csv`, and `--format html`; reject every other format at the CLI boundary.
+  - Preserve every audit field consistently across table, CSV, and HTML representations.
+  - Keep workflow audit-report output machine-oriented and explicitly defaulted to CSV.
+  Validation:
+  - Add black-box CLI coverage for default table output, CSV export, HTML export, and invalid formats.
+  - Run `make format`, `make test`, `make lint`, and `make ci`.
+  Resolution:
+  - Added one canonical renderer for terminal tables, CSV, and standalone HTML reports, including escaped HTML cells and complete audit columns in every format.
+  - Added strict `--format table|csv|html` parsing to direct `gix audit`; unsupported values fail before audit work begins.
+  - Kept workflow audit reports explicitly CSV by default while allowing an intentional workflow format selection.
+  - Updated README, architecture, CLI design, site copy, and changelog examples to distinguish terminal inspection from exports.
+  Validation Result:
+  - `make format`
+  - `make test`
+  - `make lint`
+  - `make ci`
+  - `git diff --check`
+
 
 ## Maintenance
 
@@ -1446,3 +1470,120 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - Capped the semantic branch component at 56 characters and trims at word boundaries when possible.
   - Kept collision handling as a last resort: an already-occupied semantic branch advances to the next numeric suffix before the normal commit, push, and pull-request flow continues.
   - `make test`, `make lint`, and `make ci` passed locally.
+
+## Features
+
+- [ ] [F010] (P1) Make GitHub and GitLab first-class forge providers in one `gix` repository fleet.
+  Requested on 2026-07-24.
+  Goal:
+  A single `gix` configuration and invocation must operate correctly over a root containing both GitHub and GitLab repositories. Provider selection must come from the parsed origin host, so a GitHub repository uses the GitHub adapter and a GitLab repository uses the GitLab adapter without changing roots, commands, or credentials by hand.
+  Required outcome:
+  - Support public `github.com` and `gitlab.com` as explicit provider kinds in the current configuration contract.
+  - Preserve the complete GitLab project path, including nested groups such as `group/subgroup/project`; never reduce GitLab identity to a fixed two-segment GitHub-style `owner/repository` pair.
+  - Make Git-only operations host-neutral and make forge-aware operations select the configured provider for each repository independently.
+  - Treat pull requests and merge requests as one canonical `review request` concept in generic code and operator-facing generic workflows. The GitHub adapter maps that concept to a pull request; the GitLab adapter maps it to a merge request.
+  - Report unsupported or unconfigured remotes explicitly. An audit or workflow must not silently skip a GitLab repository because it is not GitHub.
+  Scope boundary:
+  - This feature covers the generic fleet-management path: discovery, audit, remote canonicalization/protocol conversion, repository metadata/default-branch lookup, `sync`, workflow execution, review-request operations, the local web audit workspace, and the matching CLI/configuration/docs contracts.
+  - GitHub-only product integrations, including GHCR package cleanup and GitHub Pages or GitHub Release publishing, remain explicitly GitHub-scoped until a separately specified GitLab-equivalent feature exists. They must fail before mutation for a GitLab repository with a capability-specific error; they must not be presented as generic provider support.
+  - Public-host support is the delivery target. The provider registry and identity model must keep host as first-class data so a later issue can add a configured self-hosted forge without another GitHub-shaped redesign.
+  Current evidence:
+  - `internal/repos/shared/types.go` defines canonical Git, SSH, and HTTPS URL prefixes with `github.com` embedded in each constant.
+  - `internal/audit/helpers.go` recognizes only GitHub URL forms and `internal/audit/service.go` rejects a non-GitHub origin. The discovery loop currently treats an inspection error as skippable, which can make a GitLab repository disappear from an otherwise mixed audit.
+  - `cmd/cli/application_config.go`, `cmd/cli/application_bootstrap.go`, and `cmd/cli/default_config.yml` expose only `github.credential` and wire that credential directly into the GitHub client context.
+  - `internal/workflow/executor.go` assumes GitHub metadata is available before it can build repository state, even when an operation is Git-only.
+  - `internal/branches/syncflow` calls the GitHub CLI client directly for pull-request discovery and creation, resolves shorthand targets to `github.com`, and normalizes only GitHub remote URL forms.
+  - `internal/repos/remotes`, `internal/migrate`, `internal/ghcr`, release scripts, and several web/API labels encode GitHub-only names or URLs. Each call site needs an explicit classification as generic, provider-capable, or GitHub-only rather than an implicit GitHub default.
+  Canonical configuration contract:
+  - Replace the top-level `github` block with one required `forges` collection. Normal application startup accepts only this new schema.
+  - Each entry has exactly `kind`, `host`, and `credential`. `kind` is the closed enum `github` or `gitlab`; `host` is a lower-case DNS host without scheme, path, port, userinfo, or trailing slash; `credential` is a non-empty literal or a `${ENVIRONMENT_VARIABLE}` reference resolved from the inherited process environment.
+  - The same host may appear once only. A configured host has one provider kind, one credential source, and one adapter. Conflicting duplicate host entries are a configuration error.
+  - The generated default configuration must use this exact shape:
+
+    ```yaml
+    forges:
+      - kind: github
+        host: github.com
+        credential: "${GH_TOKEN}"
+      - kind: gitlab
+        host: gitlab.com
+        credential: "${GITLAB_TOKEN}"
+    ```
+
+  - Credentials remain user-owned process environment inputs. Do not add dotenv loading, guessed token names, cross-provider token reuse, or a credential fallback chain.
+  Canonical repository identity contract:
+  - Introduce a provider-neutral immutable identity owned by a new `internal/forge` package. It contains the remote name, normalized transport, normalized host, forge kind, and full slash-separated project path.
+  - Parse these forms through one URL parser: SCP-style SSH (`git@host:path.git`), SSH URL (`ssh://git@host/path.git`), and HTTPS (`https://host/path.git`). Strip only the terminal `.git` suffix, normalize the host to lower case, and preserve every project-path segment for provider resolution.
+  - The generic identity must not contain `Owner`, `Repository`, `GitHubRepository`, or a hard-coded GitHub URL prefix. GitHub-specific adapters may derive a two-segment owner/repository value only after the generic parser has selected the GitHub provider.
+  - Reject malformed URLs, empty project paths, and paths that do not satisfy the selected provider's shape with a precise repository-scoped error. An unconfigured but otherwise valid host is reported as `unsupported`/`unconfigured`, never reinterpreted as GitHub.
+  - Replace audit/API/CSV fields that expose GitHub-specific identity names with `origin_host`, `origin_provider`, `origin_project_path`, `canonical_project_path`, and `final_project_path`. Remove old GitHub-specific field names from the current public contract rather than emitting aliases or duplicate columns.
+  Provider abstraction and capability contract:
+  - Add a `ForgeProvider` interface and a host-indexed registry in `internal/forge`. Generic packages receive the registry and repository identity, never a `githubcli.Client`.
+  - Model only observable shared behavior in the interface: repository metadata/default branch, canonical project identity, review-request list/find/create/update, default-branch update, branch-protection inspection/update where the operation requires it, and provider capability discovery.
+  - Define typed `RepositoryMetadata`, `ReviewRequest`, `ReviewRequestQuery`, and provider errors in the generic forge package. A review request has provider-neutral head/base refs, title, body, state, web URL, and provider-native ID; no generic package refers to `PullRequest` or `MergeRequest`.
+  - Keep the existing GitHub CLI implementation behind a GitHub adapter during the migration, but make every invocation host-aware and make its input/output conform to the generic types.
+  - Implement a GitLab REST v4 adapter behind the same interface. It must URL-encode the entire nested project path for project endpoints, use the configured GitLab credential only, and map open/merged/closed merge-request state, target branch, source branch, title, body, and web URL to the generic review-request model.
+  - Define explicit capability constants. Generic operations declare their required capabilities before any repository mutation; the executor preflights the selected provider and reports an unsupported capability with provider, host, repository path, and operation name. It must not attempt a GitHub call as a fallback.
+  Operation classification and canonical terminology:
+  - Classify `files`, folder rename, Git fetch/push, local branch inspection, and transport-only remote conversion as Git-only. They run for both providers and do not require a forge credential.
+  - Classify audit canonicalization/default-branch lookup, `sync`, default-branch management, review-request cleanup, and workflow review-request actions as provider-capable. They resolve the registry per repository and require the capability declared by that operation.
+  - Replace the current generic `prs` command/action/config vocabulary with canonical `review-requests` and `review-request` names. Remove the old `prs` and `pull_request` public configuration/action names rather than retaining aliases. GitHub-facing text may use "pull request" only inside the GitHub adapter; GitLab-facing text uses "merge request"; generic summaries use "review request".
+  - Update `sync` generated branch/review metadata, title/body options, and workflow action builders to use generic review-request types. GitHub must continue creating or updating a PR; GitLab must create or update the corresponding MR against the same semantic base branch.
+  - Classify `packages delete`, GHCR calls, GitHub Pages artifact publication, and GitHub Release object publishing as `github` capabilities. Expose the boundary in help and errors instead of silently treating them as available on GitLab.
+  Forward-only migration boundary:
+  - Deliver one explicit, bounded `gix config migrate-forges --config <path>` migration path that runs before normal application configuration bootstrap. It reads only the old top-level `github.credential`, writes the new `forges` document atomically, validates the resulting current schema, and preserves an operator-visible backup of the pre-migration file.
+  - Normal startup after this feature decodes only `forges`; a legacy `github` block is a schema error that names the migration command. Do not retain a dual reader, aliases, defaults, or runtime compatibility code.
+  - Change all checked-in examples, generated configuration, README, architecture notes, command help, web copy, and tests in the same change. The migration command is the sole temporary bridge and is removed in the release after the documented migration window; it is not a permanent fallback parser.
+  Detailed technical plan:
+  1. Establish a failing mixed-provider contract before refactoring.
+     - Add black-box fixtures for a root with a GitHub repository, a GitLab repository, a GitLab nested-group repository, and an unsupported-host repository. Use local Git repositories and controlled provider doubles; do not use live credentials or network calls in tests.
+     - Capture the current GitHub-only audit skip, URL parsing failure, workflow client dependency, and sync PR-only behavior in focused tests so the replacement proves an observable contract rather than only compiling.
+     - Inventory every import of `internal/githubcli`, every literal `github.com`/`api.github.com`, every `PullRequest`/`prs` identifier, and every GitHub-only command. Record its classification and target owner package before moving code.
+  2. Replace configuration and bootstrap ownership.
+     - Replace `ApplicationGitHubConfiguration` with `ApplicationForgeConfiguration` and an ordered `ApplicationForgesConfiguration` collection. Validate exact hosts, kinds, duplicate hosts, credentials, and environment-reference resolution at configuration load time.
+     - Build a `forge.Registry` once in `cmd/cli/application_bootstrap.go`, inject it into audit, workflow, sync, web, migration, and command constructors, and remove the globally injected GitHub credential/context path.
+     - Implement the one-off migration command as a bootstrap exception with its own narrow old-schema reader. Keep normal startup and all regular configuration tests free of legacy field decoding.
+     - Update `cmd/cli/default_config.yml` and configuration validation tests to demonstrate both providers and credential isolation.
+  3. Create the provider-neutral remote and repository identity layer.
+     - Move transport parsing and remote URL rendering out of `internal/repos/shared` GitHub constants into `internal/forge/identity` (or an equivalently owned forge package).
+     - Implement parsing, validation, normalization, equality, and renderer tests for all supported SSH/HTTPS forms, GitHub two-segment projects, GitLab nested projects, malformed paths, and unsupported hosts.
+     - Refactor remote canonicalization and protocol conversion so they change only the selected transport while preserving selected host and complete project path. A GitLab `group/subgroup/project` remote must remain that exact project on both SSH and HTTPS output.
+     - Remove GitHub URL constants from generic shared types after every caller uses the new identity renderer.
+  4. Introduce provider adapters and typed capabilities.
+     - Define the registry, provider interface, generic metadata/review-request types, capability constants, and repository-scoped provider errors in `internal/forge`.
+     - Adapt `internal/githubcli` behind the GitHub provider without changing GitHub's externally observed behavior. Ensure command construction or API calls use the repository's configured GitHub host rather than a global URL assumption.
+     - Add the GitLab REST v4 client and adapter with focused request/response tests, including URL-encoded nested paths and pagination where review-request enumeration requires it.
+     - Centralize credential redaction and ensure logs/errors never include either provider token, HTTP authorization header, or raw environment value.
+  5. Make audit and the web audit contract provider-aware.
+     - Refactor `internal/audit` to parse every configured/recognizable Git remote through forge identity. Basic audit must retain a row for every Git repository, including unconfigured hosts, instead of continuing past an inspection failure.
+     - Resolve canonical identity and remote default branch through the selected provider when that capability is available; retain Git-based default-branch discovery as the explicitly Git-only source when no provider metadata is required.
+     - Replace GitHub-specific inspection fields, CSV headers, JSON fields, browser table columns, filters, row details, and queue payloads with the provider-neutral identity fields.
+     - Make the web queue preflight provider capability before it queues or applies a forge-aware action. Git-only actions remain queueable for either supported provider; GitHub-only actions are visibly unavailable for GitLab.
+  6. Refactor workflow, sync, and review-request flows.
+     - Change workflow operation construction so each operation declares whether it is Git-only or which forge capabilities it needs. The executor must build Git-only repository state without requiring provider metadata.
+     - Replace direct GitHub client calls in `internal/branches/syncflow` with generic review-request lookup/create/update. Preserve branch safety, dirty-worktree behavior, generated-branch collision handling, commit generation, and push ordering while making review-object behavior provider-specific only at the adapter boundary.
+     - Replace GitHub shorthand target resolution with an explicit canonical form for shorthand targets, or reject shorthand where host cannot be determined. An unqualified `owner/repo` must no longer silently mean `github.com`; explicit remote URLs and configured provider-qualified targets are the supported forms.
+     - Rename the public review-request command/action/config keys, update CLI/web help and emitted messages, and remove all legacy aliases from command registration and configuration decoding.
+  7. Apply capability gating to remaining commands and scripts.
+     - Refactor `default`, repository migration, remote metadata resolution, and any workflow action that currently receives `githubcli.Client` so it receives the registry plus required capability set.
+     - Keep GHCR/package cleanup, GitHub Pages deployment scripts, and GitHub Release publication in explicit GitHub-owned packages. Make their command validation reject GitLab targets before any remote/API mutation, with actionable host/provider/capability context.
+     - Review release and documentation scripts for hard-coded GitHub links. Generic repository links must use provider metadata; intentional GitHub release links remain clearly named as such.
+  8. Remove the old contract and document the finished one.
+     - Delete generic GitHub URL constants, generic GitHub client dependencies, `github` configuration fields, `prs`/`pull_request` public vocabulary, and duplicated provider-selection logic once the registry is wired everywhere.
+     - Update README, `docs/cli_design.md`, architecture documentation, sample configuration, error/help snapshots, web labels, and changelog with mixed-fleet examples and the GitHub-only capability boundary.
+     - Add a concise provider support matrix to documentation that distinguishes Git-only, both-provider, GitHub-only, and unsupported-host behavior.
+  Validation matrix:
+  - A compiled `gix audit` against one root containing GitHub, GitLab, nested GitLab, and unsupported-host fixtures emits deterministic rows for all four repositories. GitHub and GitLab rows expose the correct provider, host, project path, transport, and default branch; the unsupported host is an explicit diagnostic row, not absent output.
+  - `gix files add`, `gix files replace`, folder rename, and Git-only remote protocol conversion work across GitHub and GitLab fixtures without requiring either forge credential. Protocol conversion preserves host and the entire GitLab nested project path.
+  - A GitHub review-request fixture verifies the adapter creates/finds/updates a PR; a GitLab REST fixture verifies the adapter creates/finds/updates an MR. The same generic `sync` workflow drives both cases and reports a provider-appropriate URL.
+  - Mixed `sync` runs preflight all affected repositories. Missing GitLab credentials or a missing GitLab capability creates a precise failure for the GitLab target before mutation and never causes an attempted GitHub request or token use.
+  - GitHub-only commands reject a GitLab repository before mutation, name the unavailable capability, and leave the working tree/remotes unchanged.
+  - Configuration tests prove `forges` is the only accepted runtime schema, duplicate hosts and invalid kinds fail, credentials never cross provider boundaries, the migration output validates, and legacy `github` configuration is rejected by normal startup.
+  - Static guard tests or repository checks prove no `github.com`, `api.github.com`, `githubcli`, `PullRequest`, `prs`, or `pull_request` dependency remains in provider-neutral packages. Intentional GitHub adapter/package/release references are allowlisted by package boundary, not by broad text suppression.
+  - Run `make format`, `make test`, `make lint`, `make ci`, and `git diff --check` after each completed slice and before resolution. The final `make ci` must retain the repository's complete coverage gate.
+  Acceptance criteria:
+  - An operator can configure both public forges once, run one command over mixed roots, and receive correct per-repository behavior without moving repositories, swapping config files, or manually selecting a provider.
+  - GitLab nested-group repositories are never truncated, rehomed to GitHub, or silently omitted.
+  - Generic code has one forge-neutral identity and review-request contract; all provider branching is contained in the registry/adapters/capability boundary.
+  - The current public schema and terminology are forward-only. No runtime compatibility aliases or fallback paths for the old GitHub-only configuration or PR vocabulary remain after migration.
+  - GitHub-specific capabilities are explicit and safe, while supported generic operations have equivalent observable behavior on GitHub and GitLab.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ Declarative repository tasks are layered across dedicated modules inside `intern
 - `task_execute.go` applies the plan: it evaluates safeguards, guards against dirty worktrees (respecting per-task overrides), manages branch checkout/push lifecycles, executes task actions, and emits structured events only (no `fmt.Fprintf` calls).
 - `task_operation.go` stitches the lifecycle together so the workflow executor can run the parsed tasks across every discovered repository.
 
-This separation keeps parsing/templating logic pure, isolates Git/GitHub side effects, and guarantees that every user-facing log flows through `shared.StructuredReporter`, which now also records per-stage durations for telemetry and CLI summaries. Audit-mode consumers (for example `gix audit`) set `Dependencies.DisableWorkflowLogging` so the executor instantiates reporters that write to `io.Discard`, preserving raw CSV output for integration tests.
+This separation keeps parsing/templating logic pure, isolates Git/GitHub side effects, and guarantees that every user-facing log flows through `shared.StructuredReporter`, which now also records per-stage durations for telemetry and CLI summaries. Audit-mode consumers (for example `gix audit`) set `Dependencies.DisableWorkflowLogging` so the executor instantiates reporters that write to `io.Discard`, preserving the selected raw audit report output for integration tests.
 
 ### Workflow Runtime Variables
 
@@ -64,7 +64,7 @@ All commands accept shared flags for log level, log format, previews, repository
 
 Each feature area resides in `internal/<domain>` and exposes structs with methods instead of package-level functions. The primary packages are:
 
-- `internal/audit`: Repository discovery, metadata reconciliation, CSV export, and CLI integration (`internal/audit/cli`).
+- `internal/audit`: Repository discovery, metadata reconciliation, terminal-table reporting, CSV/HTML export, and CLI integration (`internal/audit/cli`).
 - `internal/branches`: Branch maintenance commands (`sync`, `refresh`, default promotion) and supporting adapters.
 - `internal/changelog`, `internal/commitmsg`: Generators that transform Git history and staged changes into formatted text.
 - `internal/repos`: Subpackages for repository workflows:
@@ -222,6 +222,7 @@ workflow:
       command: ["audit", "report"]
       with:
         output: ./reports/audit-latest.csv
+        format: csv
 ```
 
 ## Reusable Packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - _No changes._
 
 ### Improvements ⚙️
+- Made `gix audit` terminal-readable by default with a table and added strict `--format csv` and `--format html` exports.
 - Replaced layered implicit configuration with one strict `config.yml`: explicit path, system file, then user file, with interactive user-file creation when none exists.
 - Removed dotenv discovery and the Viper configuration layer; placeholders now resolve only from the inherited process environment, while literal configuration values pass through unchanged.
 - Replaced top-level LLM provider/model selection with complete `openai` and `llm_proxy` profiles: each owns its routing fields, endpoint, interpolated credential, and positive unique priority.
@@ -31,6 +32,7 @@
 - Kept the syncflow builder description as the canonical text shown by `gix sync --help`.
 
 ### Testing 🧪
+- Added public CLI coverage for default table output, explicit CSV and HTML exports, and rejected audit report formats.
 - Added black-box coverage for configuration discovery, initialization prompts, process-only interpolation, ignored sibling `.env` files, literal credentials, missing placeholders, strict operation schemas, and LLM profile routing.
 - Added public CLI coverage for LLM connection priority, successful OpenAI-to-llm-proxy failover, stop-after-success behavior, obsolete schema rejection, and profile validation.
 - Added public CLI regressions for lossy and timed-out AI merge resolution, including phase output, heartbeat, timeout, no merge-resolution commit or push, and the manual recovery handoff.
@@ -45,6 +47,7 @@
 - Added black-box release coverage for clean-checkout helpers, failed or missing platform outputs, replaced published manifests, and missing integrity prerequisites.
 
 ### Docs 📚
+- Documented the audit table default and CSV/HTML export commands in the CLI, architecture, and site guides.
 - Documented the canonical `config.yml` discovery and interpolation contract plus the exact Meta Muse-first and OpenAI-first priority settings.
 - Documented strict-sync AI merge-resolution deadlines, progress, and manual recovery behavior.
 - Documented explicit branch targets as binding dirty-commit destinations and distinguished explicit `master` from plain current-branch rescue.

--- a/README.md
+++ b/README.md
@@ -94,13 +94,18 @@ gix packages delete --roots ~/Development/containers --yes
 
 Remove untagged GitHub Container Registry versions in one sweep.
 
-### Generate audit CSVs for reporting
+### Inspect repositories or export an audit report
 
 ```shell
-gix audit --roots ~/Development --all > audit.csv
+gix audit --roots ~/Development --all
 ```
 
-Capture metadata (default branches, owners, remotes, protocol mismatches) for every repository in scope.
+The default terminal table captures default branches, owners, remotes, protocol mismatches, and worktree state for every repository in scope. Export a machine-readable report when needed:
+
+```shell
+gix audit --roots ~/Development --all --format csv > audit.csv
+gix audit --roots ~/Development --all --format html > audit.html
+```
 
 ### Draft commit messages and changelog entries
 
@@ -272,6 +277,7 @@ workflow:
    command: ["audit", "report"]
    with:
     output: ./reports/audit.csv
+    format: csv
 ```
 
 - `name` is optional; if omitted a stable name is generated (e.g., `convert-protocol-1`).
@@ -312,7 +318,7 @@ Other commands keep the existing human-readable console logs and suppress workfl
  - with: `targets: [{ remote_name, source_branch, target_branch, push_to_remote, delete_source_branch }]`
  - Defaults: `remote_name: origin`, `target_branch: master`, `push_to_remote: true`, `delete_source_branch: false`; `source_branch` auto-detected from remote/local if omitted.
 - `audit report`
- - with: `output: <path>` (optional). When provided, writes a CSV file; otherwise prints to stdout.
+ - with: `output: <path>` (optional), `format: <table|csv|html>` (optional; defaults to `csv`).
 - `tasks apply`
  - with: `tasks: [...]` (see below) for fine-grained file changes, commits, PRs, and built-in actions.
 - `command run`
@@ -552,9 +558,9 @@ Top-level commands and their subcommands. Aliases are shown in parentheses.
  - Use `--roots` to pre-scope the initial left-pane repository catalog, for example `gix --web --roots ~/Development/fleet`.
  - The UI exposes the command catalog, accepts one argument per line, and captures stdout/stderr for each run.
 
-- `gix audit [--roots <dir>...] [--all] [-y]` (alias `a`)
+- `gix audit [--roots <dir>...] [--all] [--format <table|csv|html>] [-y]` (alias `a`)
 
- - Flags: `--roots` (repeatable), `--all` to include non-git folders in output.
+ - Flags: `--roots` (repeatable), `--all` to include non-git folders in output, `--format` to select `table` (default), `csv`, or `html`.
 
 - `gix workflow <configuration> [--roots <dir>...] [--require-clean] [-y]` (alias `w`)
 

--- a/docs/cli_design.md
+++ b/docs/cli_design.md
@@ -21,7 +21,7 @@ The following tables document each script. "Inputs" include both positional argu
 | External dependencies | `git`, `gh`, `jq`, `find`, `readlink`/`realpath`, `mv`, `sed`, `awk`, standard GNU coreutils. Requires authenticated `gh` session. |
 | Network/API usage | `gh api` to resolve repository canonical metadata; `gh repo view` to determine default branch; optional `git fetch` for sync detection; `git remote set-url` for updates. |
 | Side effects | File-system renames of repository directories; remote URL changes; Git fetches; optional prompts; stdout/stderr logging. With ``, operations are read-only. |
-| Outputs | When the dedicated audit command runs, it emits CSV (header + one line per repo) to stdout. Operational modes emit plan/action messages (`PLAN-OK`, `UPDATE-REMOTE-DONE`, etc.) to stdout and error messages to stderr. Debug logging when `--debug` is set. |
+| Outputs | The dedicated audit command emits a terminal table by default. `--format csv` emits a header plus one line per repository, and `--format html` emits a standalone HTML report. Operational modes emit plan/action messages (`PLAN-OK`, `UPDATE-REMOTE-DONE`, etc.) to stdout and error messages to stderr. Debug logging when `--debug` is set. |
 
 ### 2.2 `delete_merged_branches.sh`
 | Aspect | Details |
@@ -166,7 +166,7 @@ Integration tests live in `tests/integration` and execute the compiled CLI binar
 
 | Feature area | Scenario | Git / GitHub setup | Expected assertions |
 | --- | --- | --- | --- |
-| Repo audit | Canonical rename detection | Local repo with simulated redirect via mocked `gh api` response | CSV output includes canonical name mismatch and `origin_matches_canonical=no`. |
+| Repo audit | Canonical rename detection | Local repo with simulated redirect via mocked `gh api` response | Default table and explicit CSV/HTML exports include the canonical name mismatch and `origin_matches_canonical=no`. |
 | Repo audit | Protocol conversion | Repo using HTTPS remote | Command logs `PLAN-CONVERT` without modifying remote. |
 | Repo rename |  and execute | Case-only rename on case-insensitive filesystem simulation |  prints `PLAN-CASE-ONLY`; execute performs two-step rename. |
 | Remote update | Redirected repository | `origin` pointing to old owner; mocked `gh api` returns new owner | Remote URL updated; message `UPDATE-REMOTE-DONE`. |

--- a/docs/index.html
+++ b/docs/index.html
@@ -146,7 +146,7 @@
                   Roll out template updates by running workflows across every
                   language pack.
                 </li>
-                <li>Capture CSV audits for compliance reviews.</li>
+                <li>Inspect audits in the terminal or export CSV for compliance reviews.</li>
               </ul>
             </article>
             <article class="card">
@@ -292,7 +292,7 @@
             </article>
             <article>
               <h3>Audit Everything</h3>
-              <p><code>gix audit --roots ~/Fleet --all &gt; audit.csv</code></p>
+              <p><code>gix audit --roots ~/Fleet --all --format csv &gt; audit.csv</code></p>
               <p>
                 Capture CSV output for branch defaults, owners, remote
                 protocols, and more.

--- a/internal/audit/cli/command.go
+++ b/internal/audit/cli/command.go
@@ -22,6 +22,8 @@ const (
 	flagRootDescriptionConstant      = "Repository roots to scan (repeatable; nested paths ignored)"
 	flagIncludeAllNameConstant       = "all"
 	flagIncludeAllDescription        = "Include directories without Git repositories in the audit output"
+	flagFormatNameConstant           = "format"
+	flagFormatDescriptionConstant    = "Audit report format: table, csv, or html"
 	taskNameGenerateAuditReport      = "Generate audit report"
 	missingRootsErrorMessageConstant = "no repository roots provided; specify --roots or configure defaults"
 )
@@ -30,6 +32,7 @@ type commandOptions struct {
 	debugOutput       bool
 	includeAllFolders bool
 	repositoryRoots   []string
+	reportFormat      audit.ReportFormat
 }
 
 // LoggerProvider yields a zap logger for command execution.
@@ -59,6 +62,7 @@ func (builder *CommandBuilder) Build() (*cobra.Command, error) {
 
 	command.Flags().StringSlice(flagRootNameConstant, nil, flagRootDescriptionConstant)
 	flagutils.AddToggleFlag(command.Flags(), nil, flagIncludeAllNameConstant, "", false, flagIncludeAllDescription)
+	command.Flags().String(flagFormatNameConstant, string(audit.DefaultReportFormat()), flagFormatDescriptionConstant)
 
 	return command, nil
 }
@@ -99,11 +103,12 @@ func (builder *CommandBuilder) run(command *cobra.Command, arguments []string) e
 
 	taskRunner := resolveTaskRunner(builder.TaskRunnerFactory, dependencyResult.Workflow)
 
-	actionOptions := map[string]any{
-		"include_all": options.includeAllFolders,
-		"debug":       options.debugOutput,
-		"depth":       string(audit.InspectionDepthFull),
-	}
+	actionOptions := workflow.AuditReportActionOptions{
+		IncludeAll: options.includeAllFolders,
+		Debug:      options.debugOutput,
+		Depth:      audit.InspectionDepthFull,
+		Format:     options.reportFormat,
+	}.Options()
 
 	taskDefinition := workflow.TaskDefinition{
 		Name:        taskNameGenerateAuditReport,
@@ -149,6 +154,19 @@ func (builder *CommandBuilder) parseOptions(command *cobra.Command) (commandOpti
 		}
 	}
 
+	reportFormat := audit.DefaultReportFormat()
+	if command != nil {
+		formatValue, formatError := command.Flags().GetString(flagFormatNameConstant)
+		if formatError != nil {
+			return commandOptions{}, formatError
+		}
+		parsedFormat, parseFormatError := audit.ParseReportFormat(formatValue)
+		if parseFormatError != nil {
+			return commandOptions{}, parseFormatError
+		}
+		reportFormat = parsedFormat
+	}
+
 	if len(repositoryRoots) == 0 {
 		if command != nil {
 			_ = command.Help()
@@ -160,6 +178,7 @@ func (builder *CommandBuilder) parseOptions(command *cobra.Command) (commandOpti
 		repositoryRoots:   repositoryRoots,
 		includeAllFolders: includeAll,
 		debugOutput:       debugMode,
+		reportFormat:      reportFormat,
 	}, nil
 }
 

--- a/internal/audit/cli/command_test.go
+++ b/internal/audit/cli/command_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	rootFlagArgumentConstant       = "--" + flagutils.DefaultRootFlagName
 	includeAllFlagArgumentConstant = "--all"
+	formatFlagArgumentConstant     = "--format"
 )
 
 var boundRootFlagValues []*flagutils.RootFlagValues
@@ -59,6 +60,7 @@ func TestCommandBuildsAuditTaskFromConfiguration(t *testing.T) {
 	require.Equal(t, "audit.report", action.Type)
 	require.Equal(t, false, action.Options["include_all"])
 	require.Equal(t, false, action.Options["debug"])
+	require.Equal(t, "table", action.Options["format"])
 }
 
 func TestCommandFlagsOverrideConfiguration(t *testing.T) {
@@ -91,6 +93,7 @@ func TestCommandFlagsOverrideConfiguration(t *testing.T) {
 	command.SetArgs([]string{
 		rootFlagArgumentConstant, flagRoot,
 		includeAllFlagArgumentConstant,
+		formatFlagArgumentConstant, "csv",
 	})
 
 	executionError := command.Execute()
@@ -100,6 +103,30 @@ func TestCommandFlagsOverrideConfiguration(t *testing.T) {
 	action := runner.definitions[0].Actions[0]
 	require.Equal(t, "audit.report", action.Type)
 	require.Equal(t, true, action.Options["include_all"])
+	require.Equal(t, "csv", action.Options["format"])
+}
+
+func TestCommandRejectsUnsupportedReportFormat(t *testing.T) {
+	t.Helper()
+
+	root := "/tmp/audit-root"
+	builder := cli.CommandBuilder{
+		LoggerProvider: func() *zap.Logger { return zap.NewNop() },
+		ConfigurationProvider: func() audit.CommandConfiguration {
+			return audit.CommandConfiguration{Roots: []string{root}}
+		},
+	}
+
+	command, buildError := builder.Build()
+	require.NoError(t, buildError)
+	bindRootAndExecutionFlags(command)
+
+	command.SetContext(context.Background())
+	command.SetArgs([]string{formatFlagArgumentConstant, "json"})
+
+	executionError := command.Execute()
+	require.Error(t, executionError)
+	require.Contains(t, executionError.Error(), "unsupported audit report format \"json\"")
 }
 
 func TestCommandDisplaysHelpWhenRootsMissing(t *testing.T) {

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -1,0 +1,197 @@
+package audit
+
+import (
+	"encoding/csv"
+	"fmt"
+	"html"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	auditReportTitleConstant               = "gix audit report"
+	auditHTMLDocumentTitlePrefixConstant   = "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>"
+	auditHTMLDocumentTitleSuffixConstant   = "</title>\n<style>body{font-family:system-ui,sans-serif;margin:2rem}table{border-collapse:collapse}th,td{border:1px solid #999;padding:.4rem;text-align:left;vertical-align:top;white-space:pre-wrap}th{background:#f3f3f3}</style>\n</head>\n<body>\n<h1>"
+	auditHTMLDocumentHeadingSuffixConstant = "</h1>\n<table>\n<thead>\n<tr>"
+	auditHTMLDocumentCloseConstant         = "\n</tbody>\n</table>\n</body>\n</html>\n"
+)
+
+// WriteReport serializes repository inspections in the requested report format.
+func WriteReport(writer io.Writer, reportFormat ReportFormat, inspections []RepositoryInspection) error {
+	normalizedFormat, formatError := normalizeReportFormat(reportFormat)
+	if formatError != nil {
+		return formatError
+	}
+
+	rows := make([]AuditReportRow, len(inspections))
+	for inspectionIndex := range inspections {
+		rows[inspectionIndex] = inspectionReportRow(inspections[inspectionIndex])
+	}
+
+	switch normalizedFormat {
+	case ReportFormatTable:
+		if writeError := writeTableReport(writer, rows); writeError != nil {
+			return fmt.Errorf("write table audit report: %w", writeError)
+		}
+	case ReportFormatCSV:
+		if writeError := writeCSVReport(writer, rows); writeError != nil {
+			return fmt.Errorf("write CSV audit report: %w", writeError)
+		}
+	case ReportFormatHTML:
+		if writeError := writeHTMLReport(writer, rows); writeError != nil {
+			return fmt.Errorf("write HTML audit report: %w", writeError)
+		}
+	}
+
+	return nil
+}
+
+func writeCSVReport(writer io.Writer, rows []AuditReportRow) error {
+	csvWriter := csv.NewWriter(writer)
+	if writeError := csvWriter.Write(auditReportCSVHeaders()); writeError != nil {
+		return writeError
+	}
+
+	for rowIndex := range rows {
+		if writeError := csvWriter.Write(rows[rowIndex].CSVRecord()); writeError != nil {
+			return writeError
+		}
+	}
+
+	csvWriter.Flush()
+	return csvWriter.Error()
+}
+
+func writeTableReport(writer io.Writer, rows []AuditReportRow) error {
+	header := auditReportDisplayHeaders()
+	values := make([][]string, 0, len(rows))
+	for rowIndex := range rows {
+		values = append(values, normalizeTableRecord(rows[rowIndex].CSVRecord()))
+	}
+
+	widths := auditTableColumnWidths(header, values)
+	border := auditTableBorder(widths)
+	if _, writeError := fmt.Fprintln(writer, border); writeError != nil {
+		return writeError
+	}
+	if writeError := writeAuditTableRow(writer, header, widths); writeError != nil {
+		return writeError
+	}
+	if _, writeError := fmt.Fprintln(writer, border); writeError != nil {
+		return writeError
+	}
+	for rowIndex := range values {
+		if writeError := writeAuditTableRow(writer, values[rowIndex], widths); writeError != nil {
+			return writeError
+		}
+	}
+	_, writeError := fmt.Fprintln(writer, border)
+	return writeError
+}
+
+func writeHTMLReport(writer io.Writer, rows []AuditReportRow) error {
+	var document strings.Builder
+	document.WriteString(auditHTMLDocumentTitlePrefixConstant)
+	document.WriteString(auditReportTitleConstant)
+	document.WriteString(auditHTMLDocumentTitleSuffixConstant)
+	document.WriteString(auditReportTitleConstant)
+	document.WriteString(auditHTMLDocumentHeadingSuffixConstant)
+	for _, header := range auditReportDisplayHeaders() {
+		document.WriteString("\n<th>")
+		document.WriteString(html.EscapeString(header))
+		document.WriteString("</th>")
+	}
+	document.WriteString("\n</tr>\n</thead>\n<tbody>")
+	for rowIndex := range rows {
+		document.WriteString("\n<tr>")
+		for _, value := range rows[rowIndex].CSVRecord() {
+			document.WriteString("\n<td>")
+			document.WriteString(html.EscapeString(value))
+			document.WriteString("</td>")
+		}
+		document.WriteString("\n</tr>")
+	}
+	document.WriteString(auditHTMLDocumentCloseConstant)
+	_, writeError := io.WriteString(writer, document.String())
+	return writeError
+}
+
+func auditReportCSVHeaders() []string {
+	return []string{
+		csvHeaderFolderName,
+		csvHeaderFinalRepository,
+		csvHeaderOriginRemoteStatus,
+		csvHeaderNameMatches,
+		csvHeaderRemoteDefault,
+		csvHeaderLocalBranch,
+		csvHeaderInSync,
+		csvHeaderRemoteProtocol,
+		csvHeaderOriginCanonical,
+		csvHeaderWorktreeDirty,
+		csvHeaderDirtyFiles,
+	}
+}
+
+func auditReportDisplayHeaders() []string {
+	return []string{
+		"Folder",
+		"Final Repository",
+		"Origin",
+		"Name Matches",
+		"Remote Default",
+		"Local Branch",
+		"In Sync",
+		"Protocol",
+		"Origin Canonical",
+		"Worktree Dirty",
+		"Dirty Files",
+	}
+}
+
+func normalizeTableRecord(record []string) []string {
+	normalized := make([]string, len(record))
+	for valueIndex := range record {
+		normalized[valueIndex] = strings.NewReplacer("\r\n", "\\n", "\n", "\\n", "\r", "\\r", "\t", "\\t").Replace(record[valueIndex])
+	}
+	return normalized
+}
+
+func auditTableColumnWidths(header []string, rows [][]string) []int {
+	widths := make([]int, len(header))
+	for columnIndex := range header {
+		widths[columnIndex] = utf8.RuneCountInString(header[columnIndex])
+	}
+	for rowIndex := range rows {
+		for columnIndex := range rows[rowIndex] {
+			width := utf8.RuneCountInString(rows[rowIndex][columnIndex])
+			if width > widths[columnIndex] {
+				widths[columnIndex] = width
+			}
+		}
+	}
+	return widths
+}
+
+func auditTableBorder(widths []int) string {
+	var border strings.Builder
+	border.WriteByte('+')
+	for widthIndex := range widths {
+		border.WriteString(strings.Repeat("-", widths[widthIndex]+2))
+		border.WriteByte('+')
+	}
+	return border.String()
+}
+
+func writeAuditTableRow(writer io.Writer, values []string, widths []int) error {
+	var line strings.Builder
+	line.WriteByte('|')
+	for valueIndex := range values {
+		line.WriteByte(' ')
+		line.WriteString(values[valueIndex])
+		line.WriteString(strings.Repeat(" ", widths[valueIndex]-utf8.RuneCountInString(values[valueIndex])+1))
+		line.WriteByte('|')
+	}
+	_, writeError := fmt.Fprintln(writer, line.String())
+	return writeError
+}

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -2,7 +2,6 @@ package audit
 
 import (
 	"context"
-	"encoding/csv"
 	"errors"
 	"fmt"
 	"io"
@@ -53,7 +52,7 @@ func (service *Service) Run(executionContext context.Context, options CommandOpt
 		return inspectionError
 	}
 
-	return service.writeAuditReport(inspections)
+	return WriteReport(service.outputWriter, options.ReportFormat, inspections)
 }
 
 // DiscoverInspections collects repository inspections for the provided roots.
@@ -129,36 +128,6 @@ func (service *Service) DiscoverInspections(executionContext context.Context, ro
 	}
 
 	return inspections, nil
-}
-
-func (service *Service) writeAuditReport(inspections []RepositoryInspection) error {
-	csvWriter := csv.NewWriter(service.outputWriter)
-	header := []string{
-		csvHeaderFolderName,
-		csvHeaderFinalRepository,
-		csvHeaderOriginRemoteStatus,
-		csvHeaderNameMatches,
-		csvHeaderRemoteDefault,
-		csvHeaderLocalBranch,
-		csvHeaderInSync,
-		csvHeaderRemoteProtocol,
-		csvHeaderOriginCanonical,
-		csvHeaderWorktreeDirty,
-		csvHeaderDirtyFiles,
-	}
-	if writeError := csvWriter.Write(header); writeError != nil {
-		return writeError
-	}
-
-	for inspectionIndex := range inspections {
-		record := inspectionReportRow(inspections[inspectionIndex])
-		if writeError := csvWriter.Write(record.CSVRecord()); writeError != nil {
-			return writeError
-		}
-	}
-
-	csvWriter.Flush()
-	return csvWriter.Error()
 }
 
 func deduplicatePaths(paths []string) []string {

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -301,6 +301,7 @@ func TestServiceRunBehaviors(testInstance *testing.T) {
 
 	for testCaseIndex, testCase := range testCases {
 		testInstance.Run(fmt.Sprintf("%d_%s", testCaseIndex, testCase.name), func(testInstance *testing.T) {
+			testCase.options.ReportFormat = audit.ReportFormatCSV
 			outputBuffer := &bytes.Buffer{}
 			errorBuffer := &bytes.Buffer{}
 
@@ -361,6 +362,7 @@ func TestServiceRunNormalizesRepositoryPaths(testInstance *testing.T) {
 		Roots:           []string{currentDirectoryRelativePathConstant},
 		InspectionDepth: audit.InspectionDepthMinimal,
 		DebugOutput:     true,
+		ReportFormat:    audit.ReportFormatCSV,
 	}
 
 	runError := service.Run(context.Background(), options)
@@ -424,6 +426,7 @@ func TestServiceRunIncludesAllFolders(testInstance *testing.T) {
 		Roots:             []string{rootDirectory},
 		InspectionDepth:   audit.InspectionDepthMinimal,
 		IncludeAllFolders: true,
+		ReportFormat:      audit.ReportFormatCSV,
 	}
 
 	runError := service.Run(context.Background(), options)
@@ -471,6 +474,7 @@ func TestServiceRunUsesRelativeFolderNames(testInstance *testing.T) {
 	options := audit.CommandOptions{
 		Roots:           []string{rootDirectory},
 		InspectionDepth: audit.InspectionDepthMinimal,
+		ReportFormat:    audit.ReportFormatCSV,
 	}
 
 	runError := service.Run(context.Background(), options)

--- a/internal/audit/types.go
+++ b/internal/audit/types.go
@@ -1,6 +1,10 @@
 package audit
 
-import "github.com/tyemirov/gix/internal/repos/shared"
+import (
+	"fmt"
+
+	"github.com/tyemirov/gix/internal/repos/shared"
+)
 
 // RemoteProtocolType enumerates supported git remote protocols.
 type RemoteProtocolType = shared.RemoteProtocol
@@ -42,12 +46,46 @@ const (
 	InspectionDepthMinimal InspectionDepth = "minimal"
 )
 
+// ReportFormat identifies the serialization used for an audit report.
+type ReportFormat string
+
+// Supported audit report formats.
+const (
+	ReportFormatTable ReportFormat = "table"
+	ReportFormatCSV   ReportFormat = "csv"
+	ReportFormatHTML  ReportFormat = "html"
+)
+
+// DefaultReportFormat returns the terminal-oriented audit report format.
+func DefaultReportFormat() ReportFormat {
+	return ReportFormatTable
+}
+
+// ParseReportFormat validates one exact audit report format value.
+func ParseReportFormat(value string) (ReportFormat, error) {
+	reportFormat := ReportFormat(value)
+	switch reportFormat {
+	case ReportFormatTable, ReportFormatCSV, ReportFormatHTML:
+		return reportFormat, nil
+	default:
+		return "", fmt.Errorf("unsupported audit report format %q; expected table, csv, or html", value)
+	}
+}
+
+func normalizeReportFormat(reportFormat ReportFormat) (ReportFormat, error) {
+	if reportFormat == "" {
+		return DefaultReportFormat(), nil
+	}
+	return ParseReportFormat(string(reportFormat))
+}
+
 // CommandOptions captures the configurable parameters for the audit command.
 type CommandOptions struct {
 	Roots             []string
 	DebugOutput       bool
 	InspectionDepth   InspectionDepth
 	IncludeAllFolders bool
+	ReportFormat      ReportFormat
 }
 
 // RepositoryInspection captures gathered repository state.

--- a/internal/workflow/action_options_builder.go
+++ b/internal/workflow/action_options_builder.go
@@ -158,13 +158,19 @@ type AuditReportActionOptions struct {
 	Debug      bool
 	Depth      audit.InspectionDepth
 	OutputPath string
+	Format     audit.ReportFormat
 }
 
 // Options returns workflow action options for audit report generation.
 func (options AuditReportActionOptions) Options() map[string]any {
+	reportFormat := options.Format
+	if reportFormat == "" {
+		reportFormat = audit.ReportFormatCSV
+	}
 	serialized := compactStringOptions(map[string]string{
 		actionOptionDepthKeyConstant: string(options.Depth),
 		optionOutputPathKeyConstant:  options.OutputPath,
+		optionFormatKeyConstant:      string(reportFormat),
 	})
 	serialized[actionOptionIncludeAllKeyConstant] = options.IncludeAll
 	serialized[actionOptionDebugKeyConstant] = options.Debug

--- a/internal/workflow/action_options_builder_test.go
+++ b/internal/workflow/action_options_builder_test.go
@@ -65,12 +65,14 @@ func TestActionOptionBuildersSerializeWorkflowContracts(testingInstance *testing
 				Debug:      true,
 				Depth:      audit.InspectionDepthMinimal,
 				OutputPath: "audit.csv",
+				Format:     audit.ReportFormatCSV,
 			}.Options(),
 			expected: map[string]any{
 				actionOptionIncludeAllKeyConstant: true,
 				actionOptionDebugKeyConstant:      true,
 				actionOptionDepthKeyConstant:      string(audit.InspectionDepthMinimal),
 				optionOutputPathKeyConstant:       "audit.csv",
+				optionFormatKeyConstant:           string(audit.ReportFormatCSV),
 			},
 		},
 	}

--- a/internal/workflow/operations_audit.go
+++ b/internal/workflow/operations_audit.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"encoding/csv"
 	"fmt"
 	"io"
 	"os"
@@ -17,23 +16,13 @@ const (
 	auditReportDestinationStdoutConstant  = "stdout"
 	auditCurrentDirectorySentinelConstant = "."
 	auditDirectoryPermissionsConstant     = 0o755
-	auditCSVHeaderFinalRepositoryConstant = "final_github_repo"
-	auditCSVHeaderFolderNameConstant      = "folder_name"
-	auditCSVHeaderRemoteStatusConstant    = "origin_remote_status"
-	auditCSVHeaderNameMatchesConstant     = "name_matches"
-	auditCSVHeaderRemoteDefaultConstant   = "remote_default_branch"
-	auditCSVHeaderLocalBranchConstant     = "local_branch"
-	auditCSVHeaderInSyncConstant          = "in_sync"
-	auditCSVHeaderRemoteProtocolConstant  = "remote_protocol"
-	auditCSVHeaderOriginCanonicalConstant = "origin_matches_canonical"
-	auditCSVHeaderWorktreeDirtyConstant   = "worktree_dirty"
-	auditCSVHeaderDirtyFilesConstant      = "dirty_files"
 )
 
-// AuditReportOperation emits an audit CSV summarizing repository state.
+// AuditReportOperation emits an audit report summarizing repository state.
 type AuditReportOperation struct {
 	OutputPath  string
 	WriteToFile bool
+	Format      audit.ReportFormat
 }
 
 // Name identifies the workflow command handled by this operation.
@@ -86,36 +75,13 @@ func (operation *AuditReportOperation) Execute(executionContext context.Context,
 		}()
 	}
 
-	csvWriter := csv.NewWriter(writer)
-	header := []string{
-		auditCSVHeaderFolderNameConstant,
-		auditCSVHeaderFinalRepositoryConstant,
-		auditCSVHeaderRemoteStatusConstant,
-		auditCSVHeaderNameMatchesConstant,
-		auditCSVHeaderRemoteDefaultConstant,
-		auditCSVHeaderLocalBranchConstant,
-		auditCSVHeaderInSyncConstant,
-		auditCSVHeaderRemoteProtocolConstant,
-		auditCSVHeaderOriginCanonicalConstant,
-		auditCSVHeaderWorktreeDirtyConstant,
-		auditCSVHeaderDirtyFilesConstant,
-	}
-
-	if writeError := csvWriter.Write(header); writeError != nil {
-		return writeError
-	}
-
+	inspections := make([]audit.RepositoryInspection, 0, len(state.Repositories))
 	for repositoryIndex := range state.Repositories {
 		repository := state.Repositories[repositoryIndex]
-		row := buildAuditReportRow(repository.Inspection)
-		if writeError := csvWriter.Write(row); writeError != nil {
-			return writeError
-		}
+		inspections = append(inspections, repository.Inspection)
 	}
-
-	csvWriter.Flush()
-	if flushError := csvWriter.Error(); flushError != nil {
-		return flushError
+	if writeError := audit.WriteReport(writer, operation.Format, inspections); writeError != nil {
+		return writeError
 	}
 
 	if operation.WriteToFile && environment.Output != nil {
@@ -123,65 +89,4 @@ func (operation *AuditReportOperation) Execute(executionContext context.Context,
 	}
 
 	return nil
-}
-
-func buildAuditReportRow(inspection audit.RepositoryInspection) []string {
-	finalRepository := strings.TrimSpace(inspection.CanonicalOwnerRepo)
-	if len(finalRepository) == 0 {
-		finalRepository = inspection.OriginOwnerRepo
-	}
-
-	nameMatches := audit.TernaryValueNotApplicable
-	if inspection.IsGitRepository {
-		nameMatches = audit.TernaryValueNo
-		if len(inspection.DesiredFolderName) > 0 && inspection.DesiredFolderName == inspection.FolderName {
-			nameMatches = audit.TernaryValueYes
-		}
-	}
-
-	remoteDefaultBranch := inspection.RemoteDefaultBranch
-	localBranch := inspection.LocalBranch
-	inSync := inspection.InSyncStatus
-	originRemoteStatus := inspection.OriginRemoteStatus
-	remoteProtocol := string(inspection.RemoteProtocol)
-	originMatches := string(inspection.OriginMatchesCanonical)
-
-	var worktreeDirty audit.TernaryValue
-	dirtyFiles := ""
-
-	if !inspection.IsGitRepository {
-		finalRepository = string(audit.TernaryValueNotApplicable)
-		originRemoteStatus = audit.OriginRemoteStatusNotApplicable
-		remoteDefaultBranch = string(audit.TernaryValueNotApplicable)
-		localBranch = string(audit.TernaryValueNotApplicable)
-		inSync = audit.TernaryValueNotApplicable
-		remoteProtocol = string(audit.TernaryValueNotApplicable)
-		originMatches = string(audit.TernaryValueNotApplicable)
-		worktreeDirty = audit.TernaryValueNotApplicable
-	} else {
-		if originRemoteStatus == audit.OriginRemoteStatusMissing {
-			finalRepository = string(audit.TernaryValueNotApplicable)
-			remoteProtocol = string(audit.TernaryValueNotApplicable)
-		}
-		if len(inspection.WorktreeDirtyFiles) > 0 {
-			worktreeDirty = audit.TernaryValueYes
-			dirtyFiles = strings.Join(inspection.WorktreeDirtyFiles, "; ")
-		} else {
-			worktreeDirty = audit.TernaryValueNo
-		}
-	}
-
-	return []string{
-		inspection.FolderName,
-		finalRepository,
-		string(originRemoteStatus),
-		string(nameMatches),
-		remoteDefaultBranch,
-		localBranch,
-		string(inSync),
-		remoteProtocol,
-		originMatches,
-		string(worktreeDirty),
-		dirtyFiles,
-	}
 }

--- a/internal/workflow/operations_audit_test.go
+++ b/internal/workflow/operations_audit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tyemirov/gix/internal/audit"
 	"github.com/tyemirov/gix/internal/workflow"
 )
 
@@ -46,7 +47,7 @@ func TestAuditReportOperationCreatesNestedOutput(testInstance *testing.T) {
 				configuredOutputPath = auditReportWhitespacePaddingConstant + configuredOutputPath + auditReportWhitespacePaddingConstant
 			}
 
-			operation := &workflow.AuditReportOperation{OutputPath: configuredOutputPath, WriteToFile: true}
+			operation := &workflow.AuditReportOperation{OutputPath: configuredOutputPath, WriteToFile: true, Format: audit.ReportFormatCSV}
 			operationEnvironment := &workflow.Environment{Output: &bytes.Buffer{}}
 			operationState := &workflow.State{}
 

--- a/internal/workflow/operations_builder.go
+++ b/internal/workflow/operations_builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tyemirov/gix/internal/audit"
 	"github.com/tyemirov/gix/internal/repos/shared"
 )
 
@@ -289,8 +290,20 @@ func buildAuditReportOperation(options map[string]any) (Operation, error) {
 	if outputError != nil {
 		return nil, outputError
 	}
+	formatValue, formatExists, formatError := reader.stringValue(optionFormatKeyConstant)
+	if formatError != nil {
+		return nil, formatError
+	}
+	reportFormat := audit.ReportFormatCSV
+	if formatExists {
+		parsedFormat, parseFormatError := audit.ParseReportFormat(formatValue)
+		if parseFormatError != nil {
+			return nil, parseFormatError
+		}
+		reportFormat = parsedFormat
+	}
 
-	return &AuditReportOperation{OutputPath: strings.TrimSpace(outputPath), WriteToFile: outputExists && len(strings.TrimSpace(outputPath)) > 0}, nil
+	return &AuditReportOperation{OutputPath: strings.TrimSpace(outputPath), WriteToFile: outputExists && len(strings.TrimSpace(outputPath)) > 0, Format: reportFormat}, nil
 }
 
 func parseProtocolValue(raw string) (shared.RemoteProtocol, error) {

--- a/internal/workflow/options_reader.go
+++ b/internal/workflow/options_reader.go
@@ -20,6 +20,7 @@ const (
 	optionPushToRemoteKeyConstant       = "push_to_remote"
 	optionDeleteSourceBranchKeyConstant = "delete_source_branch"
 	optionOutputPathKeyConstant         = "output"
+	optionFormatKeyConstant             = "format"
 )
 
 type optionReader struct {

--- a/internal/workflow/task_actions.go
+++ b/internal/workflow/task_actions.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"encoding/csv"
 	"errors"
 	"fmt"
 	"os"
@@ -355,6 +354,19 @@ func handleAuditReportAction(ctx context.Context, environment *Environment, repo
 		depth = audit.InspectionDepthMinimal
 	}
 
+	formatValue, formatExists, formatError := reader.stringValue(optionFormatKeyConstant)
+	if formatError != nil {
+		return formatError
+	}
+	reportFormat := audit.ReportFormatCSV
+	if formatExists {
+		parsedFormat, parseFormatError := audit.ParseReportFormat(formatValue)
+		if parseFormatError != nil {
+			return parseFormatError
+		}
+		reportFormat = parsedFormat
+	}
+
 	roots := collectAuditRoots(environment.State, repository)
 	if len(roots) == 0 {
 		environment.markAuditReportExecuted()
@@ -375,7 +387,7 @@ func handleAuditReportAction(ctx context.Context, environment *Environment, repo
 			return discoveryError
 		}
 
-		if writeError := writeAuditReportFile(sanitizedOutput, inspections); writeError != nil {
+		if writeError := writeAuditReportFile(sanitizedOutput, reportFormat, inspections); writeError != nil {
 			environment.markAuditReportExecuted()
 			return writeError
 		}
@@ -392,6 +404,7 @@ func handleAuditReportAction(ctx context.Context, environment *Environment, repo
 		DebugOutput:       debugOutput,
 		IncludeAllFolders: includeAll,
 		InspectionDepth:   depth,
+		ReportFormat:      reportFormat,
 	}
 
 	if runError := environment.AuditService.Run(ctx, commandOptions); runError != nil {
@@ -567,7 +580,7 @@ func readHistoryPaths(raw any) ([]string, error) {
 	}
 }
 
-func writeAuditReportFile(destination string, inspections []audit.RepositoryInspection) error {
+func writeAuditReportFile(destination string, reportFormat audit.ReportFormat, inspections []audit.RepositoryInspection) error {
 	if len(strings.TrimSpace(destination)) == 0 {
 		return errors.New("audit report destination missing")
 	}
@@ -583,31 +596,10 @@ func writeAuditReportFile(destination string, inspections []audit.RepositoryInsp
 	if createError != nil {
 		return createError
 	}
-	defer fileHandle.Close()
-
-	writer := csv.NewWriter(fileHandle)
-	header := []string{
-		auditCSVHeaderFolderNameConstant,
-		auditCSVHeaderFinalRepositoryConstant,
-		auditCSVHeaderNameMatchesConstant,
-		auditCSVHeaderRemoteDefaultConstant,
-		auditCSVHeaderLocalBranchConstant,
-		auditCSVHeaderInSyncConstant,
-		auditCSVHeaderRemoteProtocolConstant,
-		auditCSVHeaderOriginCanonicalConstant,
-	}
-
-	if writeError := writer.Write(header); writeError != nil {
+	writeError := audit.WriteReport(fileHandle, reportFormat, inspections)
+	closeError := fileHandle.Close()
+	if writeError != nil {
 		return writeError
 	}
-
-	for inspectionIndex := range inspections {
-		row := buildAuditReportRow(inspections[inspectionIndex])
-		if writeError := writer.Write(row); writeError != nil {
-			return writeError
-		}
-	}
-
-	writer.Flush()
-	return writer.Error()
+	return closeError
 }

--- a/internal/workflow/task_actions_audit_test.go
+++ b/internal/workflow/task_actions_audit_test.go
@@ -97,6 +97,7 @@ func TestHandleAuditReportActionUsesUpdatedRepositoryPaths(testInstance *testing
 	parameters := map[string]any{
 		"output": outputPath,
 		"depth":  string(audit.InspectionDepthMinimal),
+		"format": string(audit.ReportFormatCSV),
 	}
 
 	executionError := handleAuditReportAction(executionContext, environment, repository, parameters)
@@ -132,6 +133,7 @@ func TestHandleAuditReportActionFallsBackToStateRoots(testInstance *testing.T) {
 	parameters := map[string]any{
 		"output": outputPath,
 		"depth":  string(audit.InspectionDepthMinimal),
+		"format": string(audit.ReportFormatCSV),
 	}
 
 	executionError := handleAuditReportAction(executionContext, environment, &RepositoryState{}, parameters)

--- a/tests/audit_integration_test.go
+++ b/tests/audit_integration_test.go
@@ -22,6 +22,7 @@ const (
 	auditIntegrationAuditCommandName           = "audit"
 	auditIntegrationRootFlag                   = "--roots"
 	auditIntegrationIncludeAllFlag             = "--all"
+	auditIntegrationFormatFlag                 = "--format"
 	auditIntegrationGitExecutable              = "git"
 	auditIntegrationInitFlag                   = "init"
 	auditIntegrationInitialBranchFlag          = "--initial-branch=main"
@@ -36,7 +37,9 @@ const (
 	auditIntegrationCSVHeaderConstant          = "folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
 	auditIntegrationCSVRowTemplate             = "%[1]s,canonical/example,configured,no,main,,n/a,ssh,no,no,\n"
 	auditIntegrationCSVTemplate                = auditIntegrationCSVHeaderConstant + auditIntegrationCSVRowTemplate
-	auditIntegrationCSVCaseNameConstant        = "audit_csv"
+	auditIntegrationTableCaseNameConstant      = "audit_table_default"
+	auditIntegrationCSVCaseNameConstant        = "audit_csv_export"
+	auditIntegrationHTMLCaseNameConstant       = "audit_html_export"
 	auditIntegrationDebugCaseNameConstant      = "audit_debug"
 	auditIntegrationTildeCaseNameConstant      = "audit_tilde"
 	auditIntegrationIncludeAllCaseNameConstant = "audit_include_all"
@@ -117,8 +120,14 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 			root,
 		}
 	}
+	withFormat := func(arguments []string, reportFormat string) []string {
+		formattedArguments := append([]string{}, arguments...)
+		return append(formattedArguments, auditIntegrationFormatFlag, reportFormat)
+	}
 
 	rootFlagArguments := buildArguments(auditIntegrationErrorLevel, repositoryPath)
+	csvArguments := withFormat(rootFlagArguments, "csv")
+	htmlArguments := withFormat(rootFlagArguments, "html")
 	debugLogLevelArguments := buildArguments(auditIntegrationDebugLevel, repositoryPath)
 	tildeRootArguments := buildArguments(auditIntegrationErrorLevel, tildeRootArgument)
 	includeAllArguments := append(buildArguments(auditIntegrationErrorLevel, includeAllRoot), auditIntegrationIncludeAllFlag)
@@ -132,9 +141,33 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 		unexpectedFragments []string
 	}{
 		{
+			name:      auditIntegrationTableCaseNameConstant,
+			arguments: rootFlagArguments,
+			expectedFragments: []string{
+				"| Folder ",
+				"| Final Repository ",
+				repositoryFolderName,
+				"canonical/example",
+			},
+			unexpectedFragments: []string{auditIntegrationCSVHeaderConstant},
+		},
+		{
 			name:           auditIntegrationCSVCaseNameConstant,
-			arguments:      rootFlagArguments,
+			arguments:      csvArguments,
 			expectedOutput: expectedCSVOutput,
+		},
+		{
+			name:      auditIntegrationHTMLCaseNameConstant,
+			arguments: htmlArguments,
+			expectedFragments: []string{
+				"<!doctype html>",
+				"<title>gix audit report</title>",
+				"<table>",
+				"<th>Folder</th>",
+				"<td>" + repositoryFolderName + "</td>",
+				"<td>canonical/example</td>",
+			},
+			unexpectedFragments: []string{auditIntegrationCSVHeaderConstant},
 		},
 		{
 			name:      auditIntegrationDebugCaseNameConstant,
@@ -142,24 +175,29 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 			expectedFragments: []string{
 				fmt.Sprintf("DEBUG: discovered 1 candidate repos under: %s", repositoryPath),
 				fmt.Sprintf("DEBUG: checking %s", repositoryPath),
-				auditIntegrationCSVHeaderConstant,
-				fmt.Sprintf(auditIntegrationCSVRowTemplate, repositoryFolderName),
+				"| Folder ",
+				repositoryFolderName,
 			},
+			unexpectedFragments: []string{auditIntegrationCSVHeaderConstant},
 		},
 		{
-			name:           auditIntegrationTildeCaseNameConstant,
-			arguments:      tildeRootArguments,
-			expectedOutput: expectedCSVOutput,
+			name:      auditIntegrationTildeCaseNameConstant,
+			arguments: tildeRootArguments,
+			expectedFragments: []string{
+				"| Folder ",
+				repositoryFolderName,
+			},
+			unexpectedFragments: []string{auditIntegrationCSVHeaderConstant},
 		},
 		{
 			name:      auditIntegrationIncludeAllCaseNameConstant,
 			arguments: includeAllArguments,
-			expectedOutput: fmt.Sprintf(
-				"folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n%[1]s,canonical/example,configured,no,main,,n/a,ssh,no,no,\n%[2]s,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,\n",
+			expectedFragments: []string{
+				"| Folder ",
 				includeAllRepositoryFolderName,
 				nonGitFolderName,
-			),
-			unexpectedFragments: []string{nestedNonGitFolderName},
+			},
+			unexpectedFragments: []string{auditIntegrationCSVHeaderConstant, nestedNonGitFolderName},
 		},
 	}
 
@@ -179,4 +217,14 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 			}
 		})
 	}
+
+	invalidFormatOutput, invalidFormatError := runFailingIntegrationCommand(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{PathVariable: extendedPath},
+		auditIntegrationTimeout,
+		withFormat(rootFlagArguments, "json"),
+	)
+	require.Error(testInstance, invalidFormatError)
+	require.Contains(testInstance, filterStructuredOutput(invalidFormatOutput), "unsupported audit report format \"json\"")
 }


### PR DESCRIPTION
## Summary

This update enhances the audit functionality by introducing explicit output formats and table rendering for terminal use, with improvements reflected across documentation, implementation, and testing.

## Notable Changes

- **New `--format` Option:** The audit CLI command now accepts a `--format` flag with supported values: `table`, `csv`, or `html`. Unsupported formats result in an immediate error.
- **Terminal-Friendly Output:** The default audit output in direct CLI invocations is now a human-readable ASCII table, making it easier to interpret results interactively.
- **Export Formats:** In addition to the terminal table, users can export audit results to CSV or HTML formats for integration with other tools or sharing.
- **Unified Audit Renderer:** All output formats share a single rendering mechanism, ensuring consistency across table, CSV, and HTML exports (including full field coverage and proper HTML escaping).
- **Workflow/Automation Behavior:** Audit reports generated via workflows remain in machine-oriented CSV format by default, but can be set explicitly to other supported formats.
- **Documentation Updates:** The README, CLI design docs, site copy, and the architecture guide have been updated to clarify output options, usage examples (including CSV/HTML export), and the intended distinctions between terminal and machine output.
- **