### PR TITLE
fix(audit): preserve nested checkout folder identity

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -511,6 +511,24 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   Major and minor results must name the exact supported public contract.
   Regression coverage includes internal feature labels, breaking markers, and the repaired root Go installation route.
   Focused tests, `make ci`, Governor checks, changed-line language review, and `git diff --check` passed on 2026-08-09.
+- [x] [B061] (P1) Distinguish detached linked checkouts in audit reports.
+  Reported on 2026-08-10.
+  Observation:
+  - The primary `llm-proxy` checkout is on `master`.
+  - The registered `.codex-deps/llm-proxy` checkout is detached.
+  - The audit labels both checkouts as `llm-proxy`, so the detached row appears to describe the primary checkout.
+  Requirements:
+  - Keep a parent audit root when it contains discovered repository paths.
+  - Use the relative checkout path to identify each nested linked checkout.
+  - Preserve current paths for repositories that moved outside their original roots.
+  - Report the actual branch state for each checkout.
+  Validation:
+  - Add compiled CLI coverage for an attached primary checkout and a detached nested linked checkout with the same folder name.
+  - Run focused tests, `make ci`, and `git diff --check`.
+  Resolution:
+  Audit now compares relative and absolute roots through canonical paths. It keeps the containing parent and removes redundant nested repository roots.
+  The nested checkout retains `.codex-deps/llm-proxy`, while the primary checkout retains `llm-proxy`.
+  Focused tests, `make build`, `make ci`, the live fleet audit, and `git diff --check` passed on 2026-08-10.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Updated the LLM Proxy Go client from v0.2.21 to v0.2.46, moved Gix's configured proxy work budget to the current per-request timeout header, and raised the Go module floor to 1.25.12 with the dependency graph required by that client.
 
 ### Bug Fixes 🐛
+- Preserved containing audit roots, so nested linked checkouts keep relative paths and cannot share a folder label with primary checkouts.
 - Made SemVer selection depend on supported public contract effects instead of commit labels or internal implementation changes.
 - Made each Gix release use one version in its decision, tag, receipt, manifest, binary, and GitHub Release.
 - Retracted the superseded root-module versions through `v1.1.26` and excluded other major tags from the Gix release boundary.
@@ -73,6 +74,7 @@
 - Kept the syncflow builder description as the canonical text shown by `gix sync --help`.
 
 ### Testing 🧪
+- Added compiled CLI coverage for an attached primary checkout and a detached nested linked checkout with the same folder name.
 - Added compiled root-module installation coverage for the single authoritative Gix version.
 - Added public release coverage for standard SemVer, the Gix fixed-major boundary, one-tag sealed receipts, rollback, publication, and remote tag verification.
 - Added public Make and release-script coverage for zero-argument lifecycle targets, autonomous patch, minor, and major SemVer decisions, fail-closed decision errors, initial SemVer, timestamp-derived CalVer, and exact-tag reuse.

--- a/internal/workflow/task_actions.go
+++ b/internal/workflow/task_actions.go
@@ -455,8 +455,17 @@ func collectAuditRoots(state *State, repository *RepositoryState) []string {
 				continue
 			}
 
+			absoluteRoot, rootError := filepath.Abs(sanitizedRoot)
+			if rootError != nil {
+				continue
+			}
+
 			for _, repositoryPath := range repositoryPaths {
-				relative, relativeError := filepath.Rel(sanitizedRoot, repositoryPath)
+				absoluteRepositoryPath, repositoryPathError := filepath.Abs(repositoryPath)
+				if repositoryPathError != nil {
+					continue
+				}
+				relative, relativeError := filepath.Rel(absoluteRoot, absoluteRepositoryPath)
 				if relativeError != nil {
 					continue
 				}
@@ -472,7 +481,7 @@ func collectAuditRoots(state *State, repository *RepositoryState) []string {
 		appendRoot(repository.Path)
 	}
 
-	return roots
+	return audit.CommandConfiguration{Roots: roots}.Sanitize().Roots
 }
 
 func handleHistoryPurgeAction(ctx context.Context, environment *Environment, repository *RepositoryState, parameters map[string]any) error {

--- a/internal/workflow/task_actions_audit_test.go
+++ b/internal/workflow/task_actions_audit_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -140,4 +141,18 @@ func TestHandleAuditReportActionFallsBackToStateRoots(testInstance *testing.T) {
 	require.NoError(testInstance, executionError)
 	require.Len(testInstance, discoverer.recordedRoots, 1)
 	require.Equal(testInstance, []string{stateRoot}, discoverer.recordedRoots[0])
+}
+
+func TestCollectAuditRootsPreservesContainingRelativeRoot(testInstance *testing.T) {
+	workingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+
+	state := &State{
+		Roots: []string{"."},
+		Repositories: []*RepositoryState{
+			{Path: filepath.Join(workingDirectory, "nested", "llm-proxy")},
+		},
+	}
+
+	require.Equal(testInstance, []string{"."}, collectAuditRoots(state, nil))
 }

--- a/tests/audit_integration_test.go
+++ b/tests/audit_integration_test.go
@@ -360,6 +360,62 @@ func TestAuditRunCommandIntegration(testInstance *testing.T) {
 	require.Contains(testInstance, filterStructuredOutput(invalidFormatOutput), "unsupported audit report format \"json\"")
 }
 
+func TestAuditDistinguishesDetachedNestedWorktreeFromPrimaryCheckout(testInstance *testing.T) {
+	workingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+	repositoryRoot := filepath.Dir(workingDirectory)
+
+	auditRoot := testInstance.TempDir()
+	primaryRepositoryPath := createGitRepository(testInstance, gitRepositoryOptions{
+		Path:          filepath.Join(auditRoot, "llm-proxy"),
+		RemoteURL:     auditIntegrationOriginURL,
+		InitialBranch: "master",
+	})
+	configureGitIdentity(testInstance, primaryRepositoryPath)
+	require.NoError(testInstance, os.WriteFile(filepath.Join(primaryRepositoryPath, "README.md"), []byte("# fixture\n"), 0o644))
+	runGit(testInstance, primaryRepositoryPath, "add", "README.md")
+	runGit(testInstance, primaryRepositoryPath, "commit", "-m", "test: initialize audit fixture")
+
+	detachedWorktreePath := filepath.Join(auditRoot, ".codex-deps", "llm-proxy")
+	runGit(testInstance, primaryRepositoryPath, "worktree", "add", "--detach", detachedWorktreePath, "HEAD")
+
+	pathWithStub := buildStubbedExecutablePath(testInstance, auditIntegrationStubExecutableName, auditIntegrationStubScript)
+	auditOutput := runIntegrationCommand(
+		testInstance,
+		repositoryRoot,
+		integrationCommandOptions{
+			PathVariable: pathWithStub,
+			EnvironmentOverrides: map[string]string{
+				auditIntegrationColumnsEnvironmentVariable: auditIntegrationDisabledColumnsWidth,
+			},
+		},
+		auditIntegrationTimeout,
+		[]string{
+			auditIntegrationRunSubcommand,
+			auditIntegrationModulePathConstant,
+			auditIntegrationLogLevelFlag,
+			auditIntegrationErrorLevel,
+			auditIntegrationAuditCommandName,
+			auditIntegrationRootFlag,
+			auditRoot,
+			auditIntegrationFormatFlag,
+			"csv",
+		},
+	)
+
+	filteredOutput := filterStructuredOutput(auditOutput)
+	require.Contains(
+		testInstance,
+		filteredOutput,
+		".codex-deps/llm-proxy,canonical/example,configured,no,main,DETACHED,n/a,ssh,no,no,",
+	)
+	require.Contains(
+		testInstance,
+		filteredOutput,
+		"llm-proxy,canonical/example,configured,no,main,master,n/a,ssh,no,no,",
+	)
+}
+
 func requireAuditTableFitsTerminal(testInstance *testing.T, table string, terminalWidth int) {
 	testInstance.Helper()
 	for _, line := range strings.Split(strings.TrimSpace(table), "\n") {


### PR DESCRIPTION
## Summary

- Preserve the containing audit root across workflow report execution.
- Keep nested linked checkouts identifiable by their root-relative paths.
- Cover attached primary and detached nested checkout rows through the compiled CLI.

## Validation

- make ci
- make build
- live source-built audit over the Development fleet
- git diff --check