### PR TITLE
gix/escape-table-delimiters-and-align-wide-unicode-in

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -692,6 +692,10 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - `make lint`
   - `make ci`
   - `git diff --check`
+  Review Follow-up (2026-07-24):
+  - Escaped literal table-cell delimiters and switched table layout to terminal display-cell widths, keeping Unicode repository and file names aligned.
+  - Added a public CLI regression for a repository name containing both wide Unicode characters and a table delimiter.
+  - Re-ran `make format`, `make test`, `make lint`, and `make ci`.
 
 
 ## Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Removed runtime `GIX_*`, `api_key_env`, LLM `base_url`, working-directory config, `.yaml`, and embedded-default fallbacks from the configuration contract.
 
 ### Bug Fixes 🐛
+- Escaped literal delimiters in terminal audit-table cells and aligned Unicode names by their terminal display width.
 - Made strict-sync AI merge resolution visible and bounded: gix now reports conflict, resolution, validation, and recovery phases; applies `timeout_seconds` to the complete operation; and gives an exact manual handoff without pushing when a result is rejected, cancelled, or timed out.
 - Pruned stale linked-worktree metadata before `gix sync` retries branch adoption, so a missing temporary worktree no longer causes a `chdir` failure.
 - Switched worktree inspection to NUL-delimited porcelain status so `gix sync` passes literal filenames containing spaces to Git instead of treating display quotes as path bytes.
@@ -32,6 +33,7 @@
 - Kept the syncflow builder description as the canonical text shown by `gix sync --help`.
 
 ### Testing 🧪
+- Added a public CLI regression for audit-table delimiter escaping and wide-character alignment.
 - Added public CLI coverage for default table output, explicit CSV and HTML exports, and rejected audit report formats.
 - Added black-box coverage for configuration discovery, initialization prompts, process-only interpolation, ignored sibling `.env` files, literal credentials, missing placeholders, strict operation schemas, and LLM profile routing.
 - Added public CLI coverage for LLM connection priority, successful OpenAI-to-llm-proxy failover, stop-after-success behavior, obsolete schema rejection, and profile validation.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-viper/mapstructure/v2 v2.4.0
+	github.com/mattn/go-runewidth v0.0.27
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -22,6 +23,7 @@ require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/chromedp/chromedp v0.14.2 h1:r3b/WtwM50RsBZHMUm9fsNhhzRStTHrKdr2zmwbZ
 github.com/chromedp/chromedp v0.14.2/go.mod h1:rHzAv60xDE7VNy/MYtTUrYreSc0ujt2O1/C3bzctYBo=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -62,6 +64,8 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=
+github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -6,7 +6,8 @@ import (
 	"html"
 	"io"
 	"strings"
-	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
 )
 
 const (
@@ -15,6 +16,14 @@ const (
 	auditHTMLDocumentTitleSuffixConstant   = "</title>\n<style>body{font-family:system-ui,sans-serif;margin:2rem}table{border-collapse:collapse}th,td{border:1px solid #999;padding:.4rem;text-align:left;vertical-align:top;white-space:pre-wrap}th{background:#f3f3f3}</style>\n</head>\n<body>\n<h1>"
 	auditHTMLDocumentHeadingSuffixConstant = "</h1>\n<table>\n<thead>\n<tr>"
 	auditHTMLDocumentCloseConstant         = "\n</tbody>\n</table>\n</body>\n</html>\n"
+)
+
+var auditTableValueReplacer = strings.NewReplacer(
+	"\r\n", "\\n",
+	"\n", "\\n",
+	"\r", "\\r",
+	"\t", "\\t",
+	"|", "\\|",
 )
 
 // WriteReport serializes repository inspections in the requested report format.
@@ -152,7 +161,7 @@ func auditReportDisplayHeaders() []string {
 func normalizeTableRecord(record []string) []string {
 	normalized := make([]string, len(record))
 	for valueIndex := range record {
-		normalized[valueIndex] = strings.NewReplacer("\r\n", "\\n", "\n", "\\n", "\r", "\\r", "\t", "\\t").Replace(record[valueIndex])
+		normalized[valueIndex] = auditTableValueReplacer.Replace(record[valueIndex])
 	}
 	return normalized
 }
@@ -160,17 +169,21 @@ func normalizeTableRecord(record []string) []string {
 func auditTableColumnWidths(header []string, rows [][]string) []int {
 	widths := make([]int, len(header))
 	for columnIndex := range header {
-		widths[columnIndex] = utf8.RuneCountInString(header[columnIndex])
+		widths[columnIndex] = auditTableDisplayWidth(header[columnIndex])
 	}
 	for rowIndex := range rows {
 		for columnIndex := range rows[rowIndex] {
-			width := utf8.RuneCountInString(rows[rowIndex][columnIndex])
+			width := auditTableDisplayWidth(rows[rowIndex][columnIndex])
 			if width > widths[columnIndex] {
 				widths[columnIndex] = width
 			}
 		}
 	}
 	return widths
+}
+
+func auditTableDisplayWidth(value string) int {
+	return runewidth.StringWidth(value)
 }
 
 func auditTableBorder(widths []int) string {
@@ -189,7 +202,7 @@ func writeAuditTableRow(writer io.Writer, values []string, widths []int) error {
 	for valueIndex := range values {
 		line.WriteByte(' ')
 		line.WriteString(values[valueIndex])
-		line.WriteString(strings.Repeat(" ", widths[valueIndex]-utf8.RuneCountInString(values[valueIndex])+1))
+		line.WriteString(strings.Repeat(" ", widths[valueIndex]-auditTableDisplayWidth(values[valueIndex])+1))
 		line.WriteByte('|')
 	}
 	_, writeError := fmt.Fprintln(writer, line.String())

--- a/tests/audit_integration_test.go
+++ b/tests/audit_integration_test.go
@@ -13,37 +13,41 @@ import (
 )
 
 const (
-	auditIntegrationTimeout                    = 10 * time.Second
-	auditIntegrationLogLevelFlag               = "--log-level"
-	auditIntegrationErrorLevel                 = "error"
-	auditIntegrationDebugLevel                 = "debug"
-	auditIntegrationRunSubcommand              = "run"
-	auditIntegrationModulePathConstant         = "."
-	auditIntegrationAuditCommandName           = "audit"
-	auditIntegrationRootFlag                   = "--roots"
-	auditIntegrationIncludeAllFlag             = "--all"
-	auditIntegrationFormatFlag                 = "--format"
-	auditIntegrationGitExecutable              = "git"
-	auditIntegrationInitFlag                   = "init"
-	auditIntegrationInitialBranchFlag          = "--initial-branch=main"
-	auditIntegrationRemoteSubcommand           = "remote"
-	auditIntegrationAddSubcommand              = "add"
-	auditIntegrationOriginRemoteName           = "origin"
-	auditIntegrationOriginURL                  = "git@github.com:origin/example.git"
-	auditIntegrationStubExecutableName         = "gh"
-	auditIntegrationStubScript                 = "#!/bin/sh\nif [ \"$1\" = \"repo\" ] && [ \"$2\" = \"view\" ]; then\n  cat <<'EOF'\n{\"nameWithOwner\":\"canonical/example\",\"defaultBranchRef\":{\"name\":\"main\"},\"description\":\"\"}\nEOF\n  exit 0\nfi\nexit 0\n"
-	auditIntegrationRepositoryPrefixConstant   = "audit-integration-repository-"
-	auditIntegrationHomeShortcutPrefixConstant = "~/"
-	auditIntegrationCSVHeaderConstant          = "folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
-	auditIntegrationCSVRowTemplate             = "%[1]s,canonical/example,configured,no,main,,n/a,ssh,no,no,\n"
-	auditIntegrationCSVTemplate                = auditIntegrationCSVHeaderConstant + auditIntegrationCSVRowTemplate
-	auditIntegrationTableCaseNameConstant      = "audit_table_default"
-	auditIntegrationCSVCaseNameConstant        = "audit_csv_export"
-	auditIntegrationHTMLCaseNameConstant       = "audit_html_export"
-	auditIntegrationDebugCaseNameConstant      = "audit_debug"
-	auditIntegrationTildeCaseNameConstant      = "audit_tilde"
-	auditIntegrationIncludeAllCaseNameConstant = "audit_include_all"
-	auditIntegrationSubtestNameTemplate        = "%d_%s"
+	auditIntegrationTimeout                       = 10 * time.Second
+	auditIntegrationLogLevelFlag                  = "--log-level"
+	auditIntegrationErrorLevel                    = "error"
+	auditIntegrationDebugLevel                    = "debug"
+	auditIntegrationRunSubcommand                 = "run"
+	auditIntegrationModulePathConstant            = "."
+	auditIntegrationAuditCommandName              = "audit"
+	auditIntegrationRootFlag                      = "--roots"
+	auditIntegrationIncludeAllFlag                = "--all"
+	auditIntegrationFormatFlag                    = "--format"
+	auditIntegrationGitExecutable                 = "git"
+	auditIntegrationInitFlag                      = "init"
+	auditIntegrationInitialBranchFlag             = "--initial-branch=main"
+	auditIntegrationRemoteSubcommand              = "remote"
+	auditIntegrationAddSubcommand                 = "add"
+	auditIntegrationOriginRemoteName              = "origin"
+	auditIntegrationOriginURL                     = "git@github.com:origin/example.git"
+	auditIntegrationStubExecutableName            = "gh"
+	auditIntegrationStubScript                    = "#!/bin/sh\nif [ \"$1\" = \"repo\" ] && [ \"$2\" = \"view\" ]; then\n  cat <<'EOF'\n{\"nameWithOwner\":\"canonical/example\",\"defaultBranchRef\":{\"name\":\"main\"},\"description\":\"\"}\nEOF\n  exit 0\nfi\nexit 0\n"
+	auditIntegrationRepositoryPrefixConstant      = "audit-integration-repository-"
+	auditIntegrationHomeShortcutPrefixConstant    = "~/"
+	auditIntegrationCSVHeaderConstant             = "folder_name,final_github_repo,origin_remote_status,name_matches,remote_default_branch,local_branch,in_sync,remote_protocol,origin_matches_canonical,worktree_dirty,dirty_files\n"
+	auditIntegrationCSVRowTemplate                = "%[1]s,canonical/example,configured,no,main,,n/a,ssh,no,no,\n"
+	auditIntegrationCSVTemplate                   = auditIntegrationCSVHeaderConstant + auditIntegrationCSVRowTemplate
+	auditIntegrationTableCaseNameConstant         = "audit_table_default"
+	auditIntegrationCSVCaseNameConstant           = "audit_csv_export"
+	auditIntegrationHTMLCaseNameConstant          = "audit_html_export"
+	auditIntegrationTableEscapingCaseNameConstant = "audit_table_escapes_delimiters_and_aligns_wide_characters"
+	auditIntegrationDebugCaseNameConstant         = "audit_debug"
+	auditIntegrationTildeCaseNameConstant         = "audit_tilde"
+	auditIntegrationIncludeAllCaseNameConstant    = "audit_include_all"
+	auditIntegrationSubtestNameTemplate           = "%d_%s"
+	auditIntegrationTableFormattingFolderName     = "界界|a"
+	auditIntegrationEscapedTableFolderName        = "界界\\|a"
+	auditIntegrationTableFirstBorder              = "+---------+"
 )
 
 func TestAuditRunCommandIntegration(testInstance *testing.T) {
@@ -109,6 +113,16 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 	nestedNonGitFolderPath := filepath.Join(nonGitFolderPath, nestedNonGitFolderName)
 	require.NoError(testInstance, os.MkdirAll(nestedNonGitFolderPath, 0o755))
 
+	tableFormattingRoot := filepath.Join(tempDirectory, "table-formatting-root")
+	require.NoError(testInstance, os.Mkdir(tableFormattingRoot, 0o755))
+	tableFormattingRepositoryPath := filepath.Join(tableFormattingRoot, auditIntegrationTableFormattingFolderName)
+	tableFormattingInitCommand := exec.Command(auditIntegrationGitExecutable, auditIntegrationInitFlag, auditIntegrationInitialBranchFlag, tableFormattingRepositoryPath)
+	tableFormattingInitCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, tableFormattingInitCommand.Run())
+	tableFormattingRemoteCommand := exec.Command(auditIntegrationGitExecutable, "-C", tableFormattingRepositoryPath, auditIntegrationRemoteSubcommand, auditIntegrationAddSubcommand, auditIntegrationOriginRemoteName, auditIntegrationOriginURL)
+	tableFormattingRemoteCommand.Env = buildGitCommandEnvironment(nil)
+	require.NoError(testInstance, tableFormattingRemoteCommand.Run())
+
 	buildArguments := func(logLevel string, root string) []string {
 		return []string{
 			auditIntegrationRunSubcommand,
@@ -132,10 +146,12 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 	tildeRootArguments := buildArguments(auditIntegrationErrorLevel, tildeRootArgument)
 	includeAllArguments := append(buildArguments(auditIntegrationErrorLevel, includeAllRoot), auditIntegrationIncludeAllFlag)
 	includeAllRepositoryFolderName := filepath.Base(includeAllRepositoryPath)
+	tableFormattingArguments := buildArguments(auditIntegrationErrorLevel, tableFormattingRoot)
 
 	testCases := []struct {
 		name                string
 		arguments           []string
+		expectedPrefix      string
 		expectedOutput      string
 		expectedFragments   []string
 		unexpectedFragments []string
@@ -168,6 +184,15 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 				"<td>canonical/example</td>",
 			},
 			unexpectedFragments: []string{auditIntegrationCSVHeaderConstant},
+		},
+		{
+			name:           auditIntegrationTableEscapingCaseNameConstant,
+			arguments:      tableFormattingArguments,
+			expectedPrefix: auditIntegrationTableFirstBorder,
+			expectedFragments: []string{
+				auditIntegrationEscapedTableFolderName,
+			},
+			unexpectedFragments: []string{auditIntegrationTableFormattingFolderName, auditIntegrationCSVHeaderConstant},
 		},
 		{
 			name:      auditIntegrationDebugCaseNameConstant,
@@ -208,6 +233,9 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 			filteredOutput := filterStructuredOutput(subtestOutput)
 			if len(testCase.expectedOutput) > 0 {
 				require.Equal(subtest, testCase.expectedOutput, filteredOutput)
+			}
+			if len(testCase.expectedPrefix) > 0 {
+				require.True(subtest, strings.HasPrefix(filteredOutput, testCase.expectedPrefix))
 			}
 			for _, fragment := range testCase.expectedFragments {
 				require.Contains(subtest, filteredOutput, fragment)


### PR DESCRIPTION
### Bug Fixes

- Escaped literal table-cell delimiters (such as "|") and made table rendering use terminal display-cell widths to correctly align wide Unicode characters, particularly in the audit CLI report.
- Now, repository and file names containing wide Unicode characters or table delimiters are properly aligned and do not break table formatting.

### Testing

- Added a regression test that creates a repository with a name containing both wide Unicode characters and a "|" delimiter to verify correct cell escaping and alignment.
- Updated integration tests to check for proper escaping and alignment in table outputs.

### Dependency Updates

- Added `go-runewidth` (for measuring terminal cell width of Unicode strings) and `uax29` to dependencies.

### Documentation

- Updated changelog and issue tracker to document the corner case addressed and coverage added.