### PR TITLE
gix/ignore-whitespace-in-merge-replacement-intent-validation

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -11,6 +11,30 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 
 ## BugFixes
 
+- [x] [B073] (P0) Ignore whitespace when validating merge replacement intent.
+  Reported on 2026-08-20 after `gix sync master --stash` rejected four semantic candidates.
+  Expected result:
+  Gix accepts a candidate when it keeps each replacement's non-whitespace content in the correct order.
+  Actual result:
+  Gix uses a raw substring comparison. A different line wrap causes a false missing-intent error.
+  Requirements:
+  - Compare replacement intent without whitespace.
+  - Preserve the exact non-whitespace content and order.
+  - Report all missing OURS and THEIRS replacement content in one error.
+  - Preserve additive validation, semantic audit, bounded attempts, and exact rollback.
+  Validation:
+  - Reproduce a multiline stash conflict through the compiled CLI.
+  - Return a valid semantic candidate that changes only line wrapping.
+  - Verify that local validation accepts the candidate before semantic audit.
+  - Verify that one-sided loss reports all missing replacement content.
+  - Run focused tests and complete CI.
+  Resolution:
+  Gix now removes Unicode whitespace from each replacement and candidate before comparison.
+  It reports every missing OURS and THEIRS replacement fragment in one error.
+  The compiled CLI regression reproduces a multiline `--stash` conflict.
+  It accepts the reflowed candidate, completes semantic audit, and finalizes the exact invocation stash.
+  Focused tests and `make ci` passed on 2026-08-20.
+
 - [x] [B072] (P0) Stop semantic repair after a provider request failure.
   Reported on 2026-08-20 after a strict-sync conflict request failed.
   Expected result:

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -34,6 +34,20 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   The compiled CLI regression reproduces a multiline `--stash` conflict.
   It accepts the reflowed candidate, completes semantic audit, and finalizes the exact invocation stash.
   Focused tests and `make ci` passed on 2026-08-20.
+  Review finding on 2026-08-20:
+  A candidate can use an unrelated normalized match from a different location.
+  This match can hide the loss of an edited occurrence.
+  Follow-up requirements:
+  - Require a new occurrence or an edit context match for each replacement intent.
+  - Reject an unrelated normalized match before semantic audit.
+  - Cover the failure through the compiled CLI.
+  Follow-up resolution:
+  Gix now requires the necessary normalized occurrence count or a matching edit context.
+  An unrelated occurrence cannot satisfy this validation.
+  The focused test covers occurrence counting and edit context matching.
+  The compiled CLI rejects the lossy alias candidate before audit.
+  It preserves the lossless stash candidate and completes strict sync.
+  Focused tests and `make ci` passed on 2026-08-20.
 
 - [x] [B072] (P0) Stop semantic repair after a provider request failure.
   Reported on 2026-08-20 after a strict-sync conflict request failed.

--- a/.mprlab/TERMINOLOGY.md
+++ b/.mprlab/TERMINOLOGY.md
@@ -83,6 +83,7 @@ Add repository-specific technical nouns below this line.
 - `fixed-major policy`: A SemVer policy that keeps one configured major value.
 - `provider round`: One LLM request that uses the complete configured provider order.
 - `release policy`: The invocation input that selects one release version scheme and its scheme-specific options.
+- `replacement intent`: The non-whitespace content that one conflict side adds or changes relative to a common base.
 - `SemVer`: A release version with major, minor, and patch fields.
 - `version decision`: The Gix result that selects one release version from repository evidence and policy.
 

--- a/.mprlab/TERMINOLOGY.md
+++ b/.mprlab/TERMINOLOGY.md
@@ -80,6 +80,7 @@ Give each term one meaning. Use the same term for the same concept in all docume
 Add repository-specific technical nouns below this line.
 
 - `CalVer`: A release version that derives its numeric fields from a release timestamp.
+- `edit context`: The unchanged tokens next to a replacement intent base location.
 - `fixed-major policy`: A SemVer policy that keeps one configured major value.
 - `provider round`: One LLM request that uses the complete configured provider order.
 - `release policy`: The invocation input that selects one release version scheme and its scheme-specific options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Updated the LLM Proxy Go client from v0.2.21 to v0.2.46, moved Gix's configured proxy work budget to the current per-request timeout header, and raised the Go module floor to 1.25.12 with the dependency graph required by that client.
 
 ### Bug Fixes 🐛
+- Made replacement intent validation ignore Unicode whitespace. Reported all missing OURS and THEIRS content in one rejection. Preserved reflowed semantic candidates through stash finalization.
 - Stopped semantic repair after one failed provider round. Kept marker-bearing responses and other returned candidate rejections in the validation-guided repair loop. Preserved typed LLM Proxy HTTP status and exact rollback.
 - Deleted the old default branch after all safety gates passed. Fetched remote branch commits before each deletion safety check. Made deletion conditional on the verified source commit.
 - Mapped GitHub Pages `404` responses to the disabled state. Other Pages lookup and response failures now stop default-branch migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Updated the LLM Proxy Go client from v0.2.21 to v0.2.46, moved Gix's configured proxy work budget to the current per-request timeout header, and raised the Go module floor to 1.25.12 with the dependency graph required by that client.
 
 ### Bug Fixes 🐛
-- Made replacement intent validation ignore Unicode whitespace. Reported all missing OURS and THEIRS content in one rejection. Preserved reflowed semantic candidates through stash finalization.
+- Made replacement intent validation ignore Unicode whitespace and require a new occurrence or matching edit context. Reported all missing OURS and THEIRS content in one rejection. Preserved reflowed semantic candidates through stash finalization.
 - Stopped semantic repair after one failed provider round. Kept marker-bearing responses and other returned candidate rejections in the validation-guided repair loop. Preserved typed LLM Proxy HTTP status and exact rollback.
 - Deleted the old default branch after all safety gates passed. Fetched remote branch commits before each deletion safety check. Made deletion conditional on the verified source commit.
 - Mapped GitHub Pages `404` responses to the disabled state. Other Pages lookup and response failures now stop default-branch migration.

--- a/internal/branches/syncflow/merge_conflict_resolution.go
+++ b/internal/branches/syncflow/merge_conflict_resolution.go
@@ -41,8 +41,8 @@ const (
 	mergeConflictResolutionEmptyResponse        = "llm returned an empty merge resolution for %s"
 	mergeConflictResolutionEnvelopeTemplate     = "llm merge resolution for %s did not use the required content envelope"
 	mergeConflictResolutionConflictMarkers      = "llm left conflict markers in merge resolution for %s"
-	mergeConflictResolutionOursTemplate         = "llm merge resolution for %s conflict region %d does not preserve OURS replacement intent %q"
-	mergeConflictResolutionTheirsTemplate       = "llm merge resolution for %s conflict region %d does not preserve THEIRS replacement intent %q"
+	mergeConflictResolutionOursTemplate         = "llm merge resolution for %s conflict region %d does not preserve OURS replacement intent %s"
+	mergeConflictResolutionTheirsTemplate       = "llm merge resolution for %s conflict region %d does not preserve THEIRS replacement intent %s"
 	mergeConflictResolutionAdditiveTemplate     = "llm merge resolution for %s additive conflict region %d is not an exact ordering of OURS and THEIRS"
 	mergeConflictResolutionIntentTemplate       = "llm merge resolution for %s conflict region %d cannot be validated against %s replacement intent"
 	mergeConflictResolutionBaseOnlyTemplate     = "llm merge resolution for %s conflict region %d returned BASE without either side's changes"
@@ -1190,21 +1190,46 @@ func validateMergeConflictRegionResponse(path string, regionIndex int, region me
 	if response == region.Base && (region.Ours != region.Base || region.Theirs != region.Base) {
 		return fmt.Errorf(mergeConflictResolutionBaseOnlyTemplate, path, regionIndex+1)
 	}
-	missingOursIntent, oursIntentMissing, oursIntentAvailable := mergeConflictMissingReplacementIntent(region.Base, region.Ours, response)
+	intentErrors := make([]error, 0, 2)
+	missingOursIntents, oursIntentAvailable := mergeConflictMissingReplacementIntents(region.Base, region.Ours, response)
 	if !oursIntentAvailable {
-		return fmt.Errorf(mergeConflictResolutionIntentTemplate, path, regionIndex+1, "OURS")
+		intentErrors = append(intentErrors, fmt.Errorf(mergeConflictResolutionIntentTemplate, path, regionIndex+1, "OURS"))
 	}
-	if oursIntentMissing {
-		return fmt.Errorf(mergeConflictResolutionOursTemplate, path, regionIndex+1, missingOursIntent)
+	if len(missingOursIntents) != 0 {
+		intentErrors = append(
+			intentErrors,
+			fmt.Errorf(
+				mergeConflictResolutionOursTemplate,
+				path,
+				regionIndex+1,
+				mergeConflictReplacementIntentDetails(missingOursIntents),
+			),
+		)
 	}
-	missingTheirsIntent, theirsIntentMissing, theirsIntentAvailable := mergeConflictMissingReplacementIntent(region.Base, region.Theirs, response)
+	missingTheirsIntents, theirsIntentAvailable := mergeConflictMissingReplacementIntents(region.Base, region.Theirs, response)
 	if !theirsIntentAvailable {
-		return fmt.Errorf(mergeConflictResolutionIntentTemplate, path, regionIndex+1, "THEIRS")
+		intentErrors = append(intentErrors, fmt.Errorf(mergeConflictResolutionIntentTemplate, path, regionIndex+1, "THEIRS"))
 	}
-	if theirsIntentMissing {
-		return fmt.Errorf(mergeConflictResolutionTheirsTemplate, path, regionIndex+1, missingTheirsIntent)
+	if len(missingTheirsIntents) != 0 {
+		intentErrors = append(
+			intentErrors,
+			fmt.Errorf(
+				mergeConflictResolutionTheirsTemplate,
+				path,
+				regionIndex+1,
+				mergeConflictReplacementIntentDetails(missingTheirsIntents),
+			),
+		)
 	}
-	return nil
+	return errors.Join(intentErrors...)
+}
+
+func mergeConflictReplacementIntentDetails(intents []string) string {
+	details := make([]string, 0, len(intents))
+	for _, intent := range intents {
+		details = append(details, strconv.Quote(intent))
+	}
+	return strings.Join(details, ", ")
 }
 
 func parseMergeConflictDocument(content string) (mergeConflictDocument, error) {

--- a/internal/branches/syncflow/merge_conflict_resolution_test.go
+++ b/internal/branches/syncflow/merge_conflict_resolution_test.go
@@ -219,6 +219,44 @@ func TestValidateMergeConflictRegionResponseIgnoresWhitespaceAndReportsAllMissin
 	require.Contains(t, multipleLossErr.Error(), "mode=strict")
 }
 
+func TestValidateMergeConflictRegionResponseRejectsReplacementIntentFromUnrelatedOccurrence(t *testing.T) {
+	region := mergeConflictRegion{
+		Ours:        "primary: foo bar\nalias: foobar\nmode: standard\n",
+		Base:        "primary: old\nalias: foobar\nmode: standard\n",
+		BasePresent: true,
+		Theirs:      "primary: old\nalias: foobar\nmode: strict\n",
+	}
+
+	lossyCandidateErr := validateMergeConflictRegionResponse(
+		"policy.txt",
+		0,
+		region,
+		"primary: old\nalias: foobar\nmode: strict\n",
+	)
+	require.Error(t, lossyCandidateErr)
+	require.Contains(t, lossyCandidateErr.Error(), "does not preserve OURS replacement intent")
+	require.Contains(t, lossyCandidateErr.Error(), "foo bar")
+
+	require.NoError(
+		t,
+		validateMergeConflictRegionResponse(
+			"policy.txt",
+			0,
+			region,
+			"primary: foo\n  bar\nalias: foobar\nmode: strict\n",
+		),
+	)
+	require.NoError(
+		t,
+		validateMergeConflictRegionResponse(
+			"policy.txt",
+			0,
+			region,
+			"primary: foo bar\nmode: strict\n",
+		),
+	)
+}
+
 func TestDeterministicMergeConflictRegionResolutionBuildsAuthoritativeResultsAndAuditedCandidates(t *testing.T) {
 	testCases := map[string]struct {
 		region                mergeConflictRegion

--- a/internal/branches/syncflow/merge_conflict_resolution_test.go
+++ b/internal/branches/syncflow/merge_conflict_resolution_test.go
@@ -181,6 +181,44 @@ func TestValidateMergeConflictRegionResponseContracts(t *testing.T) {
 	require.Contains(t, theirsLossErr.Error(), "does not preserve THEIRS replacement intent")
 }
 
+func TestValidateMergeConflictRegionResponseIgnoresWhitespaceAndReportsAllMissingIntent(t *testing.T) {
+	reflowedRegion := mergeConflictRegion{
+		Ours:        "policy: strict\n  timeout=30\n",
+		Base:        "policy: standard timeout=30\n",
+		BasePresent: true,
+		Theirs:      "policy: standard timeout=60\n",
+	}
+	require.NoError(
+		t,
+		validateMergeConflictRegionResponse(
+			"policy.txt",
+			0,
+			reflowedRegion,
+			"policy: strict timeout=60\n",
+		),
+	)
+
+	multipleLossRegion := mergeConflictRegion{
+		Ours:        "owners: carol; reviewers: dave; timeout=30\n",
+		Base:        "owners: alice; reviewers: bob; timeout=30\n",
+		BasePresent: true,
+		Theirs:      "owners: alice; reviewers: bob; timeout=60; mode=strict\n",
+	}
+	multipleLossErr := validateMergeConflictRegionResponse(
+		"policy.txt",
+		1,
+		multipleLossRegion,
+		"owners: alice; reviewers: bob; timeout=45\n",
+	)
+	require.Error(t, multipleLossErr)
+	require.Contains(t, multipleLossErr.Error(), "does not preserve OURS replacement intent")
+	require.Contains(t, multipleLossErr.Error(), "carol")
+	require.Contains(t, multipleLossErr.Error(), "dave")
+	require.Contains(t, multipleLossErr.Error(), "does not preserve THEIRS replacement intent")
+	require.Contains(t, multipleLossErr.Error(), "60")
+	require.Contains(t, multipleLossErr.Error(), "mode=strict")
+}
+
 func TestDeterministicMergeConflictRegionResolutionBuildsAuthoritativeResultsAndAuditedCandidates(t *testing.T) {
 	testCases := map[string]struct {
 		region                mergeConflictRegion

--- a/internal/branches/syncflow/merge_conflict_strategy.go
+++ b/internal/branches/syncflow/merge_conflict_strategy.go
@@ -7,7 +7,10 @@ import (
 	"unicode/utf8"
 )
 
-const mergeConflictTokenDiffMaximumCells = 4_000_000
+const (
+	mergeConflictTokenDiffMaximumCells              = 4_000_000
+	mergeConflictReplacementIntentContextTokenCount = 3
+)
 
 type mergeConflictDeterministicResolution struct {
 	Content               string
@@ -251,10 +254,13 @@ func applyMergeConflictTokenEdits(baseTokens []string, edits []mergeConflictToke
 }
 
 func mergeConflictMissingReplacementIntents(base string, variant string, candidate string) ([]string, bool) {
-	edits, editsAvailable := mergeConflictTokenEdits(mergeConflictTokens(base), mergeConflictTokens(variant))
+	baseTokens := mergeConflictTokens(base)
+	edits, editsAvailable := mergeConflictTokenEdits(baseTokens, mergeConflictTokens(variant))
 	if !editsAvailable {
 		return nil, false
 	}
+	normalizedBase := mergeConflictWithoutWhitespace(base)
+	normalizedVariant := mergeConflictWithoutWhitespace(variant)
 	normalizedCandidate := mergeConflictWithoutWhitespace(candidate)
 	missingIntents := make([]string, 0, len(edits))
 	for _, edit := range edits {
@@ -262,11 +268,57 @@ func mergeConflictMissingReplacementIntents(base string, variant string, candida
 		if normalizedReplacement == "" {
 			continue
 		}
-		if !strings.Contains(normalizedCandidate, normalizedReplacement) {
+		baseOccurrences := strings.Count(normalizedBase, normalizedReplacement)
+		variantOccurrences := strings.Count(normalizedVariant, normalizedReplacement)
+		candidateOccurrences := strings.Count(normalizedCandidate, normalizedReplacement)
+		preservesNewOccurrences := variantOccurrences > baseOccurrences && candidateOccurrences >= variantOccurrences
+		if !preservesNewOccurrences && !mergeConflictCandidateMatchesEditContext(baseTokens, edit, normalizedReplacement, normalizedCandidate) {
 			missingIntents = append(missingIntents, edit.Replacement)
 		}
 	}
 	return missingIntents, true
+}
+
+func mergeConflictCandidateMatchesEditContext(
+	baseTokens []string,
+	edit mergeConflictTokenEdit,
+	normalizedReplacement string,
+	normalizedCandidate string,
+) bool {
+	leftContext := mergeConflictReplacementIntentLeftContext(baseTokens, edit.Start)
+	if leftContext != "" && strings.Contains(normalizedCandidate, leftContext+normalizedReplacement) {
+		return true
+	}
+	rightContext := mergeConflictReplacementIntentRightContext(baseTokens, edit.End)
+	return rightContext != "" && strings.Contains(normalizedCandidate, normalizedReplacement+rightContext)
+}
+
+func mergeConflictReplacementIntentLeftContext(baseTokens []string, editStart int) string {
+	contextTokens := make([]string, 0, mergeConflictReplacementIntentContextTokenCount)
+	for tokenIndex := editStart - 1; tokenIndex >= 0 && len(contextTokens) < mergeConflictReplacementIntentContextTokenCount; tokenIndex-- {
+		normalizedToken := mergeConflictWithoutWhitespace(baseTokens[tokenIndex])
+		if normalizedToken != "" {
+			contextTokens = append(contextTokens, normalizedToken)
+		}
+	}
+	var context strings.Builder
+	for tokenIndex := len(contextTokens) - 1; tokenIndex >= 0; tokenIndex-- {
+		context.WriteString(contextTokens[tokenIndex])
+	}
+	return context.String()
+}
+
+func mergeConflictReplacementIntentRightContext(baseTokens []string, editEnd int) string {
+	var context strings.Builder
+	nonWhitespaceTokenCount := 0
+	for tokenIndex := editEnd; tokenIndex < len(baseTokens) && nonWhitespaceTokenCount < mergeConflictReplacementIntentContextTokenCount; tokenIndex++ {
+		normalizedToken := mergeConflictWithoutWhitespace(baseTokens[tokenIndex])
+		if normalizedToken != "" {
+			context.WriteString(normalizedToken)
+			nonWhitespaceTokenCount++
+		}
+	}
+	return context.String()
 }
 
 func mergeConflictWithoutWhitespace(value string) string {

--- a/internal/branches/syncflow/merge_conflict_strategy.go
+++ b/internal/branches/syncflow/merge_conflict_strategy.go
@@ -250,18 +250,33 @@ func applyMergeConflictTokenEdits(baseTokens []string, edits []mergeConflictToke
 	return resolved.String(), true
 }
 
-func mergeConflictMissingReplacementIntent(base string, variant string, candidate string) (string, bool, bool) {
+func mergeConflictMissingReplacementIntents(base string, variant string, candidate string) ([]string, bool) {
 	edits, editsAvailable := mergeConflictTokenEdits(mergeConflictTokens(base), mergeConflictTokens(variant))
 	if !editsAvailable {
-		return "", false, false
+		return nil, false
 	}
+	normalizedCandidate := mergeConflictWithoutWhitespace(candidate)
+	missingIntents := make([]string, 0, len(edits))
 	for _, edit := range edits {
-		if strings.TrimSpace(edit.Replacement) == "" {
+		normalizedReplacement := mergeConflictWithoutWhitespace(edit.Replacement)
+		if normalizedReplacement == "" {
 			continue
 		}
-		if !strings.Contains(candidate, edit.Replacement) {
-			return edit.Replacement, true, true
+		if !strings.Contains(normalizedCandidate, normalizedReplacement) {
+			missingIntents = append(missingIntents, edit.Replacement)
 		}
 	}
-	return "", false, true
+	return missingIntents, true
+}
+
+func mergeConflictWithoutWhitespace(value string) string {
+	var normalized strings.Builder
+	normalized.Grow(len(value))
+	for _, currentRune := range value {
+		if unicode.IsSpace(currentRune) {
+			continue
+		}
+		normalized.WriteRune(currentRune)
+	}
+	return normalized.String()
 }

--- a/tests/sync_state_transition_integration_test.go
+++ b/tests/sync_state_transition_integration_test.go
@@ -624,6 +624,7 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 			expectedStatus := ""
 			expectedIndex := ""
 			expectedFiles := []string(nil)
+			expectedResolvedPath := ""
 			expectedResolvedContents := ""
 			expectedStashes := strings.TrimSpace(runGit(testInstance, repositoryPath, "stash", "list", "--format=%H %s"))
 			arguments := []string{"sync", targetBranch}
@@ -634,8 +635,8 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 				responseWriter.Header().Set("Content-Type", "application/json")
 				if testCase.Mode == "stash_conflict" {
 					response := "GIX_MERGE_REVIEW_APPROVED"
-					if currentRequest%2 == 1 {
-						response = "GIX_MERGE_RESOLUTION_CONTENT_BEGIN\nmaster upstream\nfeature dirty\nGIX_MERGE_RESOLUTION_CONTENT_END"
+					if currentRequest == 1 {
+						response = "GIX_MERGE_RESOLUTION_CONTENT_BEGIN\npolicy: strict timeout=60\n\nGIX_MERGE_RESOLUTION_CONTENT_END"
 					}
 					_, _ = fmt.Fprintf(responseWriter, `{"choices":[{"message":{"role":"assistant","content":%q}}]}`, response)
 					return
@@ -669,15 +670,21 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 				expectedStashes = strings.TrimSpace(runGit(testInstance, repositoryPath, "stash", "list", "--format=%H %s"))
 				arguments = append(arguments, "--stash")
 			case "stash_conflict":
+				policyPath := filepath.Join(repositoryPath, "policy.txt")
+				require.NoError(testInstance, os.WriteFile(policyPath, []byte("policy: standard timeout=30\n"), 0o644))
+				runGit(testInstance, repositoryPath, "add", "policy.txt")
+				runGit(testInstance, repositoryPath, "commit", "-m", "seed policy")
+				runGit(testInstance, repositoryPath, "push", "origin", "master")
 				runGit(testInstance, repositoryPath, "switch", "-c", syncStateTransitionBranchName)
 				runGit(testInstance, repositoryPath, "switch", "master")
-				require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("initial\nmaster upstream\n"), 0o644))
-				runGit(testInstance, repositoryPath, "add", "README.md")
-				runGit(testInstance, repositoryPath, "commit", "-m", "add master upstream line")
+				require.NoError(testInstance, os.WriteFile(policyPath, []byte("policy: strict\n  timeout=30\n"), 0o644))
+				runGit(testInstance, repositoryPath, "add", "policy.txt")
+				runGit(testInstance, repositoryPath, "commit", "-m", "make policy strict")
 				runGit(testInstance, repositoryPath, "push", "origin", "master")
 				runGit(testInstance, repositoryPath, "switch", syncStateTransitionBranchName)
-				require.NoError(testInstance, os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("initial\nfeature dirty\n"), 0o644))
-				expectedResolvedContents = "initial\nmaster upstream\nfeature dirty\n"
+				require.NoError(testInstance, os.WriteFile(policyPath, []byte("policy: standard timeout=60\n"), 0o644))
+				expectedResolvedPath = policyPath
+				expectedResolvedContents = "policy: strict timeout=60\n"
 				arguments = append(arguments, "--stash")
 			default:
 				testInstance.Fatalf("unsupported successful transition mode %q", testCase.Mode)
@@ -724,9 +731,10 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 				require.Equal(testInstance, expectedFiles, snapshotSyncFiles(testInstance, repositoryPath))
 				require.Zero(testInstance, requestCount.Load())
 			case "stash_conflict":
-				require.Equal(testInstance, expectedResolvedContents, readTextFile(testInstance, filepath.Join(repositoryPath, "README.md")))
+				require.Equal(testInstance, expectedResolvedContents, readTextFile(testInstance, expectedResolvedPath))
 				require.NotEmpty(testInstance, strings.TrimSpace(runGit(testInstance, repositoryPath, "status", "--porcelain")))
-				require.GreaterOrEqual(testInstance, requestCount.Load(), int64(1))
+				require.Equal(testInstance, int64(2), requestCount.Load())
+				require.NotContains(testInstance, output, "does not preserve OURS replacement intent")
 			}
 		})
 	}

--- a/tests/sync_state_transition_integration_test.go
+++ b/tests/sync_state_transition_integration_test.go
@@ -614,6 +614,7 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 		{Name: "dirty_clusters_commit_and_remove_transaction_snapshot", Mode: "commit"},
 		{Name: "stash_restores_exact_index_and_preserves_existing_stashes", Mode: "stash"},
 		{Name: "stash_conflict_completes_semantic_finalization_before_success", Mode: "stash_conflict"},
+		{Name: "stash_conflict_rejects_unrelated_replacement_intent_match", Mode: "stash_conflict_alias_collision"},
 	}
 
 	for testCaseIndex := range testCases {
@@ -637,6 +638,14 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 					response := "GIX_MERGE_REVIEW_APPROVED"
 					if currentRequest == 1 {
 						response = "GIX_MERGE_RESOLUTION_CONTENT_BEGIN\npolicy: strict timeout=60\n\nGIX_MERGE_RESOLUTION_CONTENT_END"
+					}
+					_, _ = fmt.Fprintf(responseWriter, `{"choices":[{"message":{"role":"assistant","content":%q}}]}`, response)
+					return
+				}
+				if testCase.Mode == "stash_conflict_alias_collision" {
+					response := "GIX_MERGE_REVIEW_APPROVED"
+					if currentRequest == 1 {
+						response = "GIX_MERGE_RESOLUTION_CONTENT_BEGIN\nprimary: old; alias: foobar; mode: strict\n\nGIX_MERGE_RESOLUTION_CONTENT_END"
 					}
 					_, _ = fmt.Fprintf(responseWriter, `{"choices":[{"message":{"role":"assistant","content":%q}}]}`, response)
 					return
@@ -685,6 +694,23 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 				require.NoError(testInstance, os.WriteFile(policyPath, []byte("policy: standard timeout=60\n"), 0o644))
 				expectedResolvedPath = policyPath
 				expectedResolvedContents = "policy: strict timeout=60\n"
+				arguments = append(arguments, "--stash")
+			case "stash_conflict_alias_collision":
+				policyPath := filepath.Join(repositoryPath, "policy.txt")
+				require.NoError(testInstance, os.WriteFile(policyPath, []byte("primary: old; alias: foobar; mode: standard\n"), 0o644))
+				runGit(testInstance, repositoryPath, "add", "policy.txt")
+				runGit(testInstance, repositoryPath, "commit", "-m", "seed policy")
+				runGit(testInstance, repositoryPath, "push", "origin", "master")
+				runGit(testInstance, repositoryPath, "switch", "-c", syncStateTransitionBranchName)
+				runGit(testInstance, repositoryPath, "switch", "master")
+				require.NoError(testInstance, os.WriteFile(policyPath, []byte("primary: foo\n  bar; alias: foobar; mode: standard\n"), 0o644))
+				runGit(testInstance, repositoryPath, "add", "policy.txt")
+				runGit(testInstance, repositoryPath, "commit", "-m", "make policy strict")
+				runGit(testInstance, repositoryPath, "push", "origin", "master")
+				runGit(testInstance, repositoryPath, "switch", syncStateTransitionBranchName)
+				require.NoError(testInstance, os.WriteFile(policyPath, []byte("primary: old; alias: foobar; mode: strict\n"), 0o644))
+				expectedResolvedPath = policyPath
+				expectedResolvedContents = "primary: foo\n  bar; alias: foobar; mode: strict\n"
 				arguments = append(arguments, "--stash")
 			default:
 				testInstance.Fatalf("unsupported successful transition mode %q", testCase.Mode)
@@ -735,6 +761,11 @@ func TestSyncSuccessfulFinalizationTable(testInstance *testing.T) {
 				require.NotEmpty(testInstance, strings.TrimSpace(runGit(testInstance, repositoryPath, "status", "--porcelain")))
 				require.Equal(testInstance, int64(2), requestCount.Load())
 				require.NotContains(testInstance, output, "does not preserve OURS replacement intent")
+			case "stash_conflict_alias_collision":
+				require.Equal(testInstance, expectedResolvedContents, readTextFile(testInstance, expectedResolvedPath))
+				require.NotEmpty(testInstance, strings.TrimSpace(runGit(testInstance, repositoryPath, "status", "--porcelain")))
+				require.Equal(testInstance, int64(2), requestCount.Load())
+				require.Contains(testInstance, output, "does not preserve OURS replacement intent")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fix merge-conflict replacement-intent validation to treat Unicode whitespace as insignificant while still requiring each side’s non-whitespace changes to be preserved in order.

This prevents valid semantic resolutions from being rejected solely because content was reflowed onto different lines or indented differently.

## Changes

- Normalize replacement fragments and candidate resolutions by removing Unicode whitespace before intent matching.
- Preserve validation of all non-whitespace replacement content.
- Collect and report every missing OURS and THEIRS replacement fragment in a single rejection rather than stopping at the first failure.
- Add unit coverage for whitespace-only formatting changes and multi-fragment loss reporting.
- Update the stash-conflict integration scenario to verify a reflowed resolution passes validation, completes semantic review, and finalizes correctly.
- Document replacement intent and the whitespace-insensitive validation behavior in the changelog and project notes.