### PR TITLE
gix/stop-repository-cleanup-after-operator-interrupts

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -11,6 +11,30 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 
 ## BugFixes
 
+- [x] [B066] (P1) Stop repository cleanup after an operator interrupt.
+  Reported on 2026-08-13 after an interrupt to `gix prs delete`.
+  Expected result:
+  An operator interrupt stops repository dispatch. The CLI exits without a repeated operation failure list.
+  Actual result:
+  The runner starts cleanup for queued repositories with a canceled context. It reports one failure for each repository and prints the list twice.
+  Requirements:
+  - Stop repository dispatch when the caller context is canceled.
+  - Do not record cancellation as a repository failure.
+  - Do not write shell execution errors for caller cancellation.
+  - Exit with the standard interrupt status and no cancellation error text.
+  - Preserve completed repository results and genuine operation failures.
+  Validation:
+  - Add compiled CLI coverage that interrupts branch cleanup during `git ls-remote`.
+  - Verify the CLI starts no queued repository after cancellation.
+  - Verify stderr has no internal cancellation failure.
+  - Run focused tests and complete CI.
+  Resolution:
+  - The workflow starts no queued repository operation after caller cancellation.
+  - Shell execution returns caller cancellation without an error log.
+  - The CLI exits with status 130 and no cancellation error text.
+  - Compiled CLI coverage interrupts branch cleanup during `git ls-remote`.
+  - Focused tests and `make ci` passed on 2026-08-13.
+
 - [x] [B065] (P0) Keep required repair inputs on the patch line.
   Reported on 2026-08-12 after B063 and B064 were published as `v1.5.0` instead of `v1.4.1`.
   Expected result:
@@ -700,6 +724,22 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - Run the focused Gix and Gateway lifecycle tests.
   - Run the final repository CI gates after the last application change.
   - Run the Governor, STE, and Git checks on changed technical documents.
+
+- [x] [I013] (P2) Normalize managed policy content.
+  Requested on 2026-08-13.
+  Goal:
+  The repository policy matches the current MPR Lab Governor contract.
+  Requirements:
+  - Add the current managed `Credential Discovery` section to `.mprlab/POLICY.md`.
+  - Preserve application files and repository-owned governance text.
+  Validation:
+  - Run the Governor check.
+  - Run `git diff --check`.
+  Resolution:
+  The Governor added the current `Credential Discovery` rules to `.mprlab/POLICY.md`.
+  The update preserved application files and other governance text.
+  The Governor check, policy STE check, and `git diff --check` passed on 2026-08-13.
+  The full issue tracker retained 275 pre-existing mechanical STE findings. The new I013 text added none.
 
 ## Maintenance
 

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -23,10 +23,15 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - Do not write shell execution errors for caller cancellation.
   - Exit with the standard interrupt status and no cancellation error text.
   - Preserve completed repository results and genuine operation failures.
+  - Preserve a runner failure when cancellation and command completion occur at the same time.
+  - Preserve an operation failure when a peer operation cancels the shared context.
+  - Preserve operation outcomes completed before stage cancellation.
   Validation:
   - Add compiled CLI coverage that interrupts branch cleanup during `git ls-remote`.
   - Verify the CLI starts no queued repository after cancellation.
   - Verify stderr has no internal cancellation failure.
+  - Add focused coverage for simultaneous cancellation and completion failures.
+  - Add focused coverage for a partially completed canceled stage.
   - Run focused tests and complete CI.
   Resolution:
   - The workflow starts no queued repository operation after caller cancellation.
@@ -34,6 +39,10 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   - The CLI exits with status 130 and no cancellation error text.
   - Compiled CLI coverage interrupts branch cleanup during `git ls-remote`.
   - Focused tests and `make ci` passed on 2026-08-13.
+  - Shell execution preserves completed results and errors during simultaneous cancellation.
+  - Workflow stages suppress only errors that match the context cancellation cause.
+  - Partially completed stages retain completed operations in the public execution outcome.
+  - Focused cancellation tests and `make ci` passed on 2026-08-13.
 
 - [x] [B065] (P0) Keep required repair inputs on the patch line.
   Reported on 2026-08-12 after B063 and B064 were published as `v1.5.0` instead of `v1.4.1`.

--- a/.mprlab/POLICY.md
+++ b/.mprlab/POLICY.md
@@ -27,6 +27,21 @@ This policy controls all agent work in this repository.
 - Hardcoded workflow, path, event, or message literals when a canonical constant or backend payload exists.
 - Unit tests as a substitute for public contract coverage.
 
+## Credential Discovery
+
+- Identify each required environment variable from the active command and repository contract.
+- Inspect the process environment before you request a login.
+- Inspect repository private environment files before you report a credential blocker.
+- Include ignored `.env`, `.env.*`, and `*.env` files in the authorized repository roots.
+- Treat tracked example and sample environment files as documentation only.
+- Search only for exact variable names. Do not print, copy, or record secret values.
+- Do not source or execute an environment file.
+- Parse only the required assignment from a discovered private environment file.
+- Pass the value through the command's documented private input channel.
+- When available, use a non-mutating authentication command to verify the discovered value.
+- Request new credentials only after each authorized existing input fails verification.
+- Report a credential blocker only after you complete this gate.
+
 ## Validation
 
 - Use repository-native `make` targets when available.

--- a/internal/execshell/executor.go
+++ b/internal/execshell/executor.go
@@ -27,6 +27,7 @@ const (
 	workingDirectoryFieldNameConstant         = "working_directory"
 	exitCodeFieldNameConstant                 = "exit_code"
 	standardErrorFieldNameConstant            = "stderr"
+	canceledCommandExitCodeConstant           = -1
 )
 
 // CommandName identifies a supported executable name.
@@ -143,6 +144,27 @@ func (executionError CommandExecutionError) Unwrap() error {
 	return executionError.Cause
 }
 
+func commandCancellationCause(
+	executionContext context.Context,
+	executionResult ExecutionResult,
+	runnerError error,
+) error {
+	cancellationError := context.Cause(executionContext)
+	if cancellationError == nil {
+		return nil
+	}
+	if runnerError != nil {
+		if errors.Is(runnerError, cancellationError) {
+			return cancellationError
+		}
+		return nil
+	}
+	if executionResult.ExitCode == canceledCommandExitCodeConstant {
+		return cancellationError
+	}
+	return nil
+}
+
 // NewShellExecutor builds an executor for the provided runner and logger.
 func NewShellExecutor(logger *zap.Logger, commandRunner CommandRunner, humanReadableLogging bool) (*ShellExecutor, error) {
 	if logger == nil {
@@ -187,13 +209,10 @@ func (executor *ShellExecutor) Execute(executionContext context.Context, command
 	}
 
 	executionResult, runnerError := executor.commandRunner.Run(executionContext, command)
-	if cancellationError := context.Cause(executionContext); cancellationError != nil {
+	if cancellationError := commandCancellationCause(executionContext, executionResult, runnerError); cancellationError != nil {
 		return ExecutionResult{}, cancellationError
 	}
 	if runnerError != nil {
-		if errors.Is(runnerError, context.Canceled) || errors.Is(runnerError, context.DeadlineExceeded) {
-			return ExecutionResult{}, runnerError
-		}
 		if executor.humanReadableLogging {
 			executor.logger.Error(executor.messageFormatter.BuildExecutionFailureMessage(command, runnerError))
 		} else {

--- a/internal/execshell/executor.go
+++ b/internal/execshell/executor.go
@@ -170,6 +170,9 @@ func (executor *ShellExecutor) Execute(executionContext context.Context, command
 	if preparationError != nil {
 		return ExecutionResult{}, preparationError
 	}
+	if cancellationError := context.Cause(executionContext); cancellationError != nil {
+		return ExecutionResult{}, cancellationError
+	}
 
 	if executor.humanReadableLogging {
 		if executor.messageFormatter.shouldLogStartMessage(command) {
@@ -184,7 +187,13 @@ func (executor *ShellExecutor) Execute(executionContext context.Context, command
 	}
 
 	executionResult, runnerError := executor.commandRunner.Run(executionContext, command)
+	if cancellationError := context.Cause(executionContext); cancellationError != nil {
+		return ExecutionResult{}, cancellationError
+	}
 	if runnerError != nil {
+		if errors.Is(runnerError, context.Canceled) || errors.Is(runnerError, context.DeadlineExceeded) {
+			return ExecutionResult{}, runnerError
+		}
 		if executor.humanReadableLogging {
 			executor.logger.Error(executor.messageFormatter.BuildExecutionFailureMessage(command, runnerError))
 		} else {

--- a/internal/execshell/executor_test.go
+++ b/internal/execshell/executor_test.go
@@ -129,6 +129,13 @@ func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
 			expectedLogCount: 2,
 			expectedLevels:   []zapcore.Level{zap.InfoLevel, zap.ErrorLevel},
 		},
+		{
+			name:             "uncanceled_runner_context_error",
+			runnerError:      context.Canceled,
+			expectErrorType:  execshell.CommandExecutionError{},
+			expectedLogCount: 2,
+			expectedLevels:   []zapcore.Level{zap.InfoLevel, zap.ErrorLevel},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -166,26 +173,107 @@ func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
 }
 
 func TestShellExecutorDoesNotLogCallerCancellation(testInstance *testing.T) {
-	observerCore, observerLogs := observer.New(zap.DebugLevel)
-	logger := zap.New(observerCore)
-	executionContext, cancelExecution := context.WithCancel(context.Background())
-
-	recordingRunner := &recordingCommandRunner{
-		executionError: context.Canceled,
-		beforeReturn:   cancelExecution,
+	testCases := []struct {
+		name        string
+		result      execshell.ExecutionResult
+		runnerError error
+	}{
+		{name: "runner_error", runnerError: context.Canceled},
+		{name: "signaled_result", result: execshell.ExecutionResult{ExitCode: -1}},
 	}
 
-	shellExecutor, creationError := execshell.NewShellExecutor(logger, recordingRunner, true)
-	require.NoError(testInstance, creationError)
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			observerCore, observerLogs := observer.New(zap.DebugLevel)
+			logger := zap.New(observerCore)
+			executionContext, cancelExecution := context.WithCancel(context.Background())
 
-	_, executionError := shellExecutor.ExecuteGit(executionContext, execshell.CommandDetails{
-		Arguments:        []string{"ls-remote", "--heads", "origin"},
-		WorkingDirectory: testWorkingDirectoryConstant,
-	})
+			recordingRunner := &recordingCommandRunner{
+				executionResult: testCase.result,
+				executionError:  testCase.runnerError,
+				beforeReturn:    cancelExecution,
+			}
 
-	require.ErrorIs(testInstance, executionError, context.Canceled)
-	require.Len(testInstance, observerLogs.All(), 1)
-	require.Equal(testInstance, zap.InfoLevel, observerLogs.All()[0].Level)
+			shellExecutor, creationError := execshell.NewShellExecutor(logger, recordingRunner, true)
+			require.NoError(testInstance, creationError)
+
+			_, executionError := shellExecutor.ExecuteGit(executionContext, execshell.CommandDetails{
+				Arguments:        []string{"ls-remote", "--heads", "origin"},
+				WorkingDirectory: testWorkingDirectoryConstant,
+			})
+
+			require.ErrorIs(testInstance, executionError, context.Canceled)
+			require.Len(testInstance, observerLogs.All(), 1)
+			require.Equal(testInstance, zap.InfoLevel, observerLogs.All()[0].Level)
+		})
+	}
+}
+
+func TestShellExecutorPreservesCompletedOutcomeWhenCancellationRacesReturn(testInstance *testing.T) {
+	testCases := []struct {
+		name             string
+		result           execshell.ExecutionResult
+		runnerError      error
+		expectedLogLevel zapcore.Level
+		assertOutcome    func(*testing.T, execshell.ExecutionResult, error)
+	}{
+		{
+			name:             "success",
+			result:           execshell.ExecutionResult{StandardOutput: "ok"},
+			expectedLogLevel: zap.InfoLevel,
+			assertOutcome: func(testInstance *testing.T, result execshell.ExecutionResult, executionError error) {
+				require.NoError(testInstance, executionError)
+				require.Equal(testInstance, "ok", result.StandardOutput)
+			},
+		},
+		{
+			name:             "failure_exit_code",
+			result:           execshell.ExecutionResult{StandardError: "fatal: remote unavailable", ExitCode: 128},
+			expectedLogLevel: zap.WarnLevel,
+			assertOutcome: func(testInstance *testing.T, _ execshell.ExecutionResult, executionError error) {
+				var commandError execshell.CommandFailedError
+				require.ErrorAs(testInstance, executionError, &commandError)
+				require.Equal(testInstance, 128, commandError.Result.ExitCode)
+				require.NotErrorIs(testInstance, executionError, context.Canceled)
+			},
+		},
+		{
+			name:             "runner_error",
+			runnerError:      errors.New("runner completed with an error"),
+			expectedLogLevel: zap.ErrorLevel,
+			assertOutcome: func(testInstance *testing.T, _ execshell.ExecutionResult, executionError error) {
+				var commandError execshell.CommandExecutionError
+				require.ErrorAs(testInstance, executionError, &commandError)
+				require.EqualError(testInstance, commandError.Cause, "runner completed with an error")
+				require.NotErrorIs(testInstance, executionError, context.Canceled)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testInstance.Run(testCase.name, func(testInstance *testing.T) {
+			observerCore, observerLogs := observer.New(zap.DebugLevel)
+			logger := zap.New(observerCore)
+			executionContext, cancelExecution := context.WithCancel(context.Background())
+			recordingRunner := &recordingCommandRunner{
+				executionResult: testCase.result,
+				executionError:  testCase.runnerError,
+				beforeReturn:    cancelExecution,
+			}
+
+			shellExecutor, creationError := execshell.NewShellExecutor(logger, recordingRunner, false)
+			require.NoError(testInstance, creationError)
+
+			result, executionError := shellExecutor.ExecuteGit(executionContext, execshell.CommandDetails{
+				Arguments:        []string{"ls-remote", "--heads", "origin"},
+				WorkingDirectory: testWorkingDirectoryConstant,
+			})
+
+			testCase.assertOutcome(testInstance, result, executionError)
+			require.Len(testInstance, observerLogs.All(), 2)
+			require.Equal(testInstance, testCase.expectedLogLevel, observerLogs.All()[1].Level)
+		})
+	}
 }
 
 func TestShellExecutorHumanReadableLogging(testInstance *testing.T) {

--- a/internal/execshell/executor_test.go
+++ b/internal/execshell/executor_test.go
@@ -40,11 +40,15 @@ const (
 type recordingCommandRunner struct {
 	executionResult  execshell.ExecutionResult
 	executionError   error
+	beforeReturn     func()
 	recordedCommands []execshell.ShellCommand
 }
 
 func (runner *recordingCommandRunner) Run(executionContext context.Context, command execshell.ShellCommand) (execshell.ExecutionResult, error) {
 	runner.recordedCommands = append(runner.recordedCommands, command)
+	if runner.beforeReturn != nil {
+		runner.beforeReturn()
+	}
 	return runner.executionResult, runner.executionError
 }
 
@@ -159,6 +163,29 @@ func TestShellExecutorExecuteBehavior(testInstance *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShellExecutorDoesNotLogCallerCancellation(testInstance *testing.T) {
+	observerCore, observerLogs := observer.New(zap.DebugLevel)
+	logger := zap.New(observerCore)
+	executionContext, cancelExecution := context.WithCancel(context.Background())
+
+	recordingRunner := &recordingCommandRunner{
+		executionError: context.Canceled,
+		beforeReturn:   cancelExecution,
+	}
+
+	shellExecutor, creationError := execshell.NewShellExecutor(logger, recordingRunner, true)
+	require.NoError(testInstance, creationError)
+
+	_, executionError := shellExecutor.ExecuteGit(executionContext, execshell.CommandDetails{
+		Arguments:        []string{"ls-remote", "--heads", "origin"},
+		WorkingDirectory: testWorkingDirectoryConstant,
+	})
+
+	require.ErrorIs(testInstance, executionError, context.Canceled)
+	require.Len(testInstance, observerLogs.All(), 1)
+	require.Equal(testInstance, zap.InfoLevel, observerLogs.All()[0].Level)
 }
 
 func TestShellExecutorHumanReadableLogging(testInstance *testing.T) {

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -370,10 +370,6 @@ func (executor *Executor) Execute(executionContext context.Context, roots []stri
 	outcome.EndTime = time.Now()
 	outcome.Duration = outcome.EndTime.Sub(outcome.StartTime)
 
-	if len(stageFailures) == 0 {
-		return outcome, nil
-	}
-
 	distinctErrors := make([]error, 0, len(stageFailures))
 	failuresExport := make([]OperationFailure, 0, len(stageFailures))
 	for _, failure := range stageFailures {
@@ -385,6 +381,12 @@ func (executor *Executor) Execute(executionContext context.Context, roots []stri
 		})
 	}
 	outcome.Failures = failuresExport
+	if cancellationError := context.Cause(executionContext); cancellationError != nil {
+		return outcome, cancellationError
+	}
+	if len(stageFailures) == 0 {
+		return outcome, nil
+	}
 
 	failureMessages := make([]string, 0, len(stageFailures))
 	for _, failure := range stageFailures {

--- a/internal/workflow/executor_runner.go
+++ b/internal/workflow/executor_runner.go
@@ -59,6 +59,10 @@ func runOperationStages(
 	repositoryStageIndices := make([]int, 0)
 
 	for stageIndex := range stages {
+		if ctx.Err() != nil {
+			break
+		}
+
 		stage := stages[stageIndex]
 		if len(stage.Operations) == 0 {
 			continue
@@ -96,6 +100,9 @@ func runOperationStages(
 			}
 			repositoryStages = repositoryStages[:0]
 			repositoryStageIndices = repositoryStageIndices[:0]
+			if ctx.Err() != nil {
+				break
+			}
 		}
 
 		environment.State = state
@@ -118,7 +125,7 @@ func runOperationStages(
 		result.failures = append(result.failures, stageFailures...)
 	}
 
-	if len(repositoryStages) > 0 {
+	if len(repositoryStages) > 0 && ctx.Err() == nil {
 		repositoryResults := runRepositoryPipelines(
 			ctx,
 			repositoryStages,
@@ -176,6 +183,10 @@ func runRepositoryPipelines(
 		go func() {
 			defer wg.Done()
 			for assignment := range workChannel {
+				if ctx.Err() != nil {
+					return
+				}
+
 				repoEnvironment := cloneEnvironmentForRepository(environment, assignment.item.state)
 				repoResult := repositoryPipelineResult{
 					stageOutcomes:     make([]*StageOutcome, 0, len(stages)),
@@ -185,7 +196,7 @@ func runRepositoryPipelines(
 				repositoryFailed := false
 
 				for stagePosition := range stages {
-					if repositoryFailed {
+					if repositoryFailed || ctx.Err() != nil {
 						break
 					}
 
@@ -219,10 +230,15 @@ func runRepositoryPipelines(
 		}()
 	}
 
+dispatchingRepositories:
 	for repoIndex := range workItems {
-		workChannel <- repositoryWorkAssignment{
+		select {
+		case <-ctx.Done():
+			break dispatchingRepositories
+		case workChannel <- repositoryWorkAssignment{
 			index: repoIndex,
 			item:  workItems[repoIndex],
+		}:
 		}
 	}
 	close(workChannel)
@@ -317,8 +333,15 @@ func executeRepositoryStageForRepository(
 	repositoryFailed := false
 	operationOutcomes := make(map[string]OperationOutcome)
 	previousStepName := environment.currentStepName
+	defer func() {
+		environment.currentStepName = previousStepName
+	}()
 
 	for _, node := range stage.Operations {
+		if ctx.Err() != nil {
+			break
+		}
+
 		if node == nil || node.Operation == nil {
 			continue
 		}
@@ -346,6 +369,9 @@ func executeRepositoryStageForRepository(
 
 		startTime := time.Now()
 		executeError := repoOperation.ExecuteForRepository(ctx, environment, repository)
+		if executeError != nil && ctx.Err() != nil {
+			return nil, operationOutcomes, failures, false
+		}
 		skipRepository := errors.Is(executeError, errRepositorySkipped)
 		environment.reportStepSummary(repository, operationName, executeError, skipRepository)
 		if skipRepository {
@@ -401,8 +427,6 @@ func executeRepositoryStageForRepository(
 		repositoryFailed = true
 	}
 
-	environment.currentStepName = previousStepName
-
 	if len(stageOperationNames) == 0 {
 		return nil, operationOutcomes, failures, repositoryFailed
 	}
@@ -434,6 +458,10 @@ func executeGlobalStage(
 	operationOutcomes := make(map[string]OperationOutcome)
 
 	for _, node := range stage.Operations {
+		if ctx.Err() != nil {
+			break
+		}
+
 		if node == nil || node.Operation == nil {
 			continue
 		}
@@ -449,6 +477,9 @@ func executeGlobalStage(
 
 		startTime := time.Now()
 		executeError := node.Operation.Execute(ctx, environment, state)
+		if executeError != nil && ctx.Err() != nil {
+			break
+		}
 		executionDuration := time.Since(startTime)
 
 		if reporter != nil {

--- a/internal/workflow/executor_runner.go
+++ b/internal/workflow/executor_runner.go
@@ -313,6 +313,30 @@ func sanitizeRepositoryParallelism(requested int, repositoryCount int) int {
 	return parallelism
 }
 
+func operationMatchesContextCancellation(ctx context.Context, operationError error) bool {
+	cancellationError := context.Cause(ctx)
+	return cancellationError != nil && errors.Is(operationError, cancellationError)
+}
+
+func completedStageOutcome(
+	stageStart time.Time,
+	operationNames []string,
+	reporter shared.SummaryReporter,
+	reporterStageName string,
+) *StageOutcome {
+	if len(operationNames) == 0 {
+		return nil
+	}
+	stageDuration := time.Since(stageStart)
+	if reporter != nil {
+		reporter.RecordStageDuration(reporterStageName, stageDuration)
+	}
+	return &StageOutcome{
+		Duration:   stageDuration,
+		Operations: operationNames,
+	}
+}
+
 func executeRepositoryStageForRepository(
 	ctx context.Context,
 	stage OperationStage,
@@ -365,13 +389,18 @@ func executeRepositoryStageForRepository(
 		environment.beginStep(repository.Path, operationName)
 
 		compositeName := fmt.Sprintf("%s:%s", repoLabel, operationName)
-		stageOperationNames = append(stageOperationNames, compositeName)
 
 		startTime := time.Now()
 		executeError := repoOperation.ExecuteForRepository(ctx, environment, repository)
-		if executeError != nil && ctx.Err() != nil {
-			return nil, operationOutcomes, failures, false
+		if operationMatchesContextCancellation(ctx, executeError) {
+			return completedStageOutcome(
+				stageStart,
+				stageOperationNames,
+				reporter,
+				fmt.Sprintf("%s-stage-%d", repoLabel, stageIndex+1),
+			), operationOutcomes, failures, repositoryFailed
 		}
+		stageOperationNames = append(stageOperationNames, compositeName)
 		skipRepository := errors.Is(executeError, errRepositorySkipped)
 		environment.reportStepSummary(repository, operationName, executeError, skipRepository)
 		if skipRepository {
@@ -392,7 +421,7 @@ func executeRepositoryStageForRepository(
 			executeError = nil
 		}
 
-		operationOutcomes[fmt.Sprintf("%s@%s", node.Name, repoLabel)] = OperationOutcome{
+		operationOutcomes[compositeName] = OperationOutcome{
 			Name:     compositeName,
 			Duration: executionDuration,
 			Failed:   executeError != nil,
@@ -427,19 +456,12 @@ func executeRepositoryStageForRepository(
 		repositoryFailed = true
 	}
 
-	if len(stageOperationNames) == 0 {
-		return nil, operationOutcomes, failures, repositoryFailed
-	}
-
-	stageDuration := time.Since(stageStart)
-	if reporter != nil {
-		reporter.RecordStageDuration(fmt.Sprintf("%s-stage-%d", repoLabel, stageIndex+1), stageDuration)
-	}
-
-	return &StageOutcome{
-		Duration:   stageDuration,
-		Operations: stageOperationNames,
-	}, operationOutcomes, failures, repositoryFailed
+	return completedStageOutcome(
+		stageStart,
+		stageOperationNames,
+		reporter,
+		fmt.Sprintf("%s-stage-%d", repoLabel, stageIndex+1),
+	), operationOutcomes, failures, repositoryFailed
 }
 
 func executeGlobalStage(
@@ -473,13 +495,12 @@ func executeGlobalStage(
 		if len(operationName) == 0 {
 			operationName = "operation"
 		}
-		stageOperationNames = append(stageOperationNames, operationName)
-
 		startTime := time.Now()
 		executeError := node.Operation.Execute(ctx, environment, state)
-		if executeError != nil && ctx.Err() != nil {
+		if operationMatchesContextCancellation(ctx, executeError) {
 			break
 		}
+		stageOperationNames = append(stageOperationNames, operationName)
 		executionDuration := time.Since(startTime)
 
 		if reporter != nil {
@@ -526,15 +547,12 @@ func executeGlobalStage(
 		}
 	}
 
-	stageDuration := time.Since(stageStart)
-	if reporter != nil {
-		reporter.RecordStageDuration(fmt.Sprintf("stage-%d", stageIndex+1), stageDuration)
-	}
-
-	return &StageOutcome{
-		Duration:   stageDuration,
-		Operations: stageOperationNames,
-	}, operationOutcomes, failures
+	return completedStageOutcome(
+		stageStart,
+		stageOperationNames,
+		reporter,
+		fmt.Sprintf("stage-%d", stageIndex+1),
+	), operationOutcomes, failures
 }
 
 func stageIsRepositoryScoped(stage OperationStage) bool {

--- a/internal/workflow/executor_runner_test.go
+++ b/internal/workflow/executor_runner_test.go
@@ -1,7 +1,9 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -186,6 +188,75 @@ func TestRunOperationStagesSupportsParallelRepositories(t *testing.T) {
 		[]string{fmt.Sprintf("%s:%s", repositoryLabel(repositoryTwo), "parallel-step")},
 		result.stageOutcomes[1].Operations,
 	)
+}
+
+func TestRunOperationStagesStopsRepositoryDispatchAfterCancellation(t *testing.T) {
+	repositories := []*RepositoryState{
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/one", FinalOwnerRepo: "octocat/one"}),
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/two", FinalOwnerRepo: "octocat/two"}),
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/three", FinalOwnerRepo: "octocat/three"}),
+	}
+
+	executionContext, cancelExecution := context.WithCancel(context.Background())
+	errorOutput := &bytes.Buffer{}
+	environment := &Environment{Errors: errorOutput}
+	state := &State{Repositories: repositories}
+
+	executionCount := 0
+	operation := &stubRepositoryOperation{
+		name: "cancel-step",
+		executeFunc: func(context.Context, *Environment, *RepositoryState) error {
+			executionCount++
+			cancelExecution()
+			return context.Canceled
+		},
+	}
+
+	stages := []OperationStage{{
+		Operations: []*OperationNode{{Name: "cancel-step", Operation: operation}},
+	}}
+
+	result := runOperationStages(executionContext, stages, environment, state, nil, 1)
+
+	require.Equal(t, 1, executionCount)
+	require.Empty(t, result.failures)
+	require.Empty(t, errorOutput.String())
+}
+
+func TestRunOperationStagesPreservesFailureBeforeCancellation(t *testing.T) {
+	repositories := []*RepositoryState{
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/one", FinalOwnerRepo: "octocat/one"}),
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/two", FinalOwnerRepo: "octocat/two"}),
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/three", FinalOwnerRepo: "octocat/three"}),
+	}
+
+	executionContext, cancelExecution := context.WithCancel(context.Background())
+	errorOutput := &bytes.Buffer{}
+	environment := &Environment{Errors: errorOutput}
+	state := &State{Repositories: repositories}
+
+	executionCount := 0
+	operation := &stubRepositoryOperation{
+		name: "cleanup-step",
+		executeFunc: func(context.Context, *Environment, *RepositoryState) error {
+			executionCount++
+			if executionCount == 1 {
+				return errors.New("remote unavailable")
+			}
+			cancelExecution()
+			return context.Canceled
+		},
+	}
+
+	stages := []OperationStage{{
+		Operations: []*OperationNode{{Name: "cleanup-step", Operation: operation}},
+	}}
+
+	result := runOperationStages(executionContext, stages, environment, state, nil, 1)
+
+	require.Equal(t, 2, executionCount)
+	require.Len(t, result.failures, 1)
+	require.Equal(t, "cleanup-step: remote unavailable\n", errorOutput.String())
 }
 
 func TestRunOperationStagesExecutesFullPipelinePerRepository(t *testing.T) {

--- a/internal/workflow/executor_runner_test.go
+++ b/internal/workflow/executor_runner_test.go
@@ -18,6 +18,22 @@ type stubRepositoryOperation struct {
 	executeFunc func(context.Context, *Environment, *RepositoryState) error
 }
 
+type stubGlobalOperation struct {
+	name        string
+	executeFunc func(context.Context, *Environment, *State) error
+}
+
+func (operation *stubGlobalOperation) Name() string {
+	return operation.name
+}
+
+func (operation *stubGlobalOperation) Execute(ctx context.Context, environment *Environment, state *State) error {
+	if operation.executeFunc == nil {
+		return nil
+	}
+	return operation.executeFunc(ctx, environment, state)
+}
+
 func (operation *stubRepositoryOperation) Name() string {
 	return operation.name
 }
@@ -82,8 +98,8 @@ func TestRunOperationStagesCancelsRepositoryAfterSafeguardFailure(t *testing.T) 
 	require.Equal(t, 0, followUpExecuted, "follow-up operation should not run after safeguard failure")
 	require.Len(t, result.stageOutcomes, 1)
 	require.Equal(t, []string{"octocat/example:clean-worktree-guard"}, result.stageOutcomes[0].Operations)
-	require.Contains(t, result.operationOutcomes, "clean-worktree-guard@octocat/example")
-	require.NotContains(t, result.operationOutcomes, "mutating-step@octocat/example")
+	require.Contains(t, result.operationOutcomes, "octocat/example:clean-worktree-guard")
+	require.NotContains(t, result.operationOutcomes, "octocat/example:mutating-step")
 }
 
 func TestRunOperationStagesSkipsLaterStagesAfterSafeguardFailure(t *testing.T) {
@@ -141,9 +157,9 @@ func TestRunOperationStagesSkipsLaterStagesAfterSafeguardFailure(t *testing.T) {
 	require.Equal(t, 0, stageTwoExecuted, "stage two should not run after safeguard failure")
 	require.Len(t, result.stageOutcomes, 1)
 	require.Equal(t, []string{"octocat/example:clean-worktree-guard"}, result.stageOutcomes[0].Operations)
-	require.Contains(t, result.operationOutcomes, "clean-worktree-guard@octocat/example")
-	require.NotContains(t, result.operationOutcomes, "mutating-step@octocat/example")
-	require.NotContains(t, result.operationOutcomes, "post-guard@octocat/example")
+	require.Contains(t, result.operationOutcomes, "octocat/example:clean-worktree-guard")
+	require.NotContains(t, result.operationOutcomes, "octocat/example:mutating-step")
+	require.NotContains(t, result.operationOutcomes, "octocat/example:post-guard")
 }
 
 func TestRunOperationStagesSupportsParallelRepositories(t *testing.T) {
@@ -257,6 +273,112 @@ func TestRunOperationStagesPreservesFailureBeforeCancellation(t *testing.T) {
 	require.Equal(t, 2, executionCount)
 	require.Len(t, result.failures, 1)
 	require.Equal(t, "cleanup-step: remote unavailable\n", errorOutput.String())
+}
+
+func TestRunOperationStagesPreservesParallelFailureDuringCancellation(t *testing.T) {
+	repositories := []*RepositoryState{
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/one", FinalOwnerRepo: "octocat/one"}),
+		NewRepositoryState(audit.RepositoryInspection{Path: "/repositories/two", FinalOwnerRepo: "octocat/two"}),
+	}
+
+	executionContext, cancelExecution := context.WithCancel(context.Background())
+	errorOutput := &bytes.Buffer{}
+	environment := &Environment{Errors: errorOutput}
+	state := &State{Repositories: repositories}
+	var operationBarrier sync.WaitGroup
+	operationBarrier.Add(len(repositories))
+
+	operation := &stubRepositoryOperation{
+		name: "cleanup-step",
+		executeFunc: func(_ context.Context, _ *Environment, repository *RepositoryState) error {
+			operationBarrier.Done()
+			operationBarrier.Wait()
+			if repository.Path == repositories[0].Path {
+				cancelExecution()
+				return context.Canceled
+			}
+			<-executionContext.Done()
+			return errors.New("remote unavailable")
+		},
+	}
+
+	stages := []OperationStage{{
+		Operations: []*OperationNode{{Name: "cleanup-step", Operation: operation}},
+	}}
+
+	result := runOperationStages(executionContext, stages, environment, state, nil, 2)
+
+	require.Len(t, result.failures, 1)
+	require.EqualError(t, result.failures[0].err, "remote unavailable")
+	require.Equal(t, "cleanup-step: remote unavailable\n", errorOutput.String())
+	require.Len(t, result.stageOutcomes, 1)
+	require.Equal(t, []string{"octocat/two:cleanup-step"}, result.stageOutcomes[0].Operations)
+	require.Contains(t, result.operationOutcomes, "octocat/two:cleanup-step")
+	require.NotContains(t, result.operationOutcomes, "octocat/one:cleanup-step")
+}
+
+func TestRunOperationStagesPreservesGlobalFailureDuringCancellation(t *testing.T) {
+	repository := NewRepositoryState(audit.RepositoryInspection{
+		Path:           "/repositories/example",
+		FinalOwnerRepo: "octocat/example",
+	})
+	executionContext, cancelExecution := context.WithCancel(context.Background())
+	errorOutput := &bytes.Buffer{}
+	environment := &Environment{Errors: errorOutput}
+	state := &State{Repositories: []*RepositoryState{repository}}
+
+	operation := &stubGlobalOperation{
+		name: "global-step",
+		executeFunc: func(context.Context, *Environment, *State) error {
+			cancelExecution()
+			return errors.New("API unavailable")
+		},
+	}
+	stages := []OperationStage{{
+		Operations: []*OperationNode{{Name: "global-step", Operation: operation}},
+	}}
+
+	result := runOperationStages(executionContext, stages, environment, state, nil, 1)
+
+	require.Len(t, result.failures, 1)
+	require.EqualError(t, result.failures[0].err, "API unavailable")
+	require.Equal(t, "global-step: API unavailable\n", errorOutput.String())
+	require.Len(t, result.stageOutcomes, 1)
+	require.Equal(t, []string{"global-step"}, result.stageOutcomes[0].Operations)
+	require.Contains(t, result.operationOutcomes, "global-step")
+}
+
+func TestRunOperationStagesPreservesPartialStageOutcomeAfterCancellation(t *testing.T) {
+	repository := NewRepositoryState(audit.RepositoryInspection{
+		Path:           "/repositories/example",
+		FinalOwnerRepo: "octocat/example",
+	})
+	executionContext, cancelExecution := context.WithCancel(context.Background())
+	environment := &Environment{}
+	state := &State{Repositories: []*RepositoryState{repository}}
+
+	completedOperation := &stubRepositoryOperation{name: "completed-step"}
+	canceledOperation := &stubRepositoryOperation{
+		name: "canceled-step",
+		executeFunc: func(context.Context, *Environment, *RepositoryState) error {
+			cancelExecution()
+			return context.Canceled
+		},
+	}
+	stages := []OperationStage{{
+		Operations: []*OperationNode{
+			{Name: "completed-step", Operation: completedOperation},
+			{Name: "canceled-step", Operation: canceledOperation},
+		},
+	}}
+
+	result := runOperationStages(executionContext, stages, environment, state, nil, 1)
+
+	require.Empty(t, result.failures)
+	require.Len(t, result.stageOutcomes, 1)
+	require.Equal(t, []string{"octocat/example:completed-step"}, result.stageOutcomes[0].Operations)
+	require.Contains(t, result.operationOutcomes, "octocat/example:completed-step")
+	require.NotContains(t, result.operationOutcomes, "octocat/example:canceled-step")
 }
 
 func TestRunOperationStagesExecutesFullPipelinePerRepository(t *testing.T) {

--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -333,6 +333,59 @@ func TestExecutorRecordsStageAndOperationOutcomes(testInstance *testing.T) {
 	require.Equal(testInstance, 1, outcome.ReporterSummaryData.TotalRepositories)
 }
 
+func TestExecutorPreservesCompletedRepositoryOutcomeAfterCancellation(testInstance *testing.T) {
+	tempDirectory := testInstance.TempDir()
+	repositoryPath := filepath.Join(tempDirectory, "sample")
+	require.NoError(testInstance, os.Mkdir(repositoryPath, 0o755))
+
+	gitExecutor := newStubWorkflowGitExecutor()
+	repositoryManager, managerError := gitrepo.NewRepositoryManager(gitExecutor)
+	require.NoError(testInstance, managerError)
+
+	githubClient, clientError := githubcli.NewClient(gitExecutor)
+	require.NoError(testInstance, clientError)
+
+	dependencies := humanReadableDependencies(Dependencies{
+		RepositoryDiscoverer: executorStubRepositoryDiscoverer{repositories: []string{repositoryPath}},
+		GitExecutor:          gitExecutor,
+		RepositoryManager:    repositoryManager,
+		GitHubClient:         githubClient,
+		Output:               &bytes.Buffer{},
+		Errors:               &bytes.Buffer{},
+	})
+
+	executionContext, cancelExecution := context.WithCancel(context.Background())
+	completedOperation := &stubRepositoryOperation{name: "completed-step"}
+	canceledOperation := &stubRepositoryOperation{
+		name: "canceled-step",
+		executeFunc: func(context.Context, *Environment, *RepositoryState) error {
+			cancelExecution()
+			return context.Canceled
+		},
+	}
+	executor := NewExecutorFromNodes([]*OperationNode{
+		{Name: "completed-step", Operation: completedOperation},
+		{Name: "canceled-step", Operation: canceledOperation},
+	}, dependencies)
+
+	outcome, executionError := executor.Execute(
+		executionContext,
+		[]string{repositoryPath},
+		RuntimeOptions{SkipRepositoryMetadata: true},
+	)
+
+	require.ErrorIs(testInstance, executionError, context.Canceled)
+	require.Len(testInstance, outcome.StageOutcomes, 1)
+	require.Equal(
+		testInstance,
+		[]string{"canonical/example:completed-step"},
+		outcome.StageOutcomes[0].Operations,
+	)
+	require.Len(testInstance, outcome.OperationOutcomes, 1)
+	require.Equal(testInstance, "canonical/example:completed-step", outcome.OperationOutcomes[0].Name)
+	require.False(testInstance, outcome.OperationOutcomes[0].Failed)
+}
+
 func TestRepositorySkipPreventsSubsequentOperations(testInstance *testing.T) {
 	tempDirectory := testInstance.TempDir()
 	repositoryPath := filepath.Join(tempDirectory, "sample")

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,11 +11,15 @@ import (
 
 const (
 	exitErrorTemplateConstant = "%v\n"
+	interruptExitCodeConstant = 130
 )
 
 // main executes the gix command-line application.
 func main() {
 	if executionError := cli.Execute(); executionError != nil {
+		if errors.Is(executionError, context.Canceled) {
+			os.Exit(interruptExitCodeConstant)
+		}
 		fmt.Fprintf(os.Stderr, exitErrorTemplateConstant, executionError)
 		os.Exit(1)
 	}

--- a/tests/pr_cleanup_cancellation_integration_test.go
+++ b/tests/pr_cleanup_cancellation_integration_test.go
@@ -1,0 +1,134 @@
+package tests
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	prCleanupCancellationRepositoryCount = 3
+	prCleanupCancellationTimeout         = 10 * time.Second
+)
+
+func TestPullRequestCleanupInterruptStopsWithoutFailureOutput(testInstance *testing.T) {
+	repositoryRoot := filepath.Dir(mustWorkingDirectory(testInstance))
+	binaryPath := buildIntegrationBinary(testInstance, repositoryRoot)
+	fleetRoot := testInstance.TempDir()
+
+	for repositoryIndex := 0; repositoryIndex < prCleanupCancellationRepositoryCount; repositoryIndex++ {
+		repositoryPath := createGitRepository(testInstance, gitRepositoryOptions{
+			Path:          filepath.Join(fleetRoot, fmt.Sprintf("repository-%d", repositoryIndex)),
+			RemoteURL:     fmt.Sprintf("https://github.com/octocat/repository-%d.git", repositoryIndex),
+			InitialBranch: "master",
+		})
+		runGit(testInstance, repositoryPath, "config", "user.name", "Integration Tester")
+		runGit(testInstance, repositoryPath, "config", "user.email", "tester@example.com")
+		require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("fixture\n"), 0o644))
+		runGit(testInstance, repositoryPath, "add", "README.md")
+		runGit(testInstance, repositoryPath, "commit", "-m", "test: initialize cleanup fixture")
+	}
+
+	realGitPath, lookupError := exec.LookPath("git")
+	require.NoError(testInstance, lookupError)
+	startedMarkerPath := filepath.Join(testInstance.TempDir(), "ls-remote-started")
+	invocationMarkerPath := filepath.Join(testInstance.TempDir(), "ls-remote-invocations")
+	stubScript := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "ls-remote" ] && [ "$2" = "--heads" ]; then
+  printf 'started\n' >> "$GIX_TEST_LS_REMOTE_INVOCATIONS"
+  : > "$GIX_TEST_LS_REMOTE_STARTED"
+  while :; do sleep 1; done
+fi
+exec %q "$@"
+`, realGitPath)
+	stubPath := buildStubbedExecutablePath(testInstance, "git", stubScript)
+
+	environmentOverrides := map[string]string{
+		"GIX_TEST_LS_REMOTE_INVOCATIONS": invocationMarkerPath,
+		"GIX_TEST_LS_REMOTE_STARTED":     startedMarkerPath,
+	}
+	arguments := injectBinaryIntegrationConfiguration(testInstance, []string{
+		"--log-format=console",
+		"prs",
+		"delete",
+		"--roots",
+		fleetRoot,
+		"--limit",
+		"100",
+	}, environmentOverrides)
+
+	command := exec.Command(binaryPath, arguments...)
+	command.Dir = repositoryRoot
+	command.Env = buildCommandEnvironment(integrationCommandOptions{
+		PathVariable:         stubPath,
+		EnvironmentOverrides: environmentOverrides,
+	})
+	var standardOutput bytes.Buffer
+	var standardError bytes.Buffer
+	command.Stdout = &standardOutput
+	command.Stderr = &standardError
+	require.NoError(testInstance, command.Start())
+
+	waitForFile(testInstance, startedMarkerPath, prCleanupCancellationTimeout)
+	require.NoError(testInstance, command.Process.Signal(os.Interrupt))
+
+	waitChannel := make(chan error, 1)
+	go func() {
+		waitChannel <- command.Wait()
+	}()
+
+	var runError error
+	select {
+	case runError = <-waitChannel:
+	case <-time.After(prCleanupCancellationTimeout):
+		_ = command.Process.Kill()
+		<-waitChannel
+		testInstance.Fatal("interrupted cleanup did not exit")
+	}
+
+	exitError := &exec.ExitError{}
+	require.ErrorAs(testInstance, runError, &exitError)
+	require.Equal(testInstance, 130, exitError.ExitCode())
+
+	combinedOutput := standardOutput.String() + standardError.String()
+	require.NotContains(testInstance, combinedOutput, "context canceled")
+	require.NotContains(testInstance, combinedOutput, "action failed")
+	require.NotContains(testInstance, combinedOutput, "command execution failed")
+	require.NotContains(testInstance, combinedOutput, "WORKFLOW_OPERATION_FAILURE")
+	require.NotContains(testInstance, combinedOutput, "ERROR\t")
+
+	invocationBytes, readError := os.ReadFile(invocationMarkerPath)
+	require.NoError(testInstance, readError)
+	require.Equal(testInstance, 1, strings.Count(string(invocationBytes), "started"))
+}
+
+func mustWorkingDirectory(testInstance *testing.T) string {
+	testInstance.Helper()
+	workingDirectory, workingDirectoryError := os.Getwd()
+	require.NoError(testInstance, workingDirectoryError)
+	return workingDirectory
+}
+
+func waitForFile(testInstance *testing.T, path string, timeout time.Duration) {
+	testInstance.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, statError := os.Stat(path)
+		if statError == nil {
+			return
+		}
+		if !errors.Is(statError, os.ErrNotExist) {
+			require.NoError(testInstance, statError)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	testInstance.Fatalf("timed out waiting for %s", path)
+}


### PR DESCRIPTION
## Summary

Fix cancellation handling so an operator interrupt stops repository cleanup promptly and exits cleanly.

- Stop dispatching queued repository work and halt remaining stages when the execution context is canceled.
- Avoid recording caller cancellation as a repository-operation failure while preserving failures completed before cancellation.
- Prevent shell execution from logging cancellation as an internal command failure.
- Return the cancellation cause from workflow execution and map interrupts to exit status `130` without cancellation error output.
- Restore per-repository workflow state reliably when execution exits early.

## Validation

- Added workflow coverage confirming cancellation stops queued repository dispatch without producing failure output.
- Added coverage confirming genuine failures before cancellation are retained.
- Added shell executor coverage confirming caller cancellation does not emit an error log.
- Added compiled CLI integration coverage for interrupting PR cleanup during remote branch inspection.

## Documentation

- Added credential discovery guidance to the repository policy.