### PR TITLE
fix(sync): remove adopted worktrees with read-only caches

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -72,6 +72,20 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   Resolution:
   Workflow LLM configuration now rejects fractional `timeout_seconds` before constructing a client, while omitted and zero values retain the default-timeout path. Regression coverage verifies both sub-second and larger fractional values. `make format`, `make test`, `make lint`, and `make ci` passed on 2026-07-25.
 
+- [x] [B035] (P1) Remove adopted sibling worktrees with read-only generated caches.
+  Found on 2026-07-27 while `gix sync tyemirov/B096-sqlite-execution-engine` adopted a linked B096 worktree.
+  Observation:
+  Git can deregister a linked worktree and then fail to delete it when an ignored generated directory, such as Go's read-only module cache, lacks owner write permission. The partial removal leaves an orphaned directory and blocks the requested sync.
+  Requirements:
+  - Before Gix removes its validated non-main sibling worktree, restore owner write and execute permission on directories under that exact worktree only.
+  - Do not follow symlinks, alter file permissions, use `sudo`, or widen cleanup beyond the worktree Gix already selected for adoption.
+  - Preserve contextual failure errors if the filesystem still prevents removal.
+  Validation:
+  - Add public CLI coverage that adopts a sibling worktree containing a read-only ignored cache and verifies complete removal and successful switch.
+  - Run `make format`, `make test`, `make lint`, `make ci`, and `git diff --check`.
+  Resolution:
+  Gix now prepares the validated non-main sibling worktree with a non-symlink directory walk that adds only owner write and execute bits before `git worktree remove`; files and symlink targets remain untouched. The public CLI regression creates a read-only ignored Go-style cache, confirms full sibling removal, and confirms the requested branch becomes active. `make format`, `make test`, `make lint`, `make ci`, and `git diff --check` passed on 2026-07-27.
+
 ## Maintenance
 
 - [ ] [M001R] (P2) Backlog hygiene and archive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Updated the LLM Proxy Go client from v0.2.21 to v0.2.46, moved Gix's configured proxy work budget to the current per-request timeout header, and raised the Go module floor to 1.25.12 with the dependency graph required by that client.
 
 ### Bug Fixes 🐛
+- Made linked-worktree adoption restore owner write and execute permission on its directories before removal, preventing read-only ignored caches such as Go's module cache from leaving orphaned worktrees.
 - Rejected fractional workflow LLM `timeout_seconds` before they can be truncated into shorter or invalid LLM Proxy request budgets.
 - Made `gix audit` fit its terminal table to the active width, using bounded field/value rows on narrow terminals and Unicode-aware ellipses for constrained cells.
 - Escaped literal delimiters in terminal audit-table cells and aligned Unicode names by their terminal display width.
@@ -41,6 +42,7 @@
 - Kept the syncflow builder description as the canonical text shown by `gix sync --help`.
 
 ### Testing 🧪
+- Added public CLI coverage for adopting a sibling worktree containing a read-only ignored cache.
 - Added public CLI coverage for compact and truncated horizontal audit tables at constrained terminal widths.
 - Added a public CLI regression for audit-table delimiter escaping and wide-character alignment.
 - Added public CLI coverage for default table output, explicit CSV and HTML exports, and rejected audit report formats.

--- a/internal/branches/syncflow/task_action_test.go
+++ b/internal/branches/syncflow/task_action_test.go
@@ -1189,9 +1189,11 @@ func TestHandleBranchSyncActionStrictPRBranchTreatsIgnoredOnlyStatusAsClean(t *t
 }
 
 func TestHandleBranchSyncActionStrictPRBranchAdoptsDirtySiblingWorktree(t *testing.T) {
+	blockedWorktree := filepath.Join(t.TempDir(), "project-feature")
+	require.NoError(t, os.MkdirAll(blockedWorktree, 0o755))
 	gitExecutor := &strictSyncGitExecutor{
 		blockedBranch:   "feature/foo",
-		blockedWorktree: "/tmp/project-feature",
+		blockedWorktree: blockedWorktree,
 	}
 	gitManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
 	require.NoError(t, managerError)
@@ -1233,11 +1235,12 @@ func TestHandleBranchSyncActionStrictPRBranchAdoptsDirtySiblingWorktree(t *testi
 	require.Contains(t, recordedCommands, "add --all")
 	require.Contains(t, recordedCommands, "commit -m fix: adopt sibling worktree")
 	require.Contains(t, recordedCommands, "push --set-upstream origin feature/foo")
-	require.Contains(t, recordedCommands, "worktree remove /tmp/project-feature")
+	worktreeRemoveCommand := "worktree remove " + blockedWorktree
+	require.Contains(t, recordedCommands, worktreeRemoveCommand)
 	require.Contains(t, recordedCommands, "worktree prune")
 	require.Contains(t, recordedCommands, "merge --no-edit origin/master")
 	require.Contains(t, recordedCommands, "push origin feature/foo")
-	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "worktree remove /tmp/project-feature"), recordedGitCommandLastIndex(gitExecutor.commands, "switch feature/foo"))
+	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, worktreeRemoveCommand), recordedGitCommandLastIndex(gitExecutor.commands, "switch feature/foo"))
 	require.GreaterOrEqual(t, recordedGitCommandCount(gitExecutor.commands, "fetch --prune origin"), 2)
 	require.Less(t, recordedGitCommandIndex(gitExecutor.commands, "worktree prune"), recordedGitCommandLastIndex(gitExecutor.commands, "fetch --prune origin"))
 	require.Less(t, recordedGitCommandLastIndex(gitExecutor.commands, "fetch --prune origin"), recordedGitCommandLastIndex(gitExecutor.commands, "switch feature/foo"))

--- a/internal/branches/syncflow/worktree_adoption.go
+++ b/internal/branches/syncflow/worktree_adoption.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,6 +62,13 @@ const (
 	worktreeAdoptDetachMessage               = "detached sibling main worktree"
 	worktreeAdoptPruneMessage                = "pruned worktree metadata"
 	worktreeAdoptPruneStaleMessage           = "pruned stale worktree metadata"
+)
+
+const (
+	worktreeDirectoryOwnerWriteExecute         = 0o300
+	worktreeRemovalPreparationFailureTemplate  = "failed to prepare sibling worktree %s for removal: %w"
+	worktreeDirectoryInspectionFailureTemplate = "failed to inspect sibling worktree directory %s before removal: %w"
+	worktreeDirectoryPermissionFailureTemplate = "failed to restore owner write and execute permission on sibling worktree directory %s: %w"
 )
 
 type worktreeAdoptionOptions struct {
@@ -361,6 +369,10 @@ func (service worktreeAdoptionService) adoptSiblingWorktree(ctx context.Context,
 		return nil
 	}
 
+	if preparationErr := prepareSiblingWorktreeForRemoval(worktree.Path); preparationErr != nil {
+		return fmt.Errorf(worktreeRemovalPreparationFailureTemplate, worktree.Path, preparationErr)
+	}
+
 	if removeErr := executeGit(ctx, service.environment.GitExecutor, service.repository.Path, []string{gitWorktreeSubcommandConstant, gitWorktreeRemoveSubcommandConstant, worktree.Path}); removeErr != nil {
 		return fmt.Errorf(worktreeRemoveFailureTemplate, worktree.Path, removeErr)
 	}
@@ -384,6 +396,33 @@ func (service worktreeAdoptionService) adoptSiblingWorktree(ctx context.Context,
 	)
 
 	return nil
+}
+
+func prepareSiblingWorktreeForRemoval(worktreePath string) error {
+	return filepath.WalkDir(worktreePath, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf(worktreeDirectoryInspectionFailureTemplate, path, walkErr)
+		}
+		// WalkDir does not follow symlinks; leave them untouched so preparation
+		// cannot change permissions outside the sibling worktree.
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			return nil
+		}
+
+		directoryInfo, infoErr := entry.Info()
+		if infoErr != nil {
+			return fmt.Errorf(worktreeDirectoryInspectionFailureTemplate, path, infoErr)
+		}
+		currentPermissions := directoryInfo.Mode().Perm()
+		desiredPermissions := currentPermissions | worktreeDirectoryOwnerWriteExecute
+		if desiredPermissions == currentPermissions {
+			return nil
+		}
+		if chmodErr := os.Chmod(path, desiredPermissions); chmodErr != nil {
+			return fmt.Errorf(worktreeDirectoryPermissionFailureTemplate, path, chmodErr)
+		}
+		return nil
+	})
 }
 
 func isMainWorktreePath(worktreePath string) (bool, error) {

--- a/internal/branches/syncflow/worktree_adoption_test.go
+++ b/internal/branches/syncflow/worktree_adoption_test.go
@@ -1,0 +1,46 @@
+package syncflow
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareSiblingWorktreeForRemovalOnlyChangesDirectoriesInsideWorktree(testInstance *testing.T) {
+	if runtime.GOOS == "windows" {
+		testInstance.Skip("read-only directory permissions require Unix semantics")
+	}
+
+	worktreePath := testInstance.TempDir()
+	cacheDirectory := filepath.Join(worktreePath, ".cache", "go", "pkg", "mod", "read-only-module")
+	require.NoError(testInstance, os.MkdirAll(cacheDirectory, 0o755))
+	cacheFile := filepath.Join(cacheDirectory, "cached-file")
+	require.NoError(testInstance, os.WriteFile(cacheFile, []byte("cache\n"), 0o644))
+	require.NoError(testInstance, os.Chmod(cacheFile, 0o444))
+	require.NoError(testInstance, os.Chmod(cacheDirectory, 0o555))
+	testInstance.Cleanup(func() {
+		_ = os.Chmod(cacheDirectory, 0o755)
+	})
+
+	externalDirectory := testInstance.TempDir()
+	require.NoError(testInstance, os.Chmod(externalDirectory, 0o555))
+	testInstance.Cleanup(func() {
+		_ = os.Chmod(externalDirectory, 0o755)
+	})
+	require.NoError(testInstance, os.Symlink(externalDirectory, filepath.Join(worktreePath, "external-cache")))
+
+	require.NoError(testInstance, prepareSiblingWorktreeForRemoval(worktreePath))
+
+	cacheDirectoryInfo, cacheDirectoryInfoErr := os.Stat(cacheDirectory)
+	require.NoError(testInstance, cacheDirectoryInfoErr)
+	require.Equal(testInstance, os.FileMode(0o300), cacheDirectoryInfo.Mode().Perm()&0o300)
+	cacheFileInfo, cacheFileInfoErr := os.Stat(cacheFile)
+	require.NoError(testInstance, cacheFileInfoErr)
+	require.Equal(testInstance, os.FileMode(0o444), cacheFileInfo.Mode().Perm())
+	externalDirectoryInfo, externalDirectoryInfoErr := os.Stat(externalDirectory)
+	require.NoError(testInstance, externalDirectoryInfoErr)
+	require.Equal(testInstance, os.FileMode(0o555), externalDirectoryInfo.Mode().Perm())
+}

--- a/tests/sync_worktree_adoption_integration_test.go
+++ b/tests/sync_worktree_adoption_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -115,6 +116,65 @@ func TestSyncExplicitMasterPrunesStaleLinkedWorktreeBeforeSwitch(testInstance *t
 	require.Contains(testInstance, output, fmt.Sprintf("SYNCED: %s (master)", repositoryPath))
 	require.Equal(testInstance, "master", strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
 	require.NotContains(testInstance, runGit(testInstance, repositoryPath, "worktree", "list", "--porcelain"), "worktree "+canonicalSiblingPath)
+}
+
+func TestSyncAdoptsSiblingWorktreeWithReadOnlyIgnoredCache(testInstance *testing.T) {
+	if runtime.GOOS == "windows" {
+		testInstance.Skip("read-only directory removal requires Unix permission semantics")
+	}
+
+	repositoryRoot := integrationRepositoryRoot(testInstance)
+	workspacePath := syncHomeWorkspace(testInstance)
+	remotePath := filepath.Join(workspacePath, "remote.git")
+	repositoryPath := filepath.Join(workspacePath, "project")
+	siblingPath := filepath.Join(workspacePath, "project-read-only-cache")
+	branchName := "feature/read-only-cache"
+	createSyncGitHubBackedRepository(testInstance, remotePath, repositoryPath)
+
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("initial\n"), 0o644))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, ".gitignore"), []byte(".cache/\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "README.md", ".gitignore")
+	runGit(testInstance, repositoryPath, "commit", "-m", "initial commit")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", "master")
+
+	runGit(testInstance, repositoryPath, "switch", "-c", branchName)
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "feature.txt"), []byte("feature work\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", "feature.txt")
+	runGit(testInstance, repositoryPath, "commit", "-m", "feature work")
+	runGit(testInstance, repositoryPath, "push", "-u", "origin", branchName)
+	runGit(testInstance, repositoryPath, "switch", "master")
+	runGit(testInstance, repositoryPath, "worktree", "add", siblingPath, branchName)
+
+	cacheDirectory := filepath.Join(siblingPath, ".cache", "go", "pkg", "mod", "read-only-module")
+	require.NoError(testInstance, os.MkdirAll(cacheDirectory, 0o755))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(cacheDirectory, "cached-file"), []byte("cache\n"), 0o444))
+	testInstance.Cleanup(func() {
+		_ = os.Chmod(cacheDirectory, 0o755)
+	})
+	require.NoError(testInstance, os.Chmod(cacheDirectory, 0o555))
+	require.Empty(testInstance, strings.TrimSpace(runGit(testInstance, siblingPath, "status", "--porcelain")))
+
+	configurationPath := writeSyncMergedBranchConfiguration(testInstance)
+	githubLogPath := filepath.Join(testInstance.TempDir(), "gh.log")
+	pathVariable := buildSyncMergedBranchExecutablePath(testInstance)
+	output := runIntegrationCommand(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{
+			PathVariable: pathVariable,
+			EnvironmentOverrides: map[string]string{
+				syncMergedBranchGitHubLogVariable: githubLogPath,
+				syncMergedBranchMergedVariable:    "false",
+				syncMergedBranchNameVariable:      branchName,
+			},
+		},
+		syncWorktreeAdoptionTimeout,
+		[]string{"run", ".", "--config", configurationPath, "--log-level", "error", "sync", branchName, "--body", "Adopt the read-only cache worktree.", "--roots", repositoryPath},
+	)
+	require.Contains(testInstance, output, fmt.Sprintf("SYNCED: %s (%s)", repositoryPath, branchName))
+	require.NoDirExists(testInstance, siblingPath)
+	require.NotContains(testInstance, runGit(testInstance, repositoryPath, "worktree", "list", "--porcelain"), "worktree "+siblingPath)
+	require.Equal(testInstance, branchName, strings.TrimSpace(runGit(testInstance, repositoryPath, "branch", "--show-current")))
 }
 
 func createSyncWorktreeAdoptionFixture(testInstance *testing.T) syncWorktreeAdoptionFixture {


### PR DESCRIPTION
## Summary

Fix linked-worktree adoption when an ignored generated cache contains read-only directories, such as Go module-cache content.

- restore owner write and execute permissions only on directories inside the validated sibling worktree before Git removes it
- leave files and symlink targets untouched
- add a real CLI regression plus a focused safety guardrail

## Validation

- `make format`
- `make test`
- `make lint`
- `make ci`
- `git diff --check`