### PR TITLE
Isolate release CI from outer release intent

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -414,6 +414,20 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   A checkout without local version tags reported `scheme_guess: none`, bypassed the new missing-intent guard, and still selected `v1.0.0` before running CI.
   Follow-up resolution:
   Release selection now normalizes the untagged default to the initial SemVer contract unless CalVer is explicitly requested. A public release-script regression proves that bare preparation stops before CI and preserves the canonical receipt, while an explicit patch intent selects `v1.0.0` with a SemVer scheme. Focused release tests, `bash -n scripts/release/prepare_release.sh`, `make format`, `make ci`, `make build`, and `git diff --check` passed on 2026-08-08.
+- [x] [B056] (P0) Isolate release intent from the release CI subprocess.
+  Found on 2026-08-08 while preparing the exact v5.0.1 release.
+  Goal:
+  Keep the selected release intent owned by the outer release transaction while running the canonical CI gate in a clean Make environment.
+  Requirements:
+  - Remove release-control and recursive-Make variables only from the `make ci` subprocess environment.
+  - Preserve the already selected exact version, changelog boundary, artifact preparation inputs, rollback, and receipt contracts in the outer transaction.
+  - Do not weaken or skip any CI test to make release preparation pass.
+  Validation:
+  - A public release-script regression proves exact-version and Make override values are absent inside the CI subprocess.
+  - The failed v5.0.1 attempt leaves master, the v5.0.1 tag, and the canonical v1.1.25 receipt unchanged.
+  - Run focused release tests, `bash -n scripts/release/prepare_release.sh`, `make format`, `make ci`, `make build`, and `git diff --check`.
+  Resolution:
+  Release preparation now removes release-control and recursive-Make variables only around its `make ci` subprocess, while retaining the selected version and artifact inputs in the outer transaction. The public regression seeds every affected variable and proves the CI subprocess receives none of them. The failed v5.0.1 attempt left master, the tag namespace, and the canonical v1.1.25 receipt unchanged. Focused release coverage, shell syntax validation, `make format`, `make ci`, `make build`, `go mod verify`, `go mod tidy -diff`, and `git diff --check` passed on 2026-08-08.
 
 
 

--- a/scripts/release/prepare_release.sh
+++ b/scripts/release/prepare_release.sh
@@ -298,7 +298,12 @@ if [[ "${dry_run}" == "true" ]]; then
 fi
 
 echo "==> [release] Running make ci"
-timeout -k "${ci_timeout}s" -s SIGKILL "${ci_timeout}s" make ci
+(
+  unset MAKEFLAGS MAKELEVEL MAKEOVERRIDES MFLAGS
+  unset PAGES_DEPLOY_ARGS PAGES_VERSION PUBLISH_RELEASE_ARGS
+  unset RELEASE_ARGS RELEASE_ARTIFACT_TARGETS RELEASE_BUMP RELEASE_CI_TIMEOUT RELEASE_HELPER RELEASE_SCHEME RELEASE_VERSION
+  timeout -k "${ci_timeout}s" -s SIGKILL "${ci_timeout}s" make ci
+)
 
 echo "==> [release] Rechecking local state after CI"
 run_local_preflight

--- a/tests/release_makefile_integration_test.go
+++ b/tests/release_makefile_integration_test.go
@@ -29,6 +29,7 @@ const (
 	releaseFakePublishedDirectoryVariable = "GIX_RELEASE_FAKE_PUBLISHED_DIRECTORY"
 	releaseFakeReleaseViewVariable        = "GIX_RELEASE_FAKE_RELEASE_VIEW"
 	releaseFakeMakeLogVariable            = "GIX_RELEASE_FAKE_MAKE_LOG"
+	releaseFakeMakeEnvironmentLogVariable = "GIX_RELEASE_FAKE_MAKE_ENV_LOG"
 	releaseFakeMakeFailureTargetVariable  = "GIX_RELEASE_FAKE_MAKE_FAILURE_TARGET"
 	releaseFakeMakeUnsafePayloadVariable  = "GIX_RELEASE_FAKE_MAKE_UNSAFE_PAYLOAD"
 	releaseFakePagesBuildCounterVariable  = "GIX_RELEASE_FAKE_PAGES_BUILD_COUNTER"
@@ -460,6 +461,63 @@ func TestReleaseNewSemVerSelectsExplicitIntent(testInstance *testing.T) {
 			require.Contains(t, outputText, "changelog_boundary="+releaseFixtureVersion)
 		})
 	}
+}
+
+func TestReleaseCIReceivesNoOuterReleaseOrMakeIntent(testInstance *testing.T) {
+	fixture := newExactReleaseFixture(testInstance)
+	fixture.commitNextSource(testInstance)
+	environmentLogPath := filepath.Join(testInstance.TempDir(), "make-environment.log")
+	pathVariable := buildReleaseStubbedExecutablePath(testInstance, map[string]string{"make": releaseFakeMakeScript})
+
+	outputText, runError := runReleasePrepareReleaseScript(
+		testInstance,
+		fixture.repositoryRoot,
+		fixture.repositoryPath,
+		integrationCommandOptions{
+			PathVariable: pathVariable,
+			EnvironmentOverrides: map[string]string{
+				"MAKEFLAGS":                           "-- RELEASE_BUMP=major RELEASE_VERSION=v99.0.0",
+				"MAKELEVEL":                           "7",
+				"MAKEOVERRIDES":                       "RELEASE_BUMP RELEASE_VERSION",
+				"MFLAGS":                              "--silent",
+				"PAGES_DEPLOY_ARGS":                   "--fixture-pages-argument",
+				"PAGES_VERSION":                       "v88.0.0",
+				"PUBLISH_RELEASE_ARGS":                "--fixture-publish-argument",
+				"RELEASE_ARGS":                        "--fixture-release-argument",
+				"RELEASE_ARTIFACT_TARGETS":            "fixture-artifact",
+				"RELEASE_BUMP":                        "",
+				"RELEASE_CI_TIMEOUT":                  "30",
+				"RELEASE_HELPER":                      filepath.Join(fixture.repositoryRoot, releaseToolDirectoryRelativePath, "release_helper.py"),
+				"RELEASE_SCHEME":                      "semver",
+				"RELEASE_VERSION":                     "v12.3.4",
+				releaseFakeMakeEnvironmentLogVariable: environmentLogPath,
+				releaseFakeMakeFailureTargetVariable:  "ci",
+			},
+		},
+	)
+
+	require.Error(testInstance, runError, outputText)
+	require.Contains(testInstance, outputText, "fixture artifact failure: ci")
+	environmentLog, readError := os.ReadFile(environmentLogPath)
+	require.NoError(testInstance, readError)
+	require.Equal(
+		testInstance,
+		"MAKEFLAGS=<unset>\n"+
+			"MAKELEVEL=<unset>\n"+
+			"MAKEOVERRIDES=<unset>\n"+
+			"MFLAGS=<unset>\n"+
+			"PAGES_DEPLOY_ARGS=<unset>\n"+
+			"PAGES_VERSION=<unset>\n"+
+			"PUBLISH_RELEASE_ARGS=<unset>\n"+
+			"RELEASE_ARGS=<unset>\n"+
+			"RELEASE_ARTIFACT_TARGETS=<unset>\n"+
+			"RELEASE_BUMP=<unset>\n"+
+			"RELEASE_CI_TIMEOUT=<unset>\n"+
+			"RELEASE_HELPER=<unset>\n"+
+			"RELEASE_SCHEME=<unset>\n"+
+			"RELEASE_VERSION=<unset>\n",
+		string(environmentLog),
+	)
 }
 
 func TestReleaseRejectsConflictingVersionIntent(testInstance *testing.T) {
@@ -1352,6 +1410,24 @@ set -euo pipefail
 target="${1:-}"
 if [[ "${target}" == "--no-print-directory" ]]; then
   target="${2:-}"
+fi
+if [[ -n "${GIX_RELEASE_FAKE_MAKE_ENV_LOG:-}" ]]; then
+  {
+    printf 'MAKEFLAGS=%s\n' "${MAKEFLAGS-<unset>}"
+    printf 'MAKELEVEL=%s\n' "${MAKELEVEL-<unset>}"
+    printf 'MAKEOVERRIDES=%s\n' "${MAKEOVERRIDES-<unset>}"
+    printf 'MFLAGS=%s\n' "${MFLAGS-<unset>}"
+    printf 'PAGES_DEPLOY_ARGS=%s\n' "${PAGES_DEPLOY_ARGS-<unset>}"
+    printf 'PAGES_VERSION=%s\n' "${PAGES_VERSION-<unset>}"
+    printf 'PUBLISH_RELEASE_ARGS=%s\n' "${PUBLISH_RELEASE_ARGS-<unset>}"
+    printf 'RELEASE_ARGS=%s\n' "${RELEASE_ARGS-<unset>}"
+    printf 'RELEASE_ARTIFACT_TARGETS=%s\n' "${RELEASE_ARTIFACT_TARGETS-<unset>}"
+    printf 'RELEASE_BUMP=%s\n' "${RELEASE_BUMP-<unset>}"
+    printf 'RELEASE_CI_TIMEOUT=%s\n' "${RELEASE_CI_TIMEOUT-<unset>}"
+    printf 'RELEASE_HELPER=%s\n' "${RELEASE_HELPER-<unset>}"
+    printf 'RELEASE_SCHEME=%s\n' "${RELEASE_SCHEME-<unset>}"
+    printf 'RELEASE_VERSION=%s\n' "${RELEASE_VERSION-<unset>}"
+  } >"${GIX_RELEASE_FAKE_MAKE_ENV_LOG}"
 fi
 if [[ "${target}" == "${GIX_RELEASE_FAKE_MAKE_FAILURE_TARGET:-}" ]]; then
   if [[ -n "${GIX_RELEASE_FAKE_MAKE_LOG:-}" ]]; then


### PR DESCRIPTION
Summary:
- clear release-control and recursive-Make variables only inside the release CI subprocess
- preserve the selected version and artifact inputs in the outer release transaction
- add a regression that seeds every affected variable and proves CI receives none

Reproduction:
- make release RELEASE_VERSION=v5.0.1 previously leaked that exact version through MAKEFLAGS into release integration fixtures
- preparation stopped in CI before creating a release commit or tag

Validation:
- focused release regression and complete release test suite
- bash syntax validation
- make format
- make ci
- make build
- go mod verify
- go mod tidy -diff
- git diff --check