### PR TITLE
bugfix/B065-keep-repair-inputs-on-patch-line

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -11,6 +11,26 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 
 ## BugFixes
 
+- [x] [B065] (P0) Keep required repair inputs on the patch line.
+  Reported on 2026-08-12 after B063 and B064 were published as `v1.5.0` instead of `v1.4.1`.
+  Expected result:
+  A compatible release repair increments the patch version under the fixed `v1` policy.
+  Actual result:
+  The model treated required CLI inputs for the repair as optional public functionality and selected a minor release.
+  Requirements:
+  - Classify a required repair input by the restored operation, not by its new interface shape.
+  - Keep optional new user functionality on the minor line.
+  - Preserve incompatible and additive public contract classification.
+  Validation:
+  - Reproduce the B063 release-input repair from `v1.4.0`.
+  - Verify `gix release next semver --fixed-major 1` selects `v1.4.1`.
+  - Run focused tests and complete CI.
+
+  Resolution:
+  - The version decision now keeps required repair inputs in the compatible repair.
+  - The compiled CLI test reproduced `v1.5.0` and now selects `v1.4.1`.
+  - `make test-slow`, `make format`, and `make ci` passed on 2026-08-12.
+
 - [x] [B064] (P1) Fetch a deleted pull request head before chain validation.
   Reported on 2026-08-11 during review of merged pull request chain handling.
   Observation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Updated the LLM Proxy Go client from v0.2.21 to v0.2.46, moved Gix's configured proxy work budget to the current per-request timeout header, and raised the Go module floor to 1.25.12 with the dependency graph required by that client.
 
 ### Bug Fixes 🐛
+- Kept required repair-only release inputs on the patch line and selected `v1.4.1` for the B063-shaped fixture.
 - Limited SemVer changelog evidence to the selected tag-to-source range, so historical Unreleased entries cannot raise a compatible fix from patch to minor.
 - Preserved containing audit roots, so nested linked checkouts keep relative paths and cannot share a folder label with primary checkouts.
 - Made SemVer selection depend on supported public contract effects instead of commit labels or internal implementation changes.

--- a/internal/semverdecision/generator.go
+++ b/internal/semverdecision/generator.go
@@ -298,6 +298,7 @@ func decisionSystemContent(audit bool, fixedMajor int) string {
 		"impact must be exactly incompatible, additive, or compatible.",
 		"Use incompatible only when a previously supported external use stops working or requires user migration.",
 		"Use additive only when the release adds optional public functionality for users or external consumers.",
+		"Treat required inputs that only enable a compatible repair as part of the repair, not as optional new functionality.",
 		"Use compatible for fixes, restored behavior, performance work, internal refactoring, tests, documentation, and release implementation changes.",
 		"A public contract includes supported CLI behavior, documented configuration, persisted user data, network protocols, and explicitly supported library APIs.",
 		"For an executable product, Go module paths, package paths, and internal imports are implementation details unless evidence proves a supported library API.",

--- a/tests/release_version_integration_test.go
+++ b/tests/release_version_integration_test.go
@@ -148,6 +148,125 @@ workflow: []
 	require.NotContains(testInstance, capturedRequests, "Added historical public feature")
 }
 
+func TestReleaseNextKeepsRequiredRepairInputsOnPatchLine(testInstance *testing.T) {
+	currentWorkingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+	repositoryRoot := filepath.Dir(currentWorkingDirectory)
+	binaryPath := buildIntegrationBinary(testInstance, repositoryRoot)
+
+	const repairClassificationRule = "Treat required inputs that only enable a compatible repair as part of the repair, not as optional new functionality."
+	var requestsMutex sync.Mutex
+	requests := make([]string, 0, 2)
+	decisionServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v2" {
+			http.NotFound(responseWriter, request)
+			return
+		}
+		requestBody, _ := io.ReadAll(request.Body)
+		requestText := string(requestBody)
+		requestsMutex.Lock()
+		requests = append(requests, requestText)
+		requestsMutex.Unlock()
+		if strings.Contains(requestText, repairClassificationRule) {
+			_, _ = responseWriter.Write([]byte(`{"impact":"compatible","public_contract":"gix release next artifact successor","reason":"The release repairs artifact successor selection."}`))
+			return
+		}
+		_, _ = responseWriter.Write([]byte(`{"impact":"additive","public_contract":"gix release next output identity flags","reason":"The release adds optional output identity flags."}`))
+	}))
+	testInstance.Cleanup(decisionServer.Close)
+
+	repositoryPath := createGitRepository(testInstance, gitRepositoryOptions{
+		DirectoryName: "release-repair-input-fixture",
+		InitialBranch: "master",
+	})
+	configureGitIdentity(testInstance, repositoryPath)
+	require.NoError(testInstance, os.MkdirAll(filepath.Join(repositoryPath, ".mprlab"), 0o755))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "release.go"), []byte("package fixture\n"), 0o644))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("The release command selects the next SemVer version.\n"), 0o644))
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, ".mprlab", "ISSUES.md"), []byte("# ISSUES\n\n## BugFixes\n"), 0o644))
+	runGit(testInstance, repositoryPath, "add", ".")
+	runGit(testInstance, repositoryPath, "commit", "-m", "fixture release baseline")
+	runGit(testInstance, repositoryPath, "tag", "v1.4.0")
+
+	repairSource := strings.Join([]string{
+		"package fixture",
+		"",
+		"var previousReleaseOutput string",
+		"var candidateReleaseOutput string",
+		"",
+	}, "\n")
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "release.go"), []byte(repairSource), 0o644))
+	repairDocumentation := strings.Join([]string{
+		"The release command selects the next SemVer version.",
+		"Artifact producers provide previous and candidate output identities for a same-commit patch successor.",
+		"",
+	}, "\n")
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte(repairDocumentation), 0o644))
+	repairIssue := strings.Join([]string{
+		"# ISSUES",
+		"",
+		"## BugFixes",
+		"",
+		"- [x] [B063] An artifact successor rejects an empty SemVer range.",
+		"  Goal:",
+		"  Select one patch successor when a release system changes sealed outputs for the same source commit.",
+		"  Requirements:",
+		"  - Accept exact previous and candidate output identities at the CLI boundary.",
+		"  - Select a patch successor without an LLM request.",
+		"",
+	}, "\n")
+	require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, ".mprlab", "ISSUES.md"), []byte(repairIssue), 0o644))
+	runGit(testInstance, repositoryPath, "add", ".")
+	runGit(testInstance, repositoryPath, "commit", "-m", "fix(release): select same-commit artifact successors")
+
+	configurationPath := filepath.Join(testInstance.TempDir(), "config.yml")
+	configurationContent := fmt.Sprintf(`common:
+  log_level: error
+  log_format: console
+github:
+  credential: ""
+llm:
+  openai:
+    priority: 2
+    model: gpt-5.6-terra
+    base_url: https://api.openai.com/v1
+    credential: ""
+  llm_proxy:
+    priority: 1
+    provider: meta
+    model: muse-spark-1.1
+    base_url: %q
+    credential: proxy-secret
+  max_completion_tokens: 1200
+  effort: high
+  timeout_seconds: 5
+operations: []
+workflow: []
+`, decisionServer.URL)
+	require.NoError(testInstance, os.WriteFile(configurationPath, []byte(configurationContent), 0o600))
+
+	outputText, runError := runBinaryIntegrationCommand(
+		testInstance,
+		binaryPath,
+		repositoryPath,
+		map[string]string{},
+		20*time.Second,
+		[]string{"--config", configurationPath, "release", "next", "semver", "--fixed-major", "1", "--format", "json"},
+	)
+
+	require.NoError(testInstance, runError, outputText)
+	require.Contains(testInstance, outputText, `"previous_version":"v1.4.0"`)
+	require.Contains(testInstance, outputText, `"next_version":"v1.4.1"`)
+	require.Contains(testInstance, outputText, `"bump":"patch"`)
+	requestsMutex.Lock()
+	capturedRequests := strings.Join(requests, "\n")
+	capturedRequestCount := len(requests)
+	requestsMutex.Unlock()
+	require.Equal(testInstance, 2, capturedRequestCount)
+	require.Contains(testInstance, capturedRequests, repairClassificationRule)
+	require.Contains(testInstance, capturedRequests, "Select one patch successor")
+}
+
 func TestReleaseNextSelectsSameCommitArtifactSuccessor(testInstance *testing.T) {
 	currentWorkingDirectory, workingDirectoryError := os.Getwd()
 	require.NoError(testInstance, workingDirectoryError)


### PR DESCRIPTION
## Summary

Fixes SemVer classification for repair changes that require new CLI inputs.

Required inputs that solely enable a compatible repair are now treated as part of that repair rather than optional additive functionality. This keeps those releases on the patch line while preserving minor releases for genuinely optional public features and major releases for incompatible changes.

## Validation

Adds an integration scenario modeled on the B063 artifact-successor repair:

- Starts from `v1.4.0`
- Includes required previous/candidate output identity inputs needed to restore same-commit patch successor selection
- Verifies the next fixed-major release is `v1.4.1` with a patch bump
- Confirms the repair-specific classification guidance is included in the release decision context